### PR TITLE
fix: update GitHub Actions workflow to use pnpm v10

### DIFF
--- a/.changeset/add-pnpm-lockfile.md
+++ b/.changeset/add-pnpm-lockfile.md
@@ -2,10 +2,12 @@
 "@paulhammond/dotfiles": patch
 ---
 
-Add missing pnpm-lock.yaml file to fix GitHub Actions workflow
+Fix GitHub Actions workflow pnpm version incompatibility
 
-The release workflow was failing because the Node.js setup action expected
-a pnpm lockfile when using pnpm cache, but we hadn't run pnpm install yet
-to generate the lockfile.
+The release workflow failed again after adding pnpm-lock.yaml because the
+lockfile was generated with pnpm v10 but the workflow used pnpm v8, causing:
 
-This patch adds the pnpm-lock.yaml file to the repository.
+  WARN  Ignoring not compatible lockfile at pnpm-lock.yaml
+  ERR_PNPM_NO_LOCKFILE  Cannot install with "frozen-lockfile"
+
+This updates the GitHub Actions workflow to use pnpm v10 to match the lockfile.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v3
         with:
-          version: 8
+          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## 🐛 Bug Fix: pnpm Version Incompatibility

Fixes the second GitHub Actions workflow failure that occurred after merging PR #19.

## Problem

After PR #19 added `pnpm-lock.yaml`, the workflow failed again with:

```
WARN  Ignoring not compatible lockfile at pnpm-lock.yaml
ERR_PNPM_NO_LOCKFILE  Cannot install with "frozen-lockfile"
```

**Failed run:** https://github.com/citypaul/.dotfiles/actions/runs/19000316685

## Root Cause

Version mismatch:
- **`pnpm-lock.yaml`** was generated with **pnpm v10** (local development)
- **GitHub Actions workflow** was configured to use **pnpm v8**

The lockfile format is not compatible between major versions, causing the workflow to ignore the lockfile and fail with `--frozen-lockfile`.

## Solution

Update `.github/workflows/release.yml` to use pnpm v10:

```diff
  - name: Setup pnpm
    uses: pnpm/action-setup@v3
    with:
-     version: 8
+     version: 10
```

## Changes

- **Modified:** `.github/workflows/release.yml` - Use pnpm v10 instead of v8
- **Modified:** `.changeset/add-pnpm-lockfile.md` - Updated description to reflect version fix

## Why pnpm v10?

- Latest stable version of pnpm
- Matches local development environment
- Forward compatibility for future development

## Testing

After merge, this should:
1. ✅ Allow the GitHub Actions workflow to complete successfully
2. ✅ Trigger the changesets workflow to create a "Version Packages" PR
3. ✅ When that PR merges → automatically release v2.0.1

## Timeline

1. ✅ PR #18 merged - Added v2.0.0 with changesets but no lockfile
2. ❌ Workflow failed - Missing lockfile
3. ✅ PR #19 merged - Added pnpm-lock.yaml (v10) with workflow using pnpm v8
4. ❌ Workflow failed - Version incompatibility
5. ✅ **This PR** - Updates workflow to use pnpm v10

---

## Verification

- [x] Updated workflow to pnpm v10
- [x] Updated changeset description
- [x] Tested locally with pnpm v10
- [x] Commit message follows conventional commits