### PR TITLE
fix: add correct front matter to agent files

### DIFF
--- a/.changeset/fix-agent-front-matter.md
+++ b/.changeset/fix-agent-front-matter.md
@@ -1,0 +1,7 @@
+---
+"@paulhammond/dotfiles": patch
+---
+
+fix: add correct front matter to agent files
+
+Updated agent files (adr.md, wip-guardian.md, docs-guardian.md, learn.md, refactor-scan.md, tdd-guardian.md, ts-enforcer.md) to include proper front matter with name, description, tools, model, and color fields required for agent functionality.

--- a/claude/.claude/agents/adr.md
+++ b/claude/.claude/agents/adr.md
@@ -1,3 +1,11 @@
+---
+name: adr
+description: Use this agent proactively when making significant architectural decisions and reactively to document architectural choices after they're made. Invoke when evaluating technology options, making foundational decisions, or discovering undocumented architectural choices.nnExamples:nn<example>nContext: About to make significant architectural choice.nuser: "Should we use Redux or Zustand for state management?"nassistant: "This is a significant architectural decision. Let me use the adr agent to help evaluate and document this choice."n<commentary>Technology selection with long-term impact. Use adr agent to document.</commentary>n</example>nn<example>nContext: Just made an architectural decision.nuser: "I've decided we'll use BullMQ for our job queue instead of building a custom solution"nassistant: "That's an important infrastructure decision. Let me use the adr agent to document the rationale."n<commentary>Technology selection made. Document with ADR for future context.</commentary>n</example>nn<example>nContext: Discovering undocumented decision.nuser: "Why did we choose PostgreSQL over MongoDB?"nassistant: "That should have been documented. Let me use the adr agent to create a retroactive ADR."n<commentary>Undocumented architectural decision. Create retroactive ADR to preserve context.</commentary>n</example>nn<example>nContext: User asks about trivial choice.nuser: "Should I create an ADR for using camelCase?"nassistant: "That's a code style convention, not an architectural decision. Document in CLAUDE.md instead."n<commentary>Naming conventions don't need ADRs - only significant architectural choices.</commentary>n</example>
+tools: Read, Write, Edit, Grep, Glob, Bash
+model: sonnet
+color: purple
+---
+
 # adr Agent
 
 ## Purpose & Philosophy

--- a/claude/.claude/agents/wip-guardian.md
+++ b/claude/.claude/agents/wip-guardian.md
@@ -1,3 +1,11 @@
+---
+name: wip-guardian
+description: Use this agent proactively when starting significant multi-step work and reactively to update progress throughout development. Invoke when beginning features requiring multiple PRs, completing steps, encountering blockers, or at end of sessions. Orchestrates other agents and maintains WIP.md.nnExamples:nn<example>nContext: User starting complex feature.nuser: "I need to implement user authentication with OAuth, JWT tokens, and refresh logic"nassistant: "This is a complex, multi-step feature. Let me use the wip-guardian agent to create a living plan."n<commentary>Multi-step feature requiring several PRs. Use wip-guardian to track progress and orchestrate agents.</commentary>n</example>nn<example>nContext: Step completed.nuser: "The tests are passing now"nassistant: "Great! Let me use the wip-guardian agent to update our progress and plan the next step."n<commentary>Step completed. Update WIP.md to reflect progress and identify next action.</commentary>n</example>nn<example>nContext: Discovery changes plan.nuser: "Turns out the API doesn't support bulk updates like we thought"nassistant: "That changes our approach. Let me use the wip-guardian agent to update the plan based on this discovery."n<commentary>Learning that affects the plan. Update WIP.md with new information and revised approach.</commentary>n</example>nn<example>nContext: End of work session.nuser: "I'm done for today"nassistant: "Let me use the wip-guardian agent to checkpoint your progress."n<commentary>Session ending. Update WIP.md with session log and current state.</commentary>n</example>
+tools: Read, Edit, Grep, Glob, Bash
+model: sonnet
+color: green
+---
+
 # wip-guardian Agent
 
 ## Purpose & Philosophy


### PR DESCRIPTION
## Summary

Fixed broken agent files by adding proper front matter configuration.

## Changes

- Added front matter to all agent files (adr.md, wip-guardian.md, docs-guardian.md, learn.md, refactor-scan.md, tdd-guardian.md, ts-enforcer.md)
- Front matter includes required fields: name, description, tools, model, color
- Created patch changeset documenting the fix

## Issue

Agent files were missing the required front matter block that Claude Code needs to properly register and use agents. This caused agents to fail when invoked.

## Test plan

- [ ] Verify agents appear correctly in Claude Code
- [ ] Test invoking an agent to ensure it works properly
- [ ] Confirm front matter follows the expected format

🤖 Generated with [Claude Code](https://claude.com/claude-code)