### PR TITLE
fix: add node_modules to .gitignore

### DIFF
--- a/.changeset/add-gitignore-node-modules.md
+++ b/.changeset/add-gitignore-node-modules.md
@@ -1,0 +1,8 @@
+---
+"@paulhammond/dotfiles": patch
+---
+
+Add node_modules to .gitignore
+
+The changesets action accidentally committed node_modules/ directory in PR #21.
+This adds node_modules/ to .gitignore to prevent this from happening.

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 
 # macOS
 .DS_Store
+
+# Dependencies
+node_modules/


### PR DESCRIPTION
## 🐛 Bug Fix: Add node_modules to .gitignore

Fixes the issue where the changesets GitHub Action committed the entire `node_modules/` directory in PR #21.

## Problem

PR #21 (auto-generated by changesets action) has 100+ files, all from `node_modules/`:
- https://github.com/citypaul/.dotfiles/pull/21

This happened because `.gitignore` didn't include `node_modules/`.

## Root Cause

When we added:
- `package.json` with dependencies
- `pnpm-lock.yaml`
- Changesets workflow

We forgot to add `node_modules/` to `.gitignore`.

When the changesets action ran `pnpm install` and `pnpm version`, it created `node_modules/` and git tracked all the files.

## Solution

Add `node_modules/` to `.gitignore`:

```diff
 # macOS
 .DS_Store
+
+# Dependencies
+node_modules/
```

## Changes

- **Modified:** `.gitignore` - Added `node_modules/`
- **Added:** `.changeset/add-gitignore-node-modules.md` - Changeset for patch release

## Steps After Merge

1. ✅ Merge this PR
2. ❌ Close PR #21 (it's polluted with node_modules)
3. 🗑️ Delete the `changeset-release/main` branch:
   ```bash
   git push origin --delete changeset-release/main
   ```
4. ✅ Wait for the GitHub Action to create a fresh "Version Packages" PR
5. ✅ The new PR will have node_modules properly ignored

## Why Close PR #21?

PR #21 has 100+ node_modules files already committed to its branch. Even with `.gitignore` fixed, those files would still be in that branch's history. It's cleaner to:
- Delete the polluted branch
- Let changesets create a fresh PR with the fix in place

---

## Verification

- [x] Added `node_modules/` to `.gitignore`
- [x] Created changeset for patch release
- [x] Commit message follows conventional commits
- [x] Ready to close PR #21 after merge