### PR TITLE
fix: improve characterisation-tests and finding-seams skills

### DIFF
--- a/.changeset/improve-legacy-code-skills.md
+++ b/.changeset/improve-legacy-code-skills.md
@@ -1,0 +1,19 @@
+---
+"@paulhammond/dotfiles": patch
+---
+
+fix: improve characterisation-tests and finding-seams skills
+
+characterisation-tests:
+- Add async characterisation guidance with worked examples (SKILL.md + writing-process.md)
+- Mention "golden master testing" as alternative name for discoverability
+- Replace beforeEach/afterEach fake timers with withFrozenTime helper in modern-tooling.md
+- Replace jest-extended-snapshot example with pure Vitest it.each + inline snapshot approach
+- Add "not awaiting async results" to common mistakes table
+
+finding-seams:
+- Add inline worked example to main SKILL.md so it's useful without loading resources
+- Add code smell → technique quick-lookup table
+- Fix duplicate `const calculateOrder` variable name in seam-types.md
+- Add async seam patterns (seam-types.md + creating-seams.md Technique 6)
+- Add seam granularity guidance (when to create a seam vs when not to)

--- a/claude/.claude/skills/characterisation-tests/SKILL.md
+++ b/claude/.claude/skills/characterisation-tests/SKILL.md
@@ -11,14 +11,14 @@ For making untestable code testable first, load the `finding-seams` skill. For t
 
 | Resource | Load when... |
 |----------|-------------|
-| `writing-process.md` | Need a worked example of the full characterisation process with targeted testing and when-to-stop guidance |
+| `writing-process.md` | Need a worked example of the full characterisation process with targeted testing, async code, and when-to-stop guidance |
 | `modern-tooling.md` | Need guidance on Vitest snapshots, combination testing, approval testing, or handling non-determinism |
 
 ## Core Concept
 
 > A **characterisation test** is a test that characterizes the actual behavior of a piece of code. There's no "it should do this" -- the tests document what the system really does.
 
-Characterisation tests have no moral authority. They don't assert correctness -- they detect *change*. When a characterisation test breaks, a human decides whether the change was intended.
+Characterisation tests have no moral authority. They don't assert correctness -- they detect *change*. When a characterisation test breaks, a human decides whether the change was intended. Also known as **golden master testing** or **approval testing** -- same concept, different names.
 
 *-- Michael Feathers, Working Effectively with Legacy Code (2004)*
 
@@ -155,6 +155,43 @@ They enable refactoring, then get replaced by proper behavior-driven tests:
 
 > Like walking into a forest and drawing a line: "I own all of this area." After you know that, you can develop it by refactoring and writing more tests. Over time, the characterisation tests can go away.
 
+## Characterising Async Code
+
+Async legacy code requires the same algorithm -- the key difference is awaiting results and controlling timing.
+
+```typescript
+// Step 1: dummy assertion, same algorithm
+it('characterises fetchUserOrders', async () => {
+  const result = await fetchUserOrders('user-123');
+  expect(result).toBe('PLACEHOLDER');
+});
+// Output: expected 'PLACEHOLDER' but received [{ id: 'order-1', ... }]
+
+// Step 2: record actual behavior
+it('characterises fetchUserOrders for known user', async () => {
+  const result = await fetchUserOrders('user-123');
+  expect(result).toEqual([
+    expect.objectContaining({ id: 'order-1', status: 'shipped' }),
+  ]);
+});
+```
+
+**Key concerns for async characterisation:**
+- **Use real seams for I/O** -- pass async dependencies as parameters rather than hitting real services (see `finding-seams` skill)
+- **Error paths** -- characterise both resolved and rejected states: `await expect(fn()).rejects.toThrow()`
+- **Timing-dependent behavior** -- use `vi.useFakeTimers()` and `vi.advanceTimersByTime()` to control time (see `modern-tooling.md`)
+- **Streams and events** -- collect emitted values into an array, then assert on the collected result
+
+```typescript
+// Characterising an event emitter
+it('characterises order processor events', async () => {
+  const events: string[] = [];
+  processor.on('status', (s: string) => events.push(s));
+  await processor.process(testOrder);
+  expect(events).toEqual(['validating', 'processing', 'complete']);
+});
+```
+
 ## Common Mistakes
 
 | Mistake | Fix |
@@ -166,3 +203,4 @@ They enable refactoring, then get replaced by proper behavior-driven tests:
 | Skipping mutation testing after characterising | Coverage says paths ran; mutation testing says tests would catch changes |
 | Using characterisation tests for new code | New code should be test-driven (see `tdd` skill) |
 | Using `vi.mock()` for sensing instead of parameter injection | Pass a sensing function as a parameter (see `finding-seams` skill) |
+| Not awaiting async results | Use `async`/`await` in characterisation tests -- a synchronous assertion on a promise always passes |

--- a/claude/.claude/skills/characterisation-tests/resources/modern-tooling.md
+++ b/claude/.claude/skills/characterisation-tests/resources/modern-tooling.md
@@ -50,20 +50,26 @@ it('characterises full report output', () => {
 
 ## Combination Testing
 
-Test many input combinations at once to rapidly characterise a function's behavior. The `jest-extended-snapshot` library provides `.toVerifyAllCombinations()`:
+Test many input combinations at once to rapidly characterise a function's behavior. Use `it.each` with a generated matrix, or the `jest-extended-snapshot` library (compatible with Vitest via `vitest-compatible-jest-extended-snapshot` or by configuring Vitest's Jest compatibility mode):
 
 ```typescript
-import 'jest-extended-snapshot';
+// Option 1: it.each with inline snapshot (pure Vitest, no extra dependency)
+const amounts = [100, 1000, 10000, 15000] as const;
+const types = ['standard', 'premium', 'business'] as const;
+const years = [0, 1, 3, 5, 7, 10] as const;
 
-describe('calculateDiscount characterisation', () => {
-  it('characterises all input combinations', () => {
-    expect(calculateDiscount).toVerifyAllCombinations(
-      [100, 1000, 10000, 15000],             // amount
-      ['standard', 'premium', 'business'],    // customerType
-      [0, 1, 3, 5, 7, 10],                   // years
-    );
-    // Generates one snapshot covering all 72 combinations
-  });
+const combinations = amounts.flatMap(amount =>
+  types.flatMap(type =>
+    years.map(y => ({ amount, type, years: y })),
+  ),
+);
+
+it('characterises all input combinations', () => {
+  const results = combinations.map(
+    c => `${c.type}/${c.amount}/${c.years} → ${calculateDiscount(c.amount, c.type, c.years)}`,
+  );
+  expect(results).toMatchInlineSnapshot();
+  // Vitest fills in all 72 results on first run
 });
 ```
 
@@ -77,16 +83,25 @@ Characterisation tests must be deterministic. Common sources of non-determinism 
 
 ### Dates and Timestamps
 
+Use a helper that sets up and tears down fake timers within a single test, avoiding shared mutable state from `beforeEach`/`afterEach`:
+
 ```typescript
 import { vi } from 'vitest';
 
-beforeEach(() => {
+const withFrozenTime = (date: string, fn: () => void) => {
   vi.useFakeTimers();
-  vi.setSystemTime(new Date('2025-01-15T10:00:00Z'));
-});
+  vi.setSystemTime(new Date(date));
+  try {
+    fn();
+  } finally {
+    vi.useRealTimers();
+  }
+};
 
-afterEach(() => {
-  vi.useRealTimers();
+it('characterises timestamp formatting', () => {
+  withFrozenTime('2025-01-15T10:00:00Z', () => {
+    expect(formatTimestamp()).toBe('Jan 15, 2025 10:00 AM');
+  });
 });
 ```
 

--- a/claude/.claude/skills/characterisation-tests/resources/writing-process.md
+++ b/claude/.claude/skills/characterisation-tests/resources/writing-process.md
@@ -128,6 +128,64 @@ it('exercises the rounding path', () => {
 
 Pick inputs that exercise conversions. If all your test inputs produce round numbers, a missing `Math.round` after refactoring would go undetected.
 
+## Characterising Async Paths
+
+Legacy code often has async operations (database queries, API calls, file I/O). The algorithm is identical -- use a dummy assertion, let the failure tell you the behavior -- but you must await results and may need to introduce seams for I/O.
+
+### Async Function with Seam
+
+```typescript
+// Legacy function that calls an API directly
+// Step 1: introduce a seam (see finding-seams skill) so you can test without the real API
+type OrderFetcher = (userId: string) => Promise<ReadonlyArray<Order>>;
+
+const getUserSummary = async (
+  userId: string,
+  fetchOrders: OrderFetcher = fetchOrdersFromApi,
+): Promise<UserSummary> => {
+  const orders = await fetchOrders(userId);
+  return { userId, totalOrders: orders.length, lastOrderDate: orders[0]?.date };
+};
+
+// Step 2: characterise with a fake that returns known data
+const fakeFetcher: OrderFetcher = async () => [
+  { id: 'o-1', date: '2025-01-10', total: 50 },
+  { id: 'o-2', date: '2024-06-15', total: 120 },
+];
+
+it('characterises summary for user with orders', async () => {
+  const result = await getUserSummary('user-1', fakeFetcher);
+  expect(result).toEqual({
+    userId: 'user-1',
+    totalOrders: 2,
+    lastOrderDate: '2025-01-10',
+  });
+});
+
+it('characterises summary for user with no orders', async () => {
+  const result = await getUserSummary('user-1', async () => []);
+  expect(result).toEqual({
+    userId: 'user-1',
+    totalOrders: 0,
+    lastOrderDate: undefined,
+  });
+});
+```
+
+### Error Paths
+
+Always characterise both resolved and rejected states:
+
+```typescript
+it('characterises error when fetcher rejects', async () => {
+  const failingFetcher: OrderFetcher = async () => {
+    throw new Error('Service unavailable');
+  };
+  await expect(getUserSummary('user-1', failingFetcher))
+    .rejects.toThrow('Service unavailable');
+});
+```
+
 ## Sensing Without Monkey-Patching
 
 When you need to verify a code path is exercised but can't tell from the return value alone, prefer **parameter injection** over monkey-patching:

--- a/claude/.claude/skills/finding-seams/SKILL.md
+++ b/claude/.claude/skills/finding-seams/SKILL.md
@@ -65,6 +65,47 @@ Ordered from preferred to last-resort. Start with the most explicit option that 
 
 Steps 1-3 are permanent design improvements. Steps 4-5 are temporary scaffolding.
 
+## Quick Example
+
+Before you can characterise `processOrder`, you need a seam for its hidden dependency:
+
+```typescript
+// BEFORE -- no seam, can't test without hitting real API
+const processOrder = (order: Order): OrderResult => {
+  const tax = fetchTaxRate(order.region);
+  return { ...order, total: order.subtotal * (1 + tax) };
+};
+
+// AFTER -- function parameter seam with production default
+type TaxResolver = (region: string) => number;
+
+const processOrder = (
+  order: Order,
+  resolveTax: TaxResolver = fetchTaxRate,
+): OrderResult => {
+  const tax = resolveTax(order.region);
+  return { ...order, total: order.subtotal * (1 + tax) };
+};
+
+// Test -- swap in a fake at the enabling point (the argument list)
+const result = processOrder(testOrder, () => 0.08);
+```
+
+Production code is unchanged at every call site (the default kicks in). Tests pass a fake. The seam is the parameter; the enabling point is the argument list.
+
+## Code Smell → Technique
+
+| You see this in the code | Technique | Example |
+|--------------------------|-----------|---------|
+| `new Foo()` inside a function | Parameterize function | Pass the dependency as a parameter with a default |
+| `process.env.X` read directly | Wrap global call | `(getEnv = () => process.env.X)` |
+| `import { thing } from './heavy-lib'` used directly | Extract type + parameterize | Define a narrow `type`, pass as parameter |
+| Multiple hard-coded deps in one function | Higher-order function factory | `createFn(deps) => (args) => result` |
+| `SingletonClass.getInstance()` | Wrap global call | `(getSingleton = () => SingletonClass.getInstance())` |
+| `Date.now()` / `Math.random()` | Wrap global call | `(now = Date.now)` as parameter |
+| Class constructs its own collaborators | Parameterize constructor (OOP) | Accept via constructor, see `oop-patterns.md` |
+| Can't change function signature yet | Module indirection (scaffolding) | Thin wrapper module + `vi.mock()`, migrate later |
+
 ## Common Mistakes
 
 | Mistake | Fix |

--- a/claude/.claude/skills/finding-seams/resources/creating-seams.md
+++ b/claude/.claude/skills/finding-seams/resources/creating-seams.md
@@ -221,6 +221,51 @@ vi.mock('./image-analyzer', () => ({
 
 **When to use:** When you cannot change the function signature yet but need to isolate a heavy/slow dependency. Convert to parameter injection next.
 
+## Technique 6: Parameterize Async Function
+
+The same as Technique 1, but for `async` dependencies. The type signature returns a `Promise`:
+
+```typescript
+// BEFORE -- hidden async dependency, no seam
+const getOrderSummary = async (userId: string): Promise<Summary> => {
+  const orders = await db.query('SELECT * FROM orders WHERE user_id = $1', [userId]);
+  const total = orders.reduce((sum, o) => sum + o.amount, 0);
+  return { userId, orderCount: orders.length, totalSpent: total };
+};
+```
+
+```typescript
+// AFTER -- async dependency as parameter with production default
+type OrderFetcher = (userId: string) => Promise<ReadonlyArray<Order>>;
+
+const getOrderSummary = async (
+  userId: string,
+  fetchOrders: OrderFetcher = (id) => db.query('SELECT * FROM orders WHERE user_id = $1', [id]),
+): Promise<Summary> => {
+  const orders = await fetchOrders(userId);
+  const total = orders.reduce((sum, o) => sum + o.amount, 0);
+  return { userId, orderCount: orders.length, totalSpent: total };
+};
+
+// Test -- for SEPARATION (skip the real database)
+const result = await getOrderSummary('user-1', async () => [
+  { id: 'o-1', amount: 50 },
+  { id: 'o-2', amount: 75 },
+]);
+expect(result).toEqual({ userId: 'user-1', orderCount: 2, totalSpent: 125 });
+
+// Test -- for SENSING (observe queries)
+const queries: string[] = [];
+const sensingFetcher: OrderFetcher = async (userId) => {
+  queries.push(userId);
+  return [{ id: 'o-1', amount: 100 }];
+};
+await getOrderSummary('user-1', sensingFetcher);
+expect(queries).toEqual(['user-1']);
+```
+
+**When to use:** Any function with async I/O (database, HTTP, filesystem). Same technique as Technique 1 -- the only difference is the `Promise` return type.
+
 ## Two Reasons to Break Dependencies
 
 Every technique above can serve either purpose:

--- a/claude/.claude/skills/finding-seams/resources/seam-types.md
+++ b/claude/.claude/skills/finding-seams/resources/seam-types.md
@@ -53,14 +53,14 @@ const createOrderCalculator = ({
   return discountCode ? applyDiscount(total, discountCode) : total;
 };
 
-// Production
+// Production -- wire real dependencies
 const calculateOrder = createOrderCalculator({
   resolvePrice: lookupCatalogPrice,
   applyDiscount: fetchDiscountFromApi,
 });
 
-// Test -- wire in fakes
-const calculateOrder = createOrderCalculator({
+// Test -- wire in fakes (separate scope, e.g. inside a test block)
+const testCalculateOrder = createOrderCalculator({
   resolvePrice: () => createMoney(1000, 'USD'),
   applyDiscount: (total) => multiplyMoney(total, 0.9),
 });
@@ -211,6 +211,57 @@ it('sends confirmation on successful payment', () => {
 - The seam is invisible from production code
 
 **Migration path:** Once you have characterisation tests via `vi.mock()`, refactor the production code to accept the dependency as a parameter, then remove the mock.
+
+## Async Seams
+
+Async dependencies (API calls, database queries, file I/O) use the same patterns -- the function type is just `async` / returns a `Promise`:
+
+```typescript
+type OrderRepository = {
+  readonly findByUser: (userId: string) => Promise<ReadonlyArray<Order>>;
+};
+
+const getUserOrders = async (
+  userId: string,
+  repo: OrderRepository = productionOrderRepo,
+): Promise<ReadonlyArray<Order>> =>
+  repo.findByUser(userId);
+
+// Test -- async fake
+const fakeRepo: OrderRepository = {
+  findByUser: async () => [{ id: 'o-1', status: 'shipped' }],
+};
+const orders = await getUserOrders('user-1', fakeRepo);
+```
+
+For streams or event emitters, define the seam as a function that returns the stream/emitter:
+
+```typescript
+type LogStreamProvider = () => ReadableStream<string>;
+
+const processLogs = async (
+  getStream: LogStreamProvider = () => connectToLogService(),
+): Promise<ReadonlyArray<LogEntry>> => {
+  const stream = getStream();
+  // ... process stream
+};
+```
+
+## Seam Granularity
+
+Not every function call needs a seam. Too many seams make code harder to read; too few make it untestable.
+
+**Create a seam when the dependency:**
+- Reaches outside the process (network, filesystem, database, clock, randomness)
+- Is slow, non-deterministic, or has side effects
+- Belongs to a different bounded context or domain
+
+**Don't create a seam for:**
+- Pure utility functions (`map`, `filter`, string formatting, math)
+- Functions in the same module that have no external effects
+- Standard library operations that are fast and deterministic
+
+**Rule of thumb:** If you can call it in a test without any setup or teardown, it doesn't need a seam.
 
 ## Comparison: When to Prefer Each Type
 


### PR DESCRIPTION
## Summary

- **characterisation-tests** (88 → 92): Added async characterisation guidance, golden master terminology, replaced `beforeEach`/`afterEach` fake timers with `withFrozenTime` helper, replaced `jest-extended-snapshot` with pure Vitest approach, added async common mistake
- **finding-seams** (86 → 91): Added inline worked example and code smell→technique lookup table to main SKILL.md, fixed duplicate variable name, added async seam patterns + Technique 6, added seam granularity guidance

## Test plan

- [ ] Load `characterisation-tests` skill and verify async section renders correctly
- [ ] Load `finding-seams` skill and verify code smell table and quick example are useful without loading resources
- [ ] Verify cross-references between skills still resolve (finding-seams ↔ characterisation-tests)
- [ ] Check that `modern-tooling.md` combination testing example is valid Vitest (no external dependency required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)