### PR TITLE
feat: add consolidated diagrams skill

### DIFF
--- a/.changeset/diagrams-skill.md
+++ b/.changeset/diagrams-skill.md
@@ -1,0 +1,12 @@
+---
+"@paulhammond/dotfiles": minor
+---
+
+Add consolidated diagrams skill for Markdown visualizations
+
+- New `diagrams` skill with decision-tree router for 8 diagram engines
+- Covers Mermaid, Graphviz, Vega-Lite, PlantUML, Infographic, JSON Canvas, Architecture (HTML), and Infocard (HTML)
+- Consolidates 15 upstream skills into 1 directory with 8 reference files
+- PlantUML reference covers UML, cloud (AWS/Azure/GCP), network, security, ArchiMate, BPMN, data analytics, and IoT
+- Includes examples file with 15 rendered diagram samples
+- Adapted from markdown-viewer/skills (MIT license) with proper attribution

--- a/claude/.claude/skills/diagrams/LICENSE
+++ b/claude/.claude/skills/diagrams/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 markdown-viewer (https://github.com/markdown-viewer/skills)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/claude/.claude/skills/diagrams/SKILL.md
+++ b/claude/.claude/skills/diagrams/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: diagrams
+description: Create diagrams and visualizations in Markdown using Mermaid, Graphviz, Vega-Lite, PlantUML, infographics, JSON Canvas, architecture diagrams, and info cards. Use when asked to create any diagram, chart, visualization, or visual documentation.
+metadata:
+  author: Diagram skills adapted from markdown-viewer/skills (MIT license). Powered by Markdown Viewer - https://docu.md
+---
+
+# Diagram & Visualization Skill
+
+Create professional diagrams and visualizations in Markdown documents. Choose the right tool for the job, then read the detailed reference for that tool.
+
+## Decision Guide
+
+**What are you trying to create?**
+
+| Need | Tool | Code Fence | Reference |
+|------|------|-----------|-----------|
+| Flowchart, sequence diagram, state machine, class diagram, mindmap | **Mermaid** | ` ```mermaid ` | [mermaid.md](references/mermaid.md) |
+| Dependency tree, call graph, module relationships, complex directed graphs | **Graphviz** | ` ```dot ` | [graphviz.md](references/graphviz.md) |
+| Bar chart, line chart, scatter plot, heatmap, data-driven visualization | **Vega-Lite** | ` ```vega-lite ` | [vega.md](references/vega.md) |
+| UML diagrams with icons (9,500+ stencils) | **PlantUML** | ` ```plantuml ` | [plantuml.md](references/plantuml.md) |
+| Cloud architecture (AWS/Azure/GCP/K8s) | **PlantUML** | ` ```plantuml ` | [plantuml.md](references/plantuml.md) |
+| Network topology, security architecture | **PlantUML** | ` ```plantuml ` | [plantuml.md](references/plantuml.md) |
+| KPI cards, timelines, roadmaps, funnels, SWOT, org charts, pie/bar charts | **Infographic** | ` ```infographic ` | [infographic.md](references/infographic.md) |
+| Mind map, knowledge graph, spatial planning board | **JSON Canvas** | ` ```canvas ` | [canvas.md](references/canvas.md) |
+| Layered system architecture, microservices, enterprise diagrams | **Architecture** | Raw HTML | [architecture.md](references/architecture.md) |
+| Editorial info cards, data highlights, knowledge summaries | **Infocard** | Raw HTML | [infocard.md](references/infocard.md) |
+
+## Quick Selection Rules
+
+1. **Simple process flow?** Use Mermaid
+2. **Data with numbers?** Use Vega-Lite (charts) or Infographic (visual templates)
+3. **Software modeling with icons?** Use PlantUML
+4. **Cloud/network/security architecture?** Use PlantUML with provider stencils
+5. **Complex graph with custom layout?** Use Graphviz
+6. **Styled system architecture?** Use Architecture (HTML)
+7. **Magazine-quality content card?** Use Infocard (HTML)
+8. **Quick visual summary (KPI, timeline, funnel)?** Use Infographic
+9. **Spatial/freeform layout?** Use JSON Canvas
+
+## Workflow
+
+1. Identify the diagram type from the decision guide above
+2. Read the appropriate reference file for detailed syntax and rules
+3. Follow the critical syntax rules exactly to avoid rendering failures
+4. For Architecture and Infocard: pick a layout first, then apply a style
+
+## Important Notes
+
+- **Architecture and Infocard use raw HTML** embedded directly in Markdown (no code fences)
+- **PlantUML diagrams** always start with `@startuml` and end with `@enduml`
+- **Never use ` ```text `** for any diagram type - it won't render
+- When unsure between tools, prefer Mermaid for simplicity or PlantUML for icon-rich diagrams

--- a/claude/.claude/skills/diagrams/examples.md
+++ b/claude/.claude/skills/diagrams/examples.md
@@ -1,0 +1,635 @@
+# Diagrams Skill - Examples
+
+Open this file in a Markdown viewer that supports these renderers (e.g., the [Markdown Viewer](https://docu.md) browser extension) to see rendered output.
+
+---
+
+## 1. Mermaid - CI/CD Pipeline Flow
+
+```mermaid
+flowchart LR
+    subgraph dev["Development"]
+        direction TB
+        A[Push to Branch] --> B[Run Linter]
+        B --> C[Run Tests]
+    end
+    subgraph ci["CI Pipeline"]
+        direction TB
+        D[Build Docker Image] --> E[Integration Tests]
+        E --> F{Tests Pass?}
+    end
+    subgraph deploy["Deployment"]
+        direction TB
+        G[Deploy to Staging] --> H[Smoke Tests]
+        H --> I[Deploy to Production]
+    end
+    dev --> ci
+    F -->|Yes| deploy
+    F -->|No| J[Notify Team]
+    J --> A
+
+    classDef success fill:#2ECC71,color:white,stroke:#27AE60
+    classDef fail fill:#E74C3C,color:white,stroke:#C0392B
+    classDef process fill:#3498DB,color:white,stroke:#2980B9
+    class I success
+    class J fail
+    class D,E,G,H process
+```
+
+---
+
+## 2. Mermaid - Sequence Diagram (API Authentication)
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Gateway as API Gateway
+    participant Auth as Auth Service
+    participant DB as User Store
+    participant API as Resource API
+
+    Client->>Gateway: POST /auth/login {email, password}
+    Gateway->>Auth: Validate credentials
+    Auth->>DB: Find user by email
+    DB-->>Auth: User record
+    Auth->>Auth: Verify password hash
+
+    alt Valid credentials
+        Auth-->>Gateway: JWT token + refresh token
+        Gateway-->>Client: 200 OK {access_token, refresh_token}
+        Client->>Gateway: GET /api/data (Bearer token)
+        Gateway->>Auth: Verify JWT
+        Auth-->>Gateway: Claims {user_id, roles}
+        Gateway->>API: Forward request + claims
+        API-->>Gateway: Data response
+        Gateway-->>Client: 200 OK {data}
+    else Invalid credentials
+        Auth-->>Gateway: Authentication failed
+        Gateway-->>Client: 401 Unauthorized
+    end
+```
+
+---
+
+## 3. Mermaid - Entity Relationship Diagram
+
+```mermaid
+erDiagram
+    USER ||--o{ PROJECT : owns
+    USER ||--o{ TEAM_MEMBERSHIP : "belongs to"
+    TEAM ||--o{ TEAM_MEMBERSHIP : has
+    TEAM ||--o{ PROJECT : manages
+    PROJECT ||--o{ TASK : contains
+    PROJECT ||--o{ DEPLOYMENT : "deployed via"
+    TASK ||--o{ COMMENT : has
+    TASK }o--|| USER : "assigned to"
+    DEPLOYMENT ||--|| ENVIRONMENT : "targets"
+
+    USER {
+        uuid id PK
+        string email UK
+        string name
+        timestamp created_at
+    }
+    PROJECT {
+        uuid id PK
+        string name
+        uuid owner_id FK
+        uuid team_id FK
+    }
+    TASK {
+        uuid id PK
+        string title
+        string status
+        uuid project_id FK
+        uuid assignee_id FK
+    }
+```
+
+---
+
+## 4. Graphviz - Module Dependency Graph
+
+```dot
+digraph Dependencies {
+    rankdir=LR;
+    node [shape=box, style=filled, fontsize=11, fontname="Inter"];
+    edge [color="#666666", arrowhead=vee];
+
+    subgraph cluster_core {
+        label="Core";
+        style=filled;
+        fillcolor="#EBF5FB";
+        color="#3498DB";
+        config [label="config", fillcolor="#D4E6F1"];
+        logger [label="logger", fillcolor="#D4E6F1"];
+        types [label="types", fillcolor="#D4E6F1"];
+    }
+
+    subgraph cluster_domain {
+        label="Domain";
+        style=filled;
+        fillcolor="#E8F8F5";
+        color="#1ABC9C";
+        user [label="user", fillcolor="#D1F2EB"];
+        order [label="order", fillcolor="#D1F2EB"];
+        product [label="product", fillcolor="#D1F2EB"];
+    }
+
+    subgraph cluster_infra {
+        label="Infrastructure";
+        style=filled;
+        fillcolor="#FEF9E7";
+        color="#F39C12";
+        db [label="database", fillcolor="#FCF3CF"];
+        cache [label="cache", fillcolor="#FCF3CF"];
+        queue [label="queue", fillcolor="#FCF3CF"];
+    }
+
+    subgraph cluster_api {
+        label="API";
+        style=filled;
+        fillcolor="#FDEDEC";
+        color="#E74C3C";
+        router [label="router", fillcolor="#FADBD8"];
+        middleware [label="middleware", fillcolor="#FADBD8"];
+        handlers [label="handlers", fillcolor="#FADBD8"];
+    }
+
+    handlers -> user;
+    handlers -> order;
+    handlers -> product;
+    router -> middleware -> handlers;
+    user -> db;
+    user -> cache;
+    order -> db;
+    order -> queue;
+    product -> db;
+    product -> cache;
+    user -> logger;
+    order -> logger;
+    db -> config;
+    cache -> config;
+    queue -> config;
+    user -> types;
+    order -> types;
+    product -> types;
+}
+```
+
+---
+
+## 5. Vega-Lite - Monthly Revenue Chart
+
+```vega-lite
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+  "title": "Monthly Revenue by Product Line",
+  "width": 500,
+  "height": 300,
+  "data": {
+    "values": [
+      {"month": "Jan", "revenue": 45000, "product": "SaaS"},
+      {"month": "Feb", "revenue": 52000, "product": "SaaS"},
+      {"month": "Mar", "revenue": 61000, "product": "SaaS"},
+      {"month": "Apr", "revenue": 58000, "product": "SaaS"},
+      {"month": "May", "revenue": 72000, "product": "SaaS"},
+      {"month": "Jun", "revenue": 85000, "product": "SaaS"},
+      {"month": "Jan", "revenue": 22000, "product": "Consulting"},
+      {"month": "Feb", "revenue": 28000, "product": "Consulting"},
+      {"month": "Mar", "revenue": 35000, "product": "Consulting"},
+      {"month": "Apr", "revenue": 30000, "product": "Consulting"},
+      {"month": "May", "revenue": 42000, "product": "Consulting"},
+      {"month": "Jun", "revenue": 38000, "product": "Consulting"},
+      {"month": "Jan", "revenue": 12000, "product": "Training"},
+      {"month": "Feb", "revenue": 15000, "product": "Training"},
+      {"month": "Mar", "revenue": 18000, "product": "Training"},
+      {"month": "Apr", "revenue": 20000, "product": "Training"},
+      {"month": "May", "revenue": 22000, "product": "Training"},
+      {"month": "Jun", "revenue": 25000, "product": "Training"}
+    ]
+  },
+  "mark": "bar",
+  "encoding": {
+    "x": {"field": "month", "type": "ordinal", "sort": ["Jan", "Feb", "Mar", "Apr", "May", "Jun"]},
+    "y": {"field": "revenue", "type": "quantitative", "title": "Revenue ($)"},
+    "color": {"field": "product", "type": "nominal", "title": "Product Line"},
+    "tooltip": [
+      {"field": "product", "type": "nominal"},
+      {"field": "month", "type": "ordinal"},
+      {"field": "revenue", "type": "quantitative", "format": "$,.0f"}
+    ]
+  }
+}
+```
+
+---
+
+## 6. Vega-Lite - Scatter Plot with Trend
+
+```vega-lite
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+  "title": "Response Time vs Request Volume",
+  "width": 400,
+  "height": 300,
+  "data": {
+    "values": [
+      {"requests": 100, "latency": 12, "service": "auth"},
+      {"requests": 250, "latency": 18, "service": "auth"},
+      {"requests": 500, "latency": 25, "service": "auth"},
+      {"requests": 800, "latency": 45, "service": "auth"},
+      {"requests": 1200, "latency": 85, "service": "auth"},
+      {"requests": 150, "latency": 8, "service": "api"},
+      {"requests": 400, "latency": 15, "service": "api"},
+      {"requests": 700, "latency": 22, "service": "api"},
+      {"requests": 1000, "latency": 35, "service": "api"},
+      {"requests": 1500, "latency": 52, "service": "api"},
+      {"requests": 200, "latency": 30, "service": "search"},
+      {"requests": 350, "latency": 55, "service": "search"},
+      {"requests": 600, "latency": 95, "service": "search"},
+      {"requests": 900, "latency": 150, "service": "search"},
+      {"requests": 1100, "latency": 220, "service": "search"}
+    ]
+  },
+  "mark": {"type": "point", "filled": true, "size": 80},
+  "encoding": {
+    "x": {"field": "requests", "type": "quantitative", "title": "Requests/sec"},
+    "y": {"field": "latency", "type": "quantitative", "title": "P95 Latency (ms)"},
+    "color": {"field": "service", "type": "nominal"},
+    "shape": {"field": "service", "type": "nominal"}
+  }
+}
+```
+
+---
+
+## 7. PlantUML - Component Architecture
+
+```plantuml
+@startuml
+skinparam backgroundColor white
+skinparam defaultFontSize 11
+
+package "Frontend" {
+  [React SPA] as spa
+  [Admin Dashboard] as admin
+}
+
+package "API Layer" {
+  [API Gateway] as gw
+  [GraphQL Server] as gql
+}
+
+package "Services" {
+  [User Service] as userSvc
+  [Order Service] as orderSvc
+  [Notification Service] as notifSvc
+  [Payment Service] as paySvc
+}
+
+package "Data Stores" {
+  database "PostgreSQL" as pg
+  database "Redis" as redis
+  queue "Kafka" as kafka
+}
+
+cloud "External" {
+  [Stripe API] as stripe
+  [SendGrid] as sendgrid
+}
+
+spa --> gw
+admin --> gw
+gw --> gql
+gql --> userSvc
+gql --> orderSvc
+userSvc --> pg
+userSvc --> redis
+orderSvc --> pg
+orderSvc --> kafka
+orderSvc --> paySvc
+paySvc --> stripe
+kafka --> notifSvc
+notifSvc --> sendgrid
+@enduml
+```
+
+---
+
+## 8. PlantUML - State Machine
+
+```plantuml
+@startuml
+skinparam backgroundColor white
+
+[*] --> Draft : create
+
+state Draft {
+  [*] --> Editing
+  Editing --> Editing : save
+  Editing --> ReadyForReview : submit
+}
+
+state "In Review" as Review {
+  [*] --> PeerReview
+  PeerReview --> Approved : approve
+  PeerReview --> ChangesRequested : request changes
+  ChangesRequested --> PeerReview : resubmit
+}
+
+state Published {
+  [*] --> Live
+  Live --> Archived : archive
+}
+
+Draft --> Review : submit for review
+Review --> Draft : reject
+Review --> Published : publish
+Published --> Draft : unpublish
+
+Published --> [*]
+@enduml
+```
+
+---
+
+## 9. Infographic - Product Roadmap
+
+```infographic
+infographic sequence-roadmap-vertical-simple
+data
+  title 2026 Product Roadmap
+  items
+    - label Q1 2026
+      desc Core platform rewrite with TypeScript strict mode. Migration to event-driven architecture.
+      icon mdi/rocket-launch
+    - label Q2 2026
+      desc Real-time collaboration features. WebSocket integration and conflict resolution.
+      icon mdi/account-group
+    - label Q3 2026
+      desc AI-powered code review assistant. Integration with GitHub and GitLab.
+      icon mdi/brain
+    - label Q4 2026
+      desc Enterprise SSO, audit logging, and compliance certifications.
+      icon mdi/shield-check
+```
+
+---
+
+## 10. Infographic - KPI Dashboard
+
+```infographic
+infographic list-grid-badge-card
+data
+  title Platform Health - April 2026
+  desc Real-time system metrics
+  items
+    - label Uptime
+      desc 99.97% | 13 min downtime
+      icon mdi/server
+    - label Avg Latency
+      desc 42ms | P99: 180ms
+      icon mdi/speedometer
+    - label Active Users
+      desc 24,831 | Peak: 31K
+      icon mdi/account-multiple
+    - label Error Rate
+      desc 0.03% | Down from 0.12%
+      icon mdi/alert-circle
+    - label Deployments
+      desc 47 this month | 0 rollbacks
+      icon mdi/rocket
+    - label Test Coverage
+      desc 94.2% | +2.1% MoM
+      icon mdi/check-decagram
+```
+
+---
+
+## 11. Infographic - Tech Stack Comparison
+
+```infographic
+infographic compare-binary-horizontal-underline-text-vs
+data
+  title Monolith vs Microservices
+  items
+    - label Monolith
+      children
+        - label Simplicity
+          desc Single deployment unit, easier debugging
+        - label Performance
+          desc No network overhead between modules
+        - label Consistency
+          desc Shared database, ACID transactions
+        - label Team Size
+          desc Best for small teams (2-8 devs)
+    - label Microservices
+      children
+        - label Scalability
+          desc Scale individual services independently
+        - label Resilience
+          desc Failure isolation between services
+        - label Flexibility
+          desc Different tech stacks per service
+        - label Team Size
+          desc Best for large orgs (20+ devs)
+```
+
+---
+
+## 12. Infographic - Sales Funnel
+
+```infographic
+infographic sequence-filter-mesh-simple
+data
+  title Developer Adoption Funnel
+  items
+    - label Visitors
+      value 50000
+      desc Monthly docs page views
+    - label Sign-ups
+      value 8500
+      desc Free tier registrations (17%)
+    - label Active Users
+      value 3200
+      desc Made 10+ API calls (38%)
+    - label Paying
+      value 640
+      desc Converted to paid plan (20%)
+    - label Enterprise
+      value 48
+      desc Annual contracts signed (7.5%)
+```
+
+---
+
+## 13. Architecture Diagram - Microservices Platform (Steel Blue)
+
+<div style="width: 1200px; box-sizing: border-box; position: relative;">
+  <style scoped>
+    .arch-title { text-align: center; font-size: 20px; font-weight: 600; color: #2c3e50; margin-bottom: 16px; }
+    .arch-layer { margin: 10px 0; padding: 14px; border-radius: 4px; }
+    .arch-layer-title { font-size: 12px; font-weight: 600; color: #34618d; margin-bottom: 10px; text-align: center; text-transform: uppercase; letter-spacing: 0.5px; }
+    .arch-grid { display: grid; gap: 6px; }
+    .arch-grid-2 { grid-template-columns: repeat(2, 1fr); }
+    .arch-grid-3 { grid-template-columns: repeat(3, 1fr); }
+    .arch-grid-4 { grid-template-columns: repeat(4, 1fr); }
+    .arch-box { border-radius: 3px; padding: 8px; text-align: center; font-size: 11px; font-weight: 500; background: #e8eff5; border: 1px solid #b4cae0; color: #2c3e50; }
+  </style>
+  <div>
+    <div class="arch-title">Event-Driven Microservices Platform</div>
+    <div class="arch-layer" style="background: #dce6f0; border: 1px solid #b4cae0;">
+      <div class="arch-layer-title">Client Layer</div>
+      <div class="arch-grid arch-grid-4">
+        <div class="arch-box">React SPA</div>
+        <div class="arch-box">Mobile (React Native)</div>
+        <div class="arch-box">Admin Dashboard</div>
+        <div class="arch-box">CLI Tool</div>
+      </div>
+    </div>
+    <div class="arch-layer" style="background: #c8d8e8; border: 1px solid #a0bcd4;">
+      <div class="arch-layer-title">API Gateway & Edge</div>
+      <div class="arch-grid arch-grid-3">
+        <div class="arch-box">Kong Gateway</div>
+        <div class="arch-box">Rate Limiter</div>
+        <div class="arch-box">Auth (JWT + OAuth2)</div>
+      </div>
+    </div>
+    <div class="arch-layer" style="background: #b4cae0; border: 1px solid #8caec8;">
+      <div class="arch-layer-title">Domain Services</div>
+      <div class="arch-grid arch-grid-4">
+        <div class="arch-box">User Service</div>
+        <div class="arch-box">Order Service</div>
+        <div class="arch-box">Inventory Service</div>
+        <div class="arch-box">Payment Service</div>
+      </div>
+    </div>
+    <div class="arch-layer" style="background: #a0bcd4; border: 1px solid #78a0bc;">
+      <div class="arch-layer-title">Event Bus & Messaging</div>
+      <div class="arch-grid arch-grid-3">
+        <div class="arch-box">Apache Kafka</div>
+        <div class="arch-box">Schema Registry</div>
+        <div class="arch-box">Dead Letter Queue</div>
+      </div>
+    </div>
+    <div class="arch-layer" style="background: #8caec8; border: 1px solid #6492b0;">
+      <div class="arch-layer-title">Data Layer</div>
+      <div class="arch-grid arch-grid-4">
+        <div class="arch-box">PostgreSQL (Users)</div>
+        <div class="arch-box">PostgreSQL (Orders)</div>
+        <div class="arch-box">Redis Cache</div>
+        <div class="arch-box">S3 (Documents)</div>
+      </div>
+    </div>
+    <div class="arch-layer" style="background: #78a0bc; border: 1px solid #5a88a4;">
+      <div class="arch-layer-title">Observability</div>
+      <div class="arch-grid arch-grid-3">
+        <div class="arch-box">Grafana + Prometheus</div>
+        <div class="arch-box">OpenTelemetry</div>
+        <div class="arch-box">PagerDuty Alerts</div>
+      </div>
+    </div>
+  </div>
+</div>
+
+---
+
+## 14. Infocard - Tech Blueprint Style
+
+<div style="max-width: 800px; box-sizing: border-box; position: relative;">
+  <style scoped>
+    .card { position: relative; background: #0a1628; padding: 40px; overflow: hidden; font-family: 'Inter', 'Noto Sans SC', sans-serif; color: #c8d8ea; line-height: 1.6; }
+    .card::before { content: ''; position: absolute; inset: 0; pointer-events: none; opacity: 0.08; background-image: linear-gradient(rgba(0,212,255,0.5) 1px, transparent 1px), linear-gradient(90deg, rgba(0,212,255,0.5) 1px, transparent 1px); background-size: 24px 24px; }
+    .card-meta { margin: 0 0 12px; font-size: 12px; font-weight: 700; letter-spacing: 0.18em; text-transform: uppercase; color: #5a7a96; font-family: 'SF Mono', 'Fira Code', monospace; }
+    .card-title { margin: 0 0 16px; font-size: 34px; font-weight: 700; line-height: 1.2; letter-spacing: -0.01em; color: #00d4ff; }
+    .card-bar { width: 80px; height: 3px; margin: 0 0 20px; background: #00d4ff; box-shadow: 0 0 8px rgba(0,212,255,0.3); }
+    .card-body { margin: 0 0 16px; font-size: 15px; line-height: 1.6; color: #c8d8ea; }
+    .card-grid { display: grid; gap: 16px; }
+    .card-grid-2 { grid-template-columns: 1.1fr 0.9fr; }
+    .card-grid-3 { grid-template-columns: repeat(3, 1fr); }
+    .card-panel { padding: 16px 18px; background: rgba(0,212,255,0.06); border-top: 3px solid #00d4ff; border-left: 1px solid rgba(0,212,255,0.15); }
+    .card-panel-title { margin: 0 0 8px; font-size: 12px; font-weight: 700; letter-spacing: 0.12em; text-transform: uppercase; color: #00d4ff; font-family: 'SF Mono', 'Fira Code', monospace; }
+    .card-panel-text { margin: 0; font-size: 14px; line-height: 1.55; color: #8ab0cc; }
+    .card-stat { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 44px; font-weight: 700; line-height: 1; color: #00d4ff; margin: 0; text-shadow: 0 0 12px rgba(0,212,255,0.25); }
+    .card-stat-label { font-size: 12px; font-weight: 600; color: #5a7a96; text-transform: uppercase; letter-spacing: 0.1em; margin: 4px 0 0; font-family: 'SF Mono', 'Fira Code', monospace; }
+    .card-highlight { font-size: 17px; font-weight: 500; line-height: 1.5; color: #c8d8ea; padding: 10px 0 10px 18px; border-left: 3px solid #00d4ff; margin: 16px 0; }
+    .card-footer { margin-top: 20px; padding-top: 12px; border-top: 1px solid rgba(0,212,255,0.15); font-size: 11px; color: #5a7a96; letter-spacing: 0.05em; font-family: 'SF Mono', 'Fira Code', monospace; }
+  </style>
+  <div class="card">
+    <p class="card-meta">SPEC // Database Migration</p>
+    <h1 class="card-title">PostgreSQL 16 Upgrade<br>Migration Runbook</h1>
+    <div class="card-bar"></div>
+    <p class="card-body">Zero-downtime migration from PostgreSQL 14 to 16 using logical replication. The migration window targets off-peak hours with automated rollback triggers if replication lag exceeds thresholds.</p>
+    <p class="card-highlight">Target: &lt; 30 seconds of read-only mode during cutover</p>
+    <div class="card-grid card-grid-3">
+      <div style="text-align: center; padding: 12px 0;">
+        <p class="card-stat">2.4TB</p>
+        <p class="card-stat-label">Database Size</p>
+      </div>
+      <div style="text-align: center; padding: 12px 0;">
+        <p class="card-stat">847</p>
+        <p class="card-stat-label">Tables</p>
+      </div>
+      <div style="text-align: center; padding: 12px 0;">
+        <p class="card-stat">~30s</p>
+        <p class="card-stat-label">Cutover Time</p>
+      </div>
+    </div>
+    <div class="card-grid card-grid-2" style="margin-top: 16px;">
+      <div class="card-panel">
+        <p class="card-panel-title">PREREQUISITES</p>
+        <p class="card-panel-text">pg_logical installed on source. Target provisioned with 3x IOPS. Replication slots created. Application connection pool configured for switchover.</p>
+      </div>
+      <div class="card-panel">
+        <p class="card-panel-title">ROLLBACK TRIGGERS</p>
+        <p class="card-panel-text">Replication lag > 5s. Error rate > 0.1%. Connection pool exhaustion. Any failed health check on target within first 15 minutes.</p>
+      </div>
+    </div>
+    <div class="card-footer">REV 2.1 // Database Engineering // April 2026</div>
+  </div>
+</div>
+
+---
+
+## 15. Infocard - Editorial Warm Style
+
+<div style="max-width: 800px; box-sizing: border-box; position: relative;">
+  <style scoped>
+    .card { position: relative; background: #f5f3ed; padding: 40px; overflow: hidden; font-family: 'Inter', 'Noto Sans SC', sans-serif; color: #111; line-height: 1.6; }
+    .card::before { content: ''; position: absolute; inset: 0; pointer-events: none; opacity: 0.04; background-image: radial-gradient(circle at 20% 20%, rgba(0,0,0,0.8) 0.5px, transparent 0.8px), radial-gradient(circle at 80% 40%, rgba(0,0,0,0.7) 0.4px, transparent 0.7px); background-size: 8px 8px, 11px 11px; }
+    .card-meta { margin: 0 0 12px; font-size: 12px; font-weight: 700; letter-spacing: 0.15em; text-transform: uppercase; color: #575757; }
+    .card-title { margin: 0 0 16px; font-family: 'Noto Serif SC', serif; font-size: 36px; font-weight: 900; line-height: 1.15; letter-spacing: -0.02em; color: #111; }
+    .card-bar { width: 80px; height: 6px; margin: 0 0 20px; background: #111; }
+    .card-body { margin: 0 0 16px; font-size: 15px; line-height: 1.6; color: #111; }
+    .card-grid { display: grid; gap: 16px; }
+    .card-grid-2 { grid-template-columns: 1.1fr 0.9fr; }
+    .card-panel { padding: 16px 18px; background: rgba(0,0,0,0.03); border-top: 6px solid #111; }
+    .card-panel-title { margin: 0 0 8px; font-size: 12px; font-weight: 700; letter-spacing: 0.12em; text-transform: uppercase; color: #575757; }
+    .card-panel-text { margin: 0; font-size: 14px; line-height: 1.55; color: #333; }
+    .card-highlight { font-size: 17px; font-weight: 500; line-height: 1.5; color: #111; padding: 10px 0 10px 18px; border-left: 3px solid #111; margin: 16px 0; }
+    .card-body.dropcap::first-letter { font: 900 72px/0.82 'Noto Serif SC', Georgia, serif; float: left; margin: 4px 12px 0 -2px; color: #111; }
+    .card-endmark { display: block; text-align: right; font-size: 14px; color: #111; opacity: 0.3; margin-top: 20px; }
+    .card-footer { margin-top: 20px; padding-top: 12px; border-top: 1px solid rgba(0,0,0,0.1); font-size: 11px; color: #575757; letter-spacing: 0.05em; }
+  </style>
+  <div class="card">
+    <p class="card-meta">Engineering Culture · Incident Review</p>
+    <h1 class="card-title">What We Learned From<br>Our Worst Outage</h1>
+    <div class="card-bar"></div>
+    <p class="card-body dropcap">On March 14th, a routine database migration took down our entire platform for 47 minutes during peak hours. The root cause wasn't the migration itself -- it was the cascade of retry storms from 200+ microservices that turned a 3-second blip into a sustained outage. Every service tried to reconnect simultaneously, overwhelming connection pools and creating a thundering herd that took longer to resolve than the original issue.</p>
+    <p class="card-highlight">The retry storm caused 10x more damage than the original failure</p>
+    <div class="card-grid card-grid-2">
+      <div class="card-panel">
+        <p class="card-panel-title">What Changed</p>
+        <p class="card-panel-text">Every service now implements exponential backoff with jitter. Circuit breakers trip after 3 consecutive failures. Connection pools have hard limits with graceful degradation. We run chaos engineering exercises monthly.</p>
+      </div>
+      <div class="card-panel">
+        <p class="card-panel-title">Key Lesson</p>
+        <p class="card-panel-text">Resilience isn't about preventing failures -- it's about controlling the blast radius when they happen. A system that fails gracefully under pressure is more valuable than one that works perfectly until it doesn't.</p>
+      </div>
+    </div>
+    <span class="card-endmark">&#8718;</span>
+    <div class="card-footer">Incident Retrospective IR-2026-047 · Engineering Blog · April 2026</div>
+  </div>
+</div>
+

--- a/claude/.claude/skills/diagrams/references/architecture.md
+++ b/claude/.claude/skills/diagrams/references/architecture.md
@@ -1,0 +1,256 @@
+# Architecture Diagram Reference
+
+Create layered architecture diagrams using HTML/CSS templates. Best for system layers, microservices, enterprise applications. NOT for simple flowcharts (use Mermaid) or data visualization (use Vega-Lite).
+
+**Embedding:** Write as direct HTML in Markdown. **NEVER** use code blocks/fences.
+
+## Critical Rules
+
+1. **Direct HTML embedding** -- Write as raw HTML in Markdown, never in code fences
+2. **No empty lines in HTML** -- Keep structure continuous to prevent parsing errors
+3. **Incremental approach** -- Build in stages: framework > layers > components > styling
+4. **Pick a layout first, then a style** -- Combine layout structure with style colors
+
+## Workflow
+
+1. Choose a **layout** that matches your architecture shape
+2. Choose a **style** that matches your audience/context
+3. Copy the layout template
+4. Apply the style's color palette and CSS classes
+5. Replace placeholder content with your architecture
+
+---
+
+## Layout Catalog
+
+| Layout | Best For |
+|--------|----------|
+| Layer Layouts | Standard top-to-bottom layered architectures |
+| Three Column | Services spanning three groups |
+| Pipeline | Linear data/processing flows |
+| Dashboard | Monitoring/observability views |
+| Nested Containers | Grouped subsystems within layers |
+| Hub-Spoke | Central service with satellite components |
+| Grid Catalog | Component inventory/catalog views |
+| Two Column Split | Left-right divided architectures |
+| Left/Right Sidebar | Main content with sidebar navigation |
+| Single Stack | Simple vertical stack |
+| Banner Center | Centered hero with supporting layout |
+
+## Style Catalog
+
+| Style | Audience | Mood |
+|-------|----------|------|
+| Steel Blue | Consulting, enterprise | Professional, trustworthy |
+| Neon Dark | Tech talks, demos | Modern, energetic |
+| Sage Forest | Healthcare, sustainability | Calm, natural |
+| Frost Clean | Documentation, technical | Clean, precise |
+| Slate Dark | DevOps, infrastructure | Technical, focused |
+| Dusk Glow | Creative, design | Warm, atmospheric |
+| Ember Warm | Marketing, community | Friendly, inviting |
+| Indigo Deep | Finance, security | Authoritative, deep |
+| Ocean Teal | SaaS, platforms | Fresh, scalable |
+| Pastel Mix | Education, workshops | Approachable, light |
+| Rose Bloom | Health, lifestyle | Soft, caring |
+| Stark Block | Minimalist, technical | Bold, direct |
+
+---
+
+## Semantic Layers
+
+Standard layer hierarchy for architecture diagrams:
+
+| Layer | Purpose | Typical Color |
+|-------|---------|---------------|
+| User | Interfaces, clients | Light/accent |
+| Application | Business logic, API | Primary |
+| AI/Logic | Processing, ML | Secondary |
+| Data | Storage, databases | Tertiary |
+| Infrastructure | DevOps, hosting | Dark |
+| External | Third-party APIs | Muted |
+
+---
+
+## Core CSS Framework
+
+All architecture diagrams share this base structure:
+
+```html
+<div style="width: 1200px; box-sizing: border-box; position: relative;">
+  <style scoped>
+    .arch-title { text-align: center; font-size: 20px; font-weight: 600; color: #333; margin-bottom: 16px; }
+    .arch-main { width: 100%; }
+    .arch-layer { margin: 10px 0; padding: 14px; border-radius: 4px; border: 1px solid #ccc; background: #fafafa; }
+    .arch-layer-title { font-size: 12px; font-weight: 600; color: #555; margin-bottom: 10px; text-align: center; text-transform: uppercase; letter-spacing: 0.5px; }
+    .arch-grid { display: grid; gap: 6px; }
+    .arch-grid-2 { grid-template-columns: repeat(2, 1fr); }
+    .arch-grid-3 { grid-template-columns: repeat(3, 1fr); }
+    .arch-grid-4 { grid-template-columns: repeat(4, 1fr); }
+    .arch-box { border-radius: 3px; padding: 8px; text-align: center; font-size: 11px; font-weight: 500; line-height: 1.35; color: #333; background: #fff; border: 1px solid #ddd; }
+    .arch-box.highlight { border: 2px solid #999; font-weight: 600; }
+  </style>
+  <div class="arch-main">
+    <div class="arch-title">System Architecture</div>
+    <!-- layers go here -->
+  </div>
+</div>
+```
+
+## Layer Template
+
+```html
+<div class="arch-layer" style="background: #layerColor;">
+  <div class="arch-layer-title">Layer Name</div>
+  <div class="arch-grid arch-grid-3">
+    <div class="arch-box" style="background: #boxColor;">Component A</div>
+    <div class="arch-box" style="background: #boxColor;">Component B</div>
+    <div class="arch-box" style="background: #boxColor;">Component C</div>
+  </div>
+</div>
+```
+
+---
+
+## Steel Blue Style (Example)
+
+Professional consulting style with steel blue palette.
+
+| Property | Value |
+|----------|-------|
+| Background | `#f0f4f8` |
+| Layer bg | `#dce6f0`, `#c8d8e8`, `#b4cae0` |
+| Box bg | `#e8eff5` |
+| Text | `#2c3e50` |
+| Accent | `#34618d` |
+
+```html
+<div style="width: 1200px; box-sizing: border-box; position: relative;">
+  <style scoped>
+    .arch-title { text-align: center; font-size: 20px; font-weight: 600; color: #2c3e50; margin-bottom: 16px; }
+    .arch-layer { margin: 10px 0; padding: 14px; border-radius: 4px; }
+    .arch-layer-title { font-size: 12px; font-weight: 600; color: #34618d; margin-bottom: 10px; text-align: center; text-transform: uppercase; letter-spacing: 0.5px; }
+    .arch-grid { display: grid; gap: 6px; }
+    .arch-grid-3 { grid-template-columns: repeat(3, 1fr); }
+    .arch-box { border-radius: 3px; padding: 8px; text-align: center; font-size: 11px; font-weight: 500; background: #e8eff5; border: 1px solid #b4cae0; color: #2c3e50; }
+  </style>
+  <div>
+    <div class="arch-title">Microservices Platform</div>
+    <div class="arch-layer" style="background: #dce6f0; border: 1px solid #b4cae0;">
+      <div class="arch-layer-title">Client Layer</div>
+      <div class="arch-grid arch-grid-3">
+        <div class="arch-box">Web App</div>
+        <div class="arch-box">Mobile App</div>
+        <div class="arch-box">Admin Portal</div>
+      </div>
+    </div>
+    <div class="arch-layer" style="background: #c8d8e8; border: 1px solid #a0bcd4;">
+      <div class="arch-layer-title">API Gateway</div>
+      <div class="arch-grid arch-grid-3">
+        <div class="arch-box">Auth</div>
+        <div class="arch-box">Rate Limiting</div>
+        <div class="arch-box">Routing</div>
+      </div>
+    </div>
+    <div class="arch-layer" style="background: #b4cae0; border: 1px solid #8caec8;">
+      <div class="arch-layer-title">Services</div>
+      <div class="arch-grid arch-grid-3">
+        <div class="arch-box">User Service</div>
+        <div class="arch-box">Order Service</div>
+        <div class="arch-box">Payment Service</div>
+      </div>
+    </div>
+    <div class="arch-layer" style="background: #a0bcd4; border: 1px solid #78a0bc;">
+      <div class="arch-layer-title">Data Layer</div>
+      <div class="arch-grid arch-grid-3">
+        <div class="arch-box">PostgreSQL</div>
+        <div class="arch-box">Redis</div>
+        <div class="arch-box">S3</div>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+---
+
+## Neon Dark Style
+
+Modern dark theme for tech presentations.
+
+| Property | Value |
+|----------|-------|
+| Background | `#0d1117` |
+| Layer bg | `#161b22` |
+| Box bg | `#21262d` |
+| Text | `#e6edf3` |
+| Accent | `#58a6ff` |
+| Glow | `box-shadow: 0 0 8px rgba(88,166,255,0.3)` |
+
+---
+
+## Sage Forest Style
+
+Calm, natural palette for healthcare/sustainability.
+
+| Property | Value |
+|----------|-------|
+| Background | `#f5f7f4` |
+| Layer bg | `#e8ede5`, `#dce3d8` |
+| Box bg | `#eef2eb` |
+| Text | `#2d3b2d` |
+| Accent | `#5a7a5a` |
+
+---
+
+## Frost Clean Style
+
+Clean, precise for technical documentation.
+
+| Property | Value |
+|----------|-------|
+| Background | `#fafbfc` |
+| Layer bg | `#f0f2f5`, `#e6e9ed` |
+| Box bg | `#ffffff` |
+| Text | `#24292e` |
+| Accent | `#6f7681` |
+| Border | `1px solid #d1d5da` |
+
+---
+
+## Advanced Features
+
+### Subgroups within layers
+```html
+<div class="arch-subgroup">
+  <div class="arch-subgroup-box">
+    <div class="arch-subgroup-title">Group A</div>
+    <div class="arch-grid arch-grid-2">
+      <div class="arch-box">Component 1</div>
+      <div class="arch-box">Component 2</div>
+    </div>
+  </div>
+  <div class="arch-subgroup-box">
+    <div class="arch-subgroup-title">Group B</div>
+    <div class="arch-grid arch-grid-2">
+      <div class="arch-box">Component 3</div>
+      <div class="arch-box">Component 4</div>
+    </div>
+  </div>
+</div>
+```
+
+### KPI Row
+```html
+<div class="arch-kpi-row">
+  <div class="arch-kpi"><span class="arch-kpi-value">99.9%</span><br><span class="arch-kpi-label">Uptime</span></div>
+  <div class="arch-kpi"><span class="arch-kpi-value">&lt;50ms</span><br><span class="arch-kpi-label">Latency</span></div>
+  <div class="arch-kpi"><span class="arch-kpi-value">10K</span><br><span class="arch-kpi-label">RPS</span></div>
+</div>
+```
+
+### User Type Tags
+```html
+<div class="arch-box">Dashboard<br><span class="arch-user-tag">Admin</span></div>
+```
+
+For the complete catalog of all 13 layouts and 12 styles with full HTML templates, see the source repository: https://github.com/markdown-viewer/skills

--- a/claude/.claude/skills/diagrams/references/canvas.md
+++ b/claude/.claude/skills/diagrams/references/canvas.md
@@ -1,0 +1,155 @@
+# JSON Canvas Reference
+
+Create spatial, node-based diagrams using JSON Canvas format. Best for mind maps, knowledge graphs, concept maps, and planning boards.
+
+**Code fence:** ` ```canvas `
+
+## Critical Syntax Rules
+
+1. Valid JSON with proper quotes, commas, brackets
+2. Every node needs: `id`, `type`, `x`, `y`, `width`, `height`
+3. Node IDs: alphanumeric, hyphens, underscores only (no spaces or special chars)
+4. Coordinate origin is top-left; X increases right, Y increases down
+5. No negative coordinates
+
+## Common Pitfalls
+
+| Issue | Solution |
+|-------|----------|
+| Nodes overlapping | Increase spacing to 100+ pixels |
+| Edges not visible | Check node IDs match `fromNode`/`toNode` |
+| JSON syntax error | Validate quotes, commas, brackets |
+| Layout looks messy | Use groups, increase canvas size |
+
+---
+
+## Node Types
+
+### Text Node
+```json
+{
+  "id": "node1",
+  "type": "text",
+  "text": "Your text content here",
+  "x": 100, "y": 100,
+  "width": 200, "height": 100
+}
+```
+
+### File Node
+```json
+{
+  "id": "file1",
+  "type": "file",
+  "file": "path/to/document.md",
+  "x": 100, "y": 100,
+  "width": 160, "height": 60
+}
+```
+
+### Link Node
+```json
+{
+  "id": "link1",
+  "type": "link",
+  "url": "https://example.com",
+  "x": 100, "y": 100,
+  "width": 160, "height": 60
+}
+```
+
+### Group Node (Visual Container)
+```json
+{
+  "id": "group1",
+  "type": "group",
+  "label": "Group Title",
+  "x": 0, "y": 0,
+  "width": 600, "height": 400,
+  "color": "5"
+}
+```
+
+---
+
+## Edge Attributes
+
+| Attribute | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| `id` | Yes | - | Unique identifier |
+| `fromNode` | Yes | - | Source node ID |
+| `toNode` | Yes | - | Target node ID |
+| `fromSide` | No | - | `top`, `right`, `bottom`, `left` |
+| `toSide` | No | - | `top`, `right`, `bottom`, `left` |
+| `fromEnd` | No | `none` | `none` or `arrow` |
+| `toEnd` | No | `arrow` | `none` or `arrow` |
+| `label` | No | - | Edge label text |
+| `color` | No | - | Color preset `"1"`-`"6"` or hex |
+
+---
+
+## Color Presets
+
+| Value | Color | Usage |
+|-------|-------|-------|
+| `"1"` | Red | Warnings, blockers, critical |
+| `"2"` | Orange | Actions, processes, important |
+| `"3"` | Yellow | Questions, notes, considerations |
+| `"4"` | Green | Success, completed, positive |
+| `"5"` | Cyan | Information, details, neutral |
+| `"6"` | Purple | Concepts, ideas, abstract |
+
+---
+
+## Layout Patterns
+
+### Horizontal Flow
+```canvas
+{
+  "nodes": [
+    {"id": "n1", "type": "text", "text": "Input", "x": 50, "y": 100, "width": 100, "height": 50},
+    {"id": "n2", "type": "text", "text": "Process", "x": 200, "y": 100, "width": 100, "height": 50},
+    {"id": "n3", "type": "text", "text": "Output", "x": 350, "y": 100, "width": 100, "height": 50}
+  ],
+  "edges": [
+    {"id": "e1", "fromNode": "n1", "toNode": "n2", "fromSide": "right", "toSide": "left"},
+    {"id": "e2", "fromNode": "n2", "toNode": "n3", "fromSide": "right", "toSide": "left"}
+  ]
+}
+```
+
+### Tree Structure
+```canvas
+{
+  "nodes": [
+    {"id": "root", "type": "text", "text": "Root", "x": 200, "y": 20, "width": 100, "height": 50},
+    {"id": "c1", "type": "text", "text": "Child 1", "x": 50, "y": 120, "width": 100, "height": 50},
+    {"id": "c2", "type": "text", "text": "Child 2", "x": 200, "y": 120, "width": 100, "height": 50},
+    {"id": "c3", "type": "text", "text": "Child 3", "x": 350, "y": 120, "width": 100, "height": 50}
+  ],
+  "edges": [
+    {"id": "e1", "fromNode": "root", "fromSide": "bottom", "toNode": "c1", "toSide": "top"},
+    {"id": "e2", "fromNode": "root", "fromSide": "bottom", "toNode": "c2", "toSide": "top"},
+    {"id": "e3", "fromNode": "root", "fromSide": "bottom", "toNode": "c3", "toSide": "top"}
+  ]
+}
+```
+
+### Radial Mind Map
+```canvas
+{
+  "nodes": [
+    {"id": "center", "type": "text", "text": "Central Topic", "x": 200, "y": 200, "width": 140, "height": 60, "color": "4"},
+    {"id": "n1", "type": "text", "text": "North", "x": 220, "y": 50, "width": 100, "height": 50},
+    {"id": "n2", "type": "text", "text": "East", "x": 380, "y": 210, "width": 100, "height": 50},
+    {"id": "n3", "type": "text", "text": "South", "x": 220, "y": 350, "width": 100, "height": 50},
+    {"id": "n4", "type": "text", "text": "West", "x": 50, "y": 210, "width": 100, "height": 50}
+  ],
+  "edges": [
+    {"id": "e1", "fromNode": "center", "toNode": "n1", "fromSide": "top", "toSide": "bottom"},
+    {"id": "e2", "fromNode": "center", "toNode": "n2", "fromSide": "right", "toSide": "left"},
+    {"id": "e3", "fromNode": "center", "toNode": "n3", "fromSide": "bottom", "toSide": "top"},
+    {"id": "e4", "fromNode": "center", "toNode": "n4", "fromSide": "left", "toSide": "right"}
+  ]
+}
+```

--- a/claude/.claude/skills/diagrams/references/graphviz.md
+++ b/claude/.claude/skills/diagrams/references/graphviz.md
@@ -1,0 +1,247 @@
+# Graphviz DOT Diagram Reference
+
+Create complex directed/undirected graphs using DOT language. Best for dependency trees, module relationships, package hierarchies, and call graphs.
+
+**Code fence:** ` ```dot ` (never ` ```graphviz `)
+
+## Critical Syntax Rules
+
+1. **Cluster naming**: Subgraphs must begin with `cluster_` to render as boxes
+2. **Node IDs with spaces**: Use quotes (`"node name"`) or underscores
+3. **Edge direction**: Directed graphs use `->`, undirected use `--`
+4. **Attributes**: Comma-separate all attribute list items
+5. **HTML labels**: Use `shape=plaintext` and angle brackets `<>` instead of quotes
+
+---
+
+## Node Definition
+
+### Basic Syntax
+```dot
+digraph G {
+    node_id [label="Display Name"];
+    "node with space" [label="Displayed"];
+}
+```
+
+### Node Attributes
+```dot
+digraph G {
+    node_id [
+        label="Display Name",
+        shape=box,
+        style=filled,
+        fillcolor="#4A90E2",
+        fontcolor=white,
+        fontsize=12,
+        width=2,
+        height=1
+    ];
+}
+```
+
+### Record Nodes (Structured Data)
+```dot
+digraph G {
+    struct [shape=record, label="{name: string|age: int|email: string}"];
+    table [shape=record, label="{<f0> id|<f1> name|<f2> value}"];
+}
+```
+
+---
+
+## Edge Definition
+
+### Basic Syntax
+```dot
+digraph G {
+    A -> B;                    // Simple edge
+    A -> B [label="calls"];    // Labeled edge
+    A -> {B; C; D};            // One to many
+}
+```
+
+### Edge Attributes
+```dot
+digraph G {
+    A -> B [
+        label="relationship",
+        style=dashed,
+        color="#FF6B6B",
+        penwidth=2,
+        arrowhead=normal,
+        arrowtail=none,
+        dir=both
+    ];
+}
+```
+
+### Edge Styles
+| Style | Description |
+|-------|-------------|
+| `solid` | Regular line (default) |
+| `dashed` | Dashed line |
+| `dotted` | Dotted line |
+| `bold` | Thick line |
+| `invis` | Invisible (for layout) |
+
+### Arrow Heads
+| Type | Description |
+|------|-------------|
+| `normal` | Standard arrow (default) |
+| `open` | Open arrow tip |
+| `none` | No arrow |
+| `diamond` | Diamond end |
+| `odiamond` | Open diamond |
+| `dot` | Dot end |
+| `box` | Box end |
+| `crow` | Crow's foot (ER diagrams) |
+| `vee` | V-shaped |
+
+---
+
+## Layout Control
+
+### Layout Directions
+```dot
+digraph G {
+    rankdir=TB;  // Top to Bottom (default)
+    // rankdir=LR;  // Left to Right
+    // rankdir=RL;  // Right to Left
+    // rankdir=BT;  // Bottom to Top
+}
+```
+
+### Node Ranking
+```dot
+digraph G {
+    {rank=same; A; B; C;}    // Force same level
+    {rank=min; StartNode;}   // Force to top
+    {rank=max; EndNode;}     // Force to bottom
+}
+```
+
+### Spacing Control
+```dot
+digraph G {
+    graph [
+        nodesep=0.5,     // Horizontal spacing between nodes
+        ranksep=1.0,     // Vertical spacing between ranks
+        splines=ortho    // Edge routing: ortho|polyline|curved|line
+    ];
+}
+```
+
+---
+
+## Subgraph (Clustering)
+
+```dot
+digraph G {
+    subgraph cluster_backend {
+        label="Backend Services";
+        style=filled;
+        fillcolor="#F0F0F0";
+        color="#333333";
+
+        API [label="API Gateway"];
+        DB [label="Database", shape=cylinder];
+        API -> DB;
+    }
+
+    subgraph cluster_frontend {
+        label="Frontend";
+        style=filled;
+        fillcolor="#F5F5F5";
+
+        Client [label="Web Client"];
+    }
+
+    Client -> API;
+}
+```
+
+**Cluster names must start with `cluster_` to render as boxes.**
+
+---
+
+## Global Defaults
+
+```dot
+digraph G {
+    node [shape=box, style=filled, fillcolor="#3498DB", fontcolor=white];
+    edge [color="#666666", arrowhead=vee];
+    graph [rankdir=LR, bgcolor=white];
+
+    A -> B -> C;
+}
+```
+
+---
+
+## Node Shapes
+
+| Shape | Description | Usage |
+|-------|-------------|-------|
+| `box` | Rectangle | Process, action |
+| `ellipse` | Ellipse (default) | General node |
+| `circle` | Circle | State, event |
+| `diamond` | Diamond | Decision |
+| `plaintext` | No border | Labels |
+| `record` | Structured | Data tables |
+| `cylinder` | Cylinder | Database |
+| `folder` | Folder | Directory |
+| `component` | UML component | Module |
+
+### HTML Labels
+```dot
+digraph G {
+    node [shape=plaintext];
+    A [label=<
+        <TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0">
+            <TR><TD BGCOLOR="#3498DB"><FONT COLOR="white">Header</FONT></TD></TR>
+            <TR><TD>Content</TD></TR>
+        </TABLE>
+    >];
+}
+```
+
+---
+
+## Undirected Graphs
+
+```dot
+graph G {
+    rankdir=LR;
+    A -- B -- C;
+    B -- D;
+}
+```
+
+Use `graph` instead of `digraph`, and `--` instead of `->`.
+
+---
+
+## Color Palette
+
+| Color | Hex | Usage |
+|-------|-----|-------|
+| Green | `#2ECC71` | Success, completed |
+| Red | `#E74C3C` | Error, critical |
+| Orange | `#F39C12` | Warning, action |
+| Blue | `#3498DB` | Info, process |
+| Gray | `#95A5A6` | Neutral, disabled |
+| Purple | `#9B59B6` | Concept, idea |
+
+---
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| Nodes not aligned | Use `rank=same` or invisible edges |
+| Edges crossing | Try different `splines` or `rankdir` |
+| Clusters not showing | Name must start with `cluster_` |
+| Labels too long | Use `\n` for line breaks |
+| Graph too wide | Switch to `rankdir=TB` |
+| Overlapping nodes | Increase `nodesep` or `ranksep` |

--- a/claude/.claude/skills/diagrams/references/infocard.md
+++ b/claude/.claude/skills/diagrams/references/infocard.md
@@ -1,0 +1,270 @@
+# Infocard Reference
+
+Create editorial-quality information cards in Markdown using embedded HTML/CSS. Best for knowledge summaries, data highlights, content cards, and reports. NOT for architecture diagrams (use architecture), flowcharts (use mermaid), or data visualization (use vega).
+
+**Embedding:** Write as direct HTML in Markdown. **NEVER** use code blocks/fences.
+
+## Critical Rules
+
+1. **Direct HTML embedding** -- Write as raw HTML, never in code fences
+2. **No empty lines in HTML** -- Keep structure continuous to prevent parsing errors
+3. **Content analysis first** -- Assess density, structure, and mood before picking layout/style
+4. **Anti-AI checklist** -- Avoid centered hero titles, equal-width 3-column layouts, pure black text, oversized-only hierarchy, neon gradients, filler statistics
+
+## Workflow
+
+1. **Analyze content**: Density (low/medium/high word volume), Structure (layout geometry), Mood (visual tone)
+2. **Pick a layout** matching your content structure
+3. **Pick a style** matching your content mood
+4. Combine layout HTML with style CSS
+5. Replace placeholder content
+
+---
+
+## Content Analysis
+
+### Density Assessment
+- **Low density** (few words): Generous whitespace, large type
+- **Medium density**: Balanced grid, mixed-weight cells
+- **High density** (many words): Asymmetric grids, compact panels
+
+### Structure Signals
+| Signal | Layout Pattern |
+|--------|---------------|
+| Single key message | Hero Card |
+| Main + supporting detail | Split Panel |
+| Multiple equal topics | Bento Grid |
+| Sequential steps | Timeline Flow |
+| A vs B | Comparison |
+| Numbers-first | Data Highlight |
+
+### Mood to Style Mapping
+| Content Mood | Recommended Style |
+|-------------|------------------|
+| Philosophical, literary | Editorial Warm |
+| Product launch, tech | Clean Modern |
+| Data-heavy, KPIs | Bold Contrast |
+| Project notes, docs | Notion Minimal, Paper Minimal |
+| Technical specs | Tech Blueprint |
+| Academic, formal | Navy Formal |
+| Creative, vintage | Retro Vintage |
+
+---
+
+## Layout Catalog
+
+| Layout | Best For |
+|--------|----------|
+| Hero Card | Single topic with title + summary + one panel |
+| Split Panel | Main content + sidebar, analytical spread |
+| Bento Grid | Multi-topic overviews, feature showcases |
+| Timeline Flow | Processes, step-by-step guides, chronology |
+| Comparison | A vs B, before/after, pros/cons |
+| Data Highlight | KPI cards, metric-driven announcements |
+| Metric Board | Dense metrics overview |
+| Quote Card | Pull quotes, testimonials |
+| Radial Hub | Central concept with surrounding elements |
+| Badge Grid | Categorized items with labels |
+| Stacked Modules | Vertically stacked distinct sections |
+| Funnel Stack | Conversion funnels, progressive filtering |
+| Versus Split | Head-to-head comparison |
+
+## Style Catalog
+
+| Style | Mood | Key Feature |
+|-------|------|-------------|
+| Editorial Warm | Literary, essays | Serif titles, paper texture, noise overlay |
+| Clean Modern | Product, tech | Blue accents, rounded corners, crisp |
+| Bold Contrast | Data, KPIs | Dark bg, amber accents, oversized numbers |
+| Notion Minimal | Notes, docs | Ultra-clean white, muted blue accent |
+| Tech Blueprint | Specs, engineering | Blueprint grid bg, cyan accents, monospace |
+| Paper Minimal | Briefs, checklists | Clean white, subtle blue accent |
+| Deep Night | Premium, luxury | Near-black, emerald accents |
+| Navy Formal | Corporate, academic | Navy blue, gold accents |
+| Slate Chalk | Education, training | Chalkboard aesthetic |
+| Retro Vintage | Creative, editorial | Warm browns, vintage feel |
+| Lab Journal | Research, science | Graph paper grid, clinical |
+| Soft Neutral | General purpose | Warm gray, understated |
+| Chalkboard | Teaching, workshops | Dark green, chalk-like text |
+| Wash Pastel | Light, friendly | Soft pastel palette |
+
+---
+
+## Base Card Structure
+
+All infocards share this foundation:
+
+```html
+<div style="max-width: 800px; box-sizing: border-box; position: relative;">
+  <style scoped>
+    .card { position: relative; background: #fafafa; padding: 40px; font-family: sans-serif; color: #111; line-height: 1.6; }
+    .card-meta { margin: 0 0 12px; font-size: 12px; font-weight: 700; letter-spacing: 0.15em; text-transform: uppercase; color: #888; }
+    .card-title { margin: 0 0 16px; font-size: 36px; font-weight: 700; line-height: 1.15; color: #111; }
+    .card-bar { width: 80px; height: 6px; margin: 0 0 20px; background: #111; }
+    .card-subtitle { margin: 0 0 20px; font-size: 17px; line-height: 1.55; color: #444; }
+    .card-body { margin: 0 0 16px; font-size: 15px; line-height: 1.6; color: #333; }
+    .card-panel { padding: 16px 18px; background: rgba(0,0,0,0.03); border-top: 6px solid #111; }
+    .card-panel-title { margin: 0 0 8px; font-size: 12px; font-weight: 700; letter-spacing: 0.12em; text-transform: uppercase; color: #888; }
+    .card-panel-text { margin: 0; font-size: 14px; line-height: 1.55; color: #444; }
+    .card-footer { margin-top: 20px; padding-top: 12px; border-top: 1px solid rgba(0,0,0,0.1); font-size: 11px; color: #999; }
+  </style>
+  <div class="card">
+    <p class="card-meta">Category · Date</p>
+    <h1 class="card-title">Card Title</h1>
+    <div class="card-bar"></div>
+    <!-- content goes here -->
+    <div class="card-footer">Source · Attribution</div>
+  </div>
+</div>
+```
+
+---
+
+## Layout: Hero Card
+
+Title-dominant card with hero area and one supporting panel.
+
+```html
+<div style="max-width: 800px; box-sizing: border-box; position: relative;">
+  <style scoped>
+    .card { position: relative; background: #fafafa; padding: 40px; font-family: sans-serif; color: #111; line-height: 1.6; }
+    .card-meta { margin: 0 0 12px; font-size: 12px; font-weight: 700; letter-spacing: 0.15em; text-transform: uppercase; color: #888; }
+    .card-title { margin: 0 0 16px; font-size: 36px; font-weight: 700; line-height: 1.15; color: #111; }
+    .card-bar { width: 80px; height: 6px; margin: 0 0 20px; background: #111; }
+    .card-subtitle { margin: 0 0 20px; font-size: 17px; line-height: 1.55; color: #444; }
+    .card-panel { padding: 16px 18px; background: rgba(0,0,0,0.03); border-top: 6px solid #111; }
+    .card-panel-title { margin: 0 0 8px; font-size: 12px; font-weight: 700; letter-spacing: 0.12em; text-transform: uppercase; color: #888; }
+    .card-panel-text { margin: 0; font-size: 14px; line-height: 1.55; color: #444; }
+    .card-footer { margin-top: 20px; padding-top: 12px; border-top: 1px solid rgba(0,0,0,0.1); font-size: 11px; color: #999; }
+  </style>
+  <div class="card">
+    <p class="card-meta">Category · Date</p>
+    <h1 class="card-title">Hero Headline That<br>Anchors the Entire Card</h1>
+    <div class="card-bar"></div>
+    <p class="card-subtitle">A clear summary paragraph that gives readers the core message in 2-3 sentences.</p>
+    <div class="card-panel">
+      <p class="card-panel-title">Key Takeaway</p>
+      <p class="card-panel-text">Supporting context that adds depth to the hero message.</p>
+    </div>
+    <div class="card-footer">Source · Attribution</div>
+  </div>
+</div>
+```
+
+---
+
+## Layout: Split Panel
+
+Two-column asymmetric layout with main content and sidebar.
+
+Add to base styles:
+```css
+.card-split { display: grid; grid-template-columns: 1.2fr 0.8fr; gap: 20px; }
+```
+
+---
+
+## Layout: Bento Grid
+
+Asymmetric multi-size grid with mixed-weight cells.
+
+Add to base styles:
+```css
+.card-bento { display: grid; grid-template-columns: 2fr 1fr; grid-template-rows: auto auto; gap: 12px; }
+.card-bento-cell { padding: 18px; background: rgba(0,0,0,0.03); border-top: 4px solid #111; }
+.card-bento-cell.span-col { grid-column: span 2; }
+.card-bento-cell.span-row { grid-row: span 2; }
+.card-bento-stat { font-size: 36px; font-weight: 700; line-height: 1; color: #111; }
+```
+
+---
+
+## Layout: Timeline Flow
+
+Vertical sequential flow with connected steps.
+
+Add to base styles:
+```css
+.card-timeline { position: relative; padding-left: 32px; }
+.card-timeline::before { content: ''; position: absolute; left: 8px; top: 4px; bottom: 4px; width: 2px; background: rgba(0,0,0,0.12); }
+.card-step { position: relative; margin-bottom: 24px; }
+.card-step-dot { position: absolute; left: -32px; top: 2px; width: 18px; height: 18px; border-radius: 50%; background: #111; display: flex; align-items: center; justify-content: center; font-size: 9px; font-weight: 700; color: #fafafa; }
+.card-step-title { margin: 0 0 4px; font-size: 15px; font-weight: 700; color: #111; }
+.card-step-text { margin: 0; font-size: 13px; line-height: 1.55; color: #555; }
+```
+
+---
+
+## Layout: Comparison
+
+Side-by-side contrast with visual division.
+
+Add to base styles:
+```css
+.card-vs { display: grid; grid-template-columns: 1fr auto 1fr; gap: 0; }
+.card-vs-side { padding: 20px; }
+.card-vs-side.left { background: rgba(0,0,0,0.03); border-top: 4px solid #111; }
+.card-vs-side.right { background: rgba(0,0,0,0.06); border-top: 4px solid #666; }
+.card-vs-divider { display: flex; align-items: center; justify-content: center; width: 40px; font-size: 14px; font-weight: 700; color: #999; }
+```
+
+---
+
+## Layout: Data Highlight
+
+Numbers-first card with oversized metrics.
+
+Add to base styles:
+```css
+.card-stats { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
+.card-stat { font-size: 48px; font-weight: 700; line-height: 1; color: #111; }
+.card-stat-label { font-size: 12px; font-weight: 600; color: #888; text-transform: uppercase; letter-spacing: 0.1em; }
+```
+
+---
+
+## Style: Editorial Warm
+
+Warm paper background, serif titles, noise texture, magazine typography.
+
+Key CSS changes from base:
+```css
+.card { background: #f5f3ed; }
+.card::before { content: ''; position: absolute; inset: 0; pointer-events: none; opacity: 0.04; background-image: radial-gradient(circle at 20% 20%, rgba(0,0,0,0.8) 0.5px, transparent 0.8px); background-size: 8px 8px; }
+.card-title { font-family: 'Noto Serif SC', serif; font-weight: 900; }
+.card-body.dropcap::first-letter { font: 900 72px/0.82 'Noto Serif SC', Georgia, serif; float: left; margin: 4px 12px 0 -2px; }
+```
+
+## Style: Clean Modern
+
+White background, blue accents, contemporary feel.
+
+Key values: Background `#f8fafc`, Accent `#2563eb`, Border `#e2e8f0`, Rounded `8px`
+
+## Style: Bold Contrast
+
+Dark background, amber accents, high-contrast.
+
+Key values: Background `#0f172a`, Text `#f8fafc`, Accent `#f59e0b`
+
+## Style: Tech Blueprint
+
+Blueprint grid, monospace accents, engineering schematic.
+
+Key values: Background `#0a1628`, Accent `#00d4ff`, Grid overlay at 8% opacity, Monospace meta
+
+## Style: Notion Minimal
+
+Ultra-clean white, muted blue accent, digital notebook.
+
+Key values: Background `#ffffff`, Accent `#4a7cbe`, Border `#e5e7eb`
+
+## Style: Paper Minimal
+
+Clean white, subtle blue accent, project briefs.
+
+Key values: Background `#ffffff`, Accent `#4a7cbe`, Border `#e5e7eb` (similar to Notion but without interactive feel)
+
+---
+
+For the complete catalog of all 13 layouts and 14 styles with full HTML templates, see the source repository: https://github.com/markdown-viewer/skills

--- a/claude/.claude/skills/diagrams/references/infographic.md
+++ b/claude/.claude/skills/diagrams/references/infographic.md
@@ -1,0 +1,336 @@
+# Infographic Reference
+
+Create visual infographics using pre-designed templates. Best for KPI cards, timelines, roadmaps, step-by-step processes, A vs B comparisons, SWOT analysis, funnels, org trees, pie/bar charts. Optimized for 4-8 items.
+
+**Code fence:** ` ```infographic `
+
+## Critical Syntax Rules
+
+1. First line must be `infographic <template-name>` (kebab-case, no underscores)
+2. Use 2-space indentation consistently
+3. `label` is required for every item
+4. `value` must be numeric (no units)
+5. Icons use Iconify format: `collection/name` (e.g., `mdi/star`)
+6. Array items prefixed with hyphens
+
+## Template Categories
+
+| Category | Prefix | Best For |
+|----------|--------|----------|
+| List | `list-*` | Feature lists, KPI cards, checklists |
+| Sequence | `sequence-*` | Timelines, processes, funnels, roadmaps |
+| Compare | `compare-*` | A vs B, SWOT analysis |
+| Hierarchy | `hierarchy-*` | Org charts, tree structures |
+| Chart | `chart-*` | Pie, bar, column, word cloud |
+| Quadrant | `quadrant-*` | 2x2 matrices, priority grids |
+| Relation | `relation-*` | Central concepts, relationships |
+
+## Data Fields
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `label` | Yes | string | Item title |
+| `desc` | No | string | Description text |
+| `value` | No | number | Numeric data (charts) |
+| `icon` | No | string | Iconify ref (`mdi/star`) |
+| `illus` | No | string | unDraw illustration |
+| `children` | No | array | Nested items |
+| `done` | No | boolean | Checklist status |
+| `time` | No | string | Time label |
+
+## Template Constraints
+
+- **Compare templates**: Exactly 2 root items with `children`
+- **SWOT**: Exactly 4 items labeled `Strengths`, `Weaknesses`, `Opportunities`, `Threats` (English)
+- **Quadrant**: Exactly 4 items
+- **Hierarchy**: Max 3 nesting levels
+- **Optimal items**: 4-8 (split if more than 8)
+
+---
+
+## Quick Selection Guide
+
+| Use Case | Template |
+|----------|----------|
+| KPI dashboard | `list-grid-badge-card` |
+| Feature list | `list-grid-candy-card-lite` |
+| Task checklist | `list-column-done-list` |
+| Company history | `sequence-timeline-simple` |
+| Product roadmap | `sequence-roadmap-vertical-simple` |
+| Sales funnel | `sequence-filter-mesh-simple` |
+| Onboarding flow | `sequence-snake-steps-simple` |
+| Career ladder | `sequence-stairs-front-compact-card` |
+| Product comparison | `compare-binary-horizontal-underline-text-vs` |
+| SWOT analysis | `compare-swot` |
+| Organization chart | `hierarchy-tree-tech-style-capsule-item` |
+| Revenue breakdown | `chart-pie-donut-plain-text` |
+| Priority matrix | `quadrant-quarter-simple-card` |
+| Trending topics | `chart-wordcloud` |
+
+---
+
+## All Templates
+
+### List Templates
+| Template | Description |
+|----------|-------------|
+| `list-grid-badge-card` | Grid cards with badges (KPI cards, metrics) |
+| `list-grid-candy-card-lite` | Colorful grid cards (features, services) |
+| `list-grid-ribbon-card` | Cards with ribbon decoration |
+| `list-row-horizontal-icon-arrow` | Horizontal row with arrows (process steps) |
+| `list-row-simple-illus` | Row with illustrations |
+| `list-sector-plain-text` | Radial sector layout |
+| `list-column-done-list` | Checklist with checkmarks |
+| `list-column-vertical-icon-arrow` | Vertical with arrows |
+| `list-zigzag-down-compact-card` | Zigzag down cards (journey steps) |
+| `list-zigzag-up-compact-card` | Zigzag up cards (growth path) |
+
+### Sequence Templates
+| Template | Description |
+|----------|-------------|
+| `sequence-timeline-simple` | Simple timeline (history, milestones) |
+| `sequence-timeline-rounded-rect-node` | Timeline with rounded nodes |
+| `sequence-roadmap-vertical-simple` | Vertical roadmap |
+| `sequence-filter-mesh-simple` | Funnel chart (sales funnel, conversion) |
+| `sequence-funnel-simple` | Simple funnel |
+| `sequence-snake-steps-simple` | Snake path steps (long processes) |
+| `sequence-stairs-front-compact-card` | Front stairs cards (growth/levels) |
+| `sequence-ascending-steps` | Ascending steps (progress) |
+| `sequence-circular-simple` | Circular flow (cycles, loops) |
+| `sequence-pyramid-simple` | Pyramid structure |
+
+### Compare Templates
+| Template | Description |
+|----------|-------------|
+| `compare-binary-horizontal-underline-text-vs` | A vs B comparison |
+| `compare-binary-horizontal-badge-card-arrow` | Badge cards with arrows |
+| `compare-hierarchy-left-right-circle-node-pill-badge` | Hierarchy comparison |
+| `compare-swot` | SWOT analysis (4 quadrants) |
+
+### Hierarchy Templates
+| Template | Description |
+|----------|-------------|
+| `hierarchy-tree-tech-style-capsule-item` | Tech style tree (org charts) |
+| `hierarchy-tree-curved-line-rounded-rect-node` | Curved tree |
+| `hierarchy-structure` | Generic hierarchy (max 3 levels) |
+
+### Chart Templates
+| Template | Description |
+|----------|-------------|
+| `chart-pie-donut-plain-text` | Donut chart (distribution) |
+| `chart-pie-plain-text` | Pie chart |
+| `chart-bar-plain-text` | Horizontal bar chart |
+| `chart-column-simple` | Vertical column chart |
+| `chart-line-plain-text` | Line chart (trends) |
+| `chart-wordcloud` | Word cloud (keywords, topics) |
+
+### Quadrant Templates
+| Template | Description |
+|----------|-------------|
+| `quadrant-quarter-simple-card` | Quadrant cards (priority matrix) |
+| `quadrant-quarter-circular` | Circular quadrant |
+
+---
+
+## Examples
+
+### KPI Cards
+```infographic
+infographic list-grid-badge-card
+data
+  title Key Metrics
+  desc Annual performance overview
+  items
+    - label Total Revenue
+      desc $12.8M | YoY +23.5%
+      icon mdi/currency-usd
+    - label New Customers
+      desc 3,280 | YoY +45%
+      icon mdi/account-plus
+    - label Satisfaction
+      desc 94.6% | Industry leading
+      icon mdi/emoticon-happy
+    - label Market Share
+      desc 18.5% | Rank #2
+      icon mdi/trophy
+```
+
+### Timeline
+```infographic
+infographic sequence-timeline-simple
+data
+  title Company History
+  items
+    - label 2020
+      desc Company founded in Silicon Valley
+    - label 2021
+      desc Series A funding $5M
+    - label 2022
+      desc Expanded to 50 employees
+    - label 2023
+      desc Launched flagship product
+    - label 2024
+      desc IPO and global expansion
+```
+
+### Sales Funnel
+```infographic
+infographic sequence-filter-mesh-simple
+data
+  title Sales Funnel
+  items
+    - label Website Visitors
+      value 100000
+      desc Total traffic
+    - label Leads
+      value 25000
+      desc 25% conversion
+    - label Qualified
+      value 5000
+      desc 20% qualified
+    - label Proposals
+      value 1500
+      desc 30% engaged
+    - label Customers
+      value 500
+      desc 33% closed
+```
+
+### A vs B Comparison
+```infographic
+infographic compare-binary-horizontal-underline-text-vs
+data
+  title Cloud vs On-Premise
+  items
+    - label Cloud Solution
+      children
+        - label Scalability
+          desc Scale on demand
+        - label Cost
+          desc Pay as you go
+        - label Maintenance
+          desc Provider managed
+    - label On-Premise
+      children
+        - label Control
+          desc Full data ownership
+        - label Cost
+          desc One-time investment
+        - label Maintenance
+          desc Internal IT team
+```
+
+### SWOT Analysis
+```infographic
+infographic compare-swot
+data
+  title Strategic Analysis
+  items
+    - label Strengths
+      children
+        - label Strong R&D team
+        - label Patent portfolio
+        - label Brand recognition
+    - label Weaknesses
+      children
+        - label Limited budget
+        - label Small sales team
+    - label Opportunities
+      children
+        - label AI market growth
+        - label New markets
+    - label Threats
+      children
+        - label Competition
+        - label Regulation
+```
+
+### Org Chart
+```infographic
+infographic hierarchy-tree-tech-style-capsule-item
+data
+  title Organization Structure
+  items
+    - label CEO
+      children
+        - label CTO
+          children
+            - label Engineering
+            - label DevOps
+        - label CFO
+          children
+            - label Finance
+            - label Accounting
+```
+
+### Donut Chart
+```infographic
+infographic chart-pie-donut-plain-text
+data
+  title Revenue by Region
+  items
+    - label North America
+      value 42
+    - label Europe
+      value 28
+    - label Asia Pacific
+      value 18
+    - label Other
+      value 12
+```
+
+### Priority Matrix
+```infographic
+infographic quadrant-quarter-simple-card
+data
+  title Priority Matrix
+  items
+    - label Do First
+      desc Urgent & Important
+      children
+        - label Critical bugs
+        - label Client deadlines
+    - label Schedule
+      desc Not Urgent & Important
+      children
+        - label Planning
+        - label Training
+    - label Delegate
+      desc Urgent & Not Important
+      children
+        - label Meetings
+        - label Some emails
+    - label Eliminate
+      desc Not Urgent & Not Important
+      children
+        - label Time wasters
+        - label Busy work
+```
+
+### Dark Theme
+```infographic
+infographic list-row-horizontal-icon-arrow
+theme dark
+  palette
+    - #61DDAA
+    - #F6BD16
+    - #F08BB4
+data
+  title Process Steps
+  items
+    - label Start
+      desc Begin here
+      icon mdi/play
+    - label Process
+      desc Work in progress
+      icon mdi/cog
+    - label Complete
+      desc Finish
+      icon mdi/check
+```
+
+## Theme Options
+
+- `theme dark` -- Dark background
+- `theme` with `stylize rough` -- Hand-drawn style
+- Custom palette via hex colors under `theme` > `palette`

--- a/claude/.claude/skills/diagrams/references/mermaid.md
+++ b/claude/.claude/skills/diagrams/references/mermaid.md
@@ -1,0 +1,222 @@
+# Mermaid Diagram Reference
+
+Create flowcharts, sequence diagrams, state machines, class diagrams, Gantt charts, and mindmaps using text-based syntax.
+
+**Code fence:** ` ```mermaid `
+
+## Critical Syntax Rules
+
+### Rule 1: List Syntax Conflicts
+```
+[1.Item]      -- Remove space after period
+[① Item]      -- Use circled numbers ①②③④⑤⑥⑦⑧⑨⑩
+[(1) Item]    -- Use parentheses
+```
+Never use `[1. Item]` (space after period) -- causes "Unsupported markdown: list" error.
+
+### Rule 2: Subgraph Naming
+```
+subgraph agent["AI Agent Core"]  -- ID with display name
+subgraph agent                   -- Simple ID only
+```
+Never use `subgraph AI Agent Core` (space without quotes).
+
+### Rule 3: Node References in Subgraphs
+Reference subgraph **ID**, not display name:
+```
+Title --> agent    -- correct (uses ID)
+```
+
+### Rule 4: Special Characters in Node Text
+```
+["Text with spaces"]       -- Quotes for spaces
+Use #quot; instead of "    -- Avoid quotation marks
+Use #lpar;#rpar; for ()    -- Avoid parentheses
+```
+
+### Rule 5: Use flowchart over graph
+```
+flowchart TD  -- correct (supports subgraph directions, more features)
+```
+
+## Common Pitfalls
+
+| Issue | Solution |
+|-------|----------|
+| Diagram won't render | Check unmatched brackets, quotes |
+| List syntax error | `[1.Item]` not `[1. Item]` |
+| Subgraph reference fails | Use ID not display name |
+| Too crowded | Split into multiple diagrams |
+| Crossing connections | Use different layout direction or invisible edges `~~~` |
+
+---
+
+## Sequence Diagram Syntax
+
+### Messages
+```
+->>   Solid line with arrow
+-->>  Dashed line with arrow
+-)    Solid line with open arrow
+--)   Dashed line with open arrow
+```
+
+### Activation & Notes
+```mermaid
+sequenceDiagram
+    participant A
+    participant B
+    A->>+B: Request (activates B)
+    Note right of B: Processing
+    B-->>-A: Response (deactivates B)
+    Note over A,B: Both involved
+```
+
+### Loops & Conditions
+```mermaid
+sequenceDiagram
+    loop Every minute
+        A->>B: Heartbeat
+    end
+    alt Success
+        B-->>A: OK
+    else Failure
+        B-->>A: Error
+    end
+    opt Optional
+        A->>B: Extra call
+    end
+```
+
+---
+
+## Class Diagram Syntax
+
+### Relationships
+```
+<|--  Inheritance
+*--   Composition
+o--   Aggregation
+-->   Association
+--    Link (solid)
+..>   Dependency
+..|>  Realization
+```
+
+### Class Definition
+```mermaid
+classDiagram
+    class Animal {
+        +String name
+        +int age
+        +makeSound() void
+        -privateMethod() int
+        #protectedMethod()
+    }
+    Animal <|-- Dog
+    Animal <|-- Cat
+```
+
+---
+
+## ER Diagram Syntax
+
+### Cardinality
+```
+||--||  One to one
+||--o{  One to many
+}o--o{  Many to many
+||--o|  One to zero or one
+```
+
+### Example
+```mermaid
+erDiagram
+    CUSTOMER ||--o{ ORDER : places
+    ORDER ||--|{ LINE_ITEM : contains
+    PRODUCT }|--o{ LINE_ITEM : "ordered in"
+```
+
+---
+
+---
+
+## User Journey Syntax
+
+```mermaid
+journey
+    title User Shopping Experience
+    section Browse
+        Visit website: 5: User
+        Search product: 4: User
+    section Purchase
+        Add to cart: 5: User
+        Checkout: 3: User
+        Payment: 4: User
+```
+
+Score: 1 (bad) to 5 (great)
+
+---
+
+## XY Chart Syntax
+
+```mermaid
+xychart
+    title "Monthly Sales"
+    x-axis [Jan, Feb, Mar, Apr]
+    y-axis "Revenue" 0 --> 150
+    bar [65, 78, 52, 91]
+    line [65, 78, 52, 91]
+```
+
+---
+
+## Kanban Syntax
+
+```mermaid
+kanban
+  Todo
+    [Design System]
+  InProgress
+    [Implement Feature]
+  Done
+    [Setup CI/CD]
+```
+
+---
+
+## Layout & Styling
+
+### Directions
+- `TB` / `TD` -- Top to Bottom (default)
+- `LR` -- Left to Right
+- `RL` -- Right to Left
+- `BT` -- Bottom to Top
+
+### Node Styling
+```mermaid
+flowchart TD
+    A[Node A]
+    B[Node B]
+    style A fill:#90EE90,stroke:#333,stroke-width:2px
+    style B fill:#ff6b6b,color:white
+```
+
+### Class Definitions
+```mermaid
+flowchart TD
+    A:::success --> B:::warning
+    classDef success fill:#2ECC71,color:white
+    classDef warning fill:#F39C12,color:white
+```
+
+### Subgraph Nesting & Direction
+```mermaid
+flowchart LR
+    subgraph sub["Vertical Inside"]
+        direction TB
+        A --> B --> C
+    end
+    D --> sub
+```

--- a/claude/.claude/skills/diagrams/references/plantuml.md
+++ b/claude/.claude/skills/diagrams/references/plantuml.md
@@ -1,0 +1,327 @@
+# PlantUML Diagram Reference
+
+Create UML diagrams, cloud architecture, network topology, security diagrams, enterprise architecture, and more using PlantUML syntax with 9,500+ mxgraph stencil icons.
+
+**Code fence:** ` ```plantuml ` or ` ```puml ` (never ` ```text `)
+
+## Critical Syntax Rules
+
+1. Every diagram starts with `@startuml` and ends with `@enduml`
+2. Always use ` ```plantuml ` or ` ```puml ` code fence
+3. Use `left to right direction` for typical data flows
+4. Stencil syntax: `mxgraph.<namespace>.<icon> "Label" as <alias>`
+5. Default styling applies automatically -- don't manually specify colors for stencil icons
+
+## Connection Types
+
+| Syntax | Meaning |
+|--------|---------|
+| `-->` | Solid arrow (synchronous flow, direct access) |
+| `..>` | Dashed arrow (async events, audit, detection) |
+| `--` | Plain line (bidirectional link) |
+| `-->` with label | `A --> B : "label"` |
+
+---
+
+## UML Diagrams
+
+### Supported Types
+Class, Sequence, Activity, State Machine, Component, Use Case, Deployment, Object, Package, Timing, Composite Structure, Profile, Interaction Overview, Communication
+
+### Class Diagram
+```plantuml
+@startuml
+class User {
+  +name: String
+  +email: String
+  +login(): Boolean
+}
+class Order {
+  +id: Long
+  +total: Decimal
+  +submit(): void
+}
+User "1" --> "*" Order : places
+@enduml
+```
+
+### Sequence Diagram
+```plantuml
+@startuml
+participant Client
+participant API
+participant Database
+
+Client -> API: POST /orders
+activate API
+API -> Database: INSERT order
+activate Database
+Database --> API: order_id
+deactivate Database
+API --> Client: 201 Created
+deactivate API
+@enduml
+```
+
+### Activity Diagram
+```plantuml
+@startuml
+start
+:Receive Request;
+if (Authenticated?) then (yes)
+  :Process Order;
+  if (In Stock?) then (yes)
+    :Ship Item;
+  else (no)
+    :Backorder;
+  endif
+else (no)
+  :Return 401;
+endif
+stop
+@enduml
+```
+
+### State Machine
+```plantuml
+@startuml
+[*] --> Draft
+Draft --> Review : submit
+Review --> Approved : approve
+Review --> Draft : reject
+Approved --> Published : publish
+Published --> [*]
+@enduml
+```
+
+### Component Diagram
+```plantuml
+@startuml
+package "Frontend" {
+  [Web App]
+  [Mobile App]
+}
+package "Backend" {
+  [API Gateway]
+  [Auth Service]
+  [Order Service]
+}
+database "Data" {
+  [PostgreSQL]
+  [Redis]
+}
+
+[Web App] --> [API Gateway]
+[Mobile App] --> [API Gateway]
+[API Gateway] --> [Auth Service]
+[API Gateway] --> [Order Service]
+[Order Service] --> [PostgreSQL]
+[Auth Service] --> [Redis]
+@enduml
+```
+
+### Relationship Arrows
+```
+-->    Association
+<|--   Inheritance
+*--    Composition
+o--    Aggregation
+..>    Dependency
+..|>   Realization
+```
+
+### Styling
+```plantuml
+@startuml
+skinparam backgroundColor white
+skinparam defaultFontSize 12
+skinparam classBorderColor #333
+skinparam classBackgroundColor #f8f8f8
+@enduml
+```
+
+---
+
+## Cloud Architecture
+
+### Stencil Prefixes
+
+| Provider | Prefix | Examples |
+|----------|--------|----------|
+| AWS | `mxgraph.aws4.*` | `lambda_function`, `ec2`, `s3`, `api_gateway`, `dynamodb`, `sqs`, `sns`, `cloudfront`, `rds`, `ecs` |
+| Azure | `mxgraph.azure.*` | `virtual_machine`, `app_service`, `sql_database`, `storage_blob`, `functions` |
+| GCP | `mxgraph.gcp2.*` | `compute_engine`, `cloud_functions`, `cloud_storage`, `bigquery`, `pub_sub` |
+| Kubernetes | `mxgraph.kubernetes2.*` | `pod`, `service`, `deployment`, `ingress`, `config_map` |
+| Alibaba | `mxgraph.alibaba_cloud.*` | `ecs`, `oss`, `rds`, `slb` |
+| IBM | `mxgraph.ibm_cloud.*` | `kubernetes_service`, `cloud_functions` |
+
+### AWS Example
+```plantuml
+@startuml
+left to right direction
+
+mxgraph.aws4.api_gateway "API Gateway" as apigw
+mxgraph.aws4.lambda_function "Order Lambda" as lambda
+mxgraph.aws4.dynamodb "Orders Table" as dynamo
+mxgraph.aws4.sqs "Order Queue" as sqs
+mxgraph.aws4.sns "Notifications" as sns
+
+apigw --> lambda
+lambda --> dynamo
+lambda --> sqs
+sqs ..> sns
+@enduml
+```
+
+---
+
+## Network Topology
+
+### Stencil Families
+
+| Family | Prefix | Use For |
+|--------|--------|---------|
+| Basic Network | `mxgraph.networks.*` | Switches, routers, firewalls |
+| Cisco | `mxgraph.cisco.*` | Enterprise Cisco equipment |
+| Cisco 19 | `mxgraph.cisco19.*` | Modern Cisco icons |
+| Cisco SAFE | `mxgraph.cisco_safe.*` | Security icons |
+| Citrix | `mxgraph.citrix.*` | Virtual infrastructure |
+
+### Connection Types for Networks
+| Syntax | Meaning |
+|--------|---------|
+| `--` | Physical connection |
+| `-->` | Directed flow |
+| `..` | VPN/wireless link |
+| `..>` | Logical flow |
+
+### Diagram Types
+LAN, WAN, Enterprise, Wireless, Cloud-Hybrid, Citrix, Security, Data Center, Monitoring
+
+---
+
+## Security Architecture
+
+### Stencil Categories
+
+| Domain | Key Stencils |
+|--------|-------------|
+| Identity & Access | IAM roles, SSO, directory services, STS |
+| Encryption | Key management, secrets rotation, HSM, certificates |
+| Network Security | Firewalls, WAF, DDoS protection, security groups |
+| Threat Detection | GuardDuty, Detective, Inspector |
+| Compliance | CloudTrail, audit managers, compliance frameworks |
+| Data Protection | Sensitive data discovery, classification |
+
+### Patterns
+IAM authentication, encryption pipelines, network defense, threat response, compliance auditing, zero-trust, data classification, multi-account governance
+
+---
+
+## Enterprise Architecture (ArchiMate)
+
+Requires: `!include <archimate/Archimate>`
+
+### Element Macros by Layer
+
+| Layer | Macros |
+|-------|--------|
+| Business | `Business_Actor`, `Business_Role`, `Business_Process`, `Business_Function`, `Business_Service`, `Business_Event`, `Business_Object` |
+| Application | `Application_Component`, `Application_Service`, `Application_Function`, `Application_Interface`, `Application_DataObject` |
+| Technology | `Technology_Device`, `Technology_Node`, `Technology_SystemSoftware`, `Technology_Artifact`, `Technology_CommunicationNetwork` |
+| Motivation | `Motivation_Stakeholder`, `Motivation_Driver`, `Motivation_Goal`, `Motivation_Requirement` |
+| Strategy | `Strategy_Capability`, `Strategy_Resource`, `Strategy_ValueStream` |
+| Implementation | `Implementation_WorkPackage`, `Implementation_Deliverable`, `Implementation_Plateau`, `Implementation_Gap` |
+
+### Relationship Macros
+All support directional suffixes: `_Up`, `_Down`, `_Left`, `_Right`
+
+| Macro | Relationship |
+|-------|-------------|
+| `Rel_Composition` | Composition (solid + filled diamond) |
+| `Rel_Aggregation` | Aggregation (solid + open diamond) |
+| `Rel_Assignment` | Assignment (solid + circle-triangle) |
+| `Rel_Realization` | Realization (dotted + hollow triangle) |
+| `Rel_Serving` | Serving (solid + arrow) |
+| `Rel_Triggering` | Triggering (solid + filled triangle) |
+| `Rel_Flow` | Flow (dashed + filled triangle) |
+| `Rel_Access` | Access (dotted line) |
+| `Rel_Access_r` | Access read (dotted + arrow) |
+| `Rel_Access_w` | Access write (dotted + reverse arrow) |
+
+### ArchiMate Example
+```plantuml
+@startuml
+!include <archimate/Archimate>
+
+rectangle "Business" {
+  Business_Actor(customer, "Customer")
+  Business_Process(order, "Order Process")
+  Business_Service(orderSvc, "Order Service")
+}
+
+rectangle "Application" {
+  Application_Component(orderApp, "Order System")
+  Application_Service(orderAPI, "Order API")
+}
+
+rectangle "Technology" {
+  Technology_Node(server, "App Server")
+  Technology_Device(db, "Database Server")
+}
+
+Rel_Triggering(customer, order, "places order")
+Rel_Realization(order, orderSvc, "realizes")
+Rel_Serving(orderAPI, orderSvc, "serves")
+Rel_Realization(orderApp, orderAPI, "realizes")
+Rel_Assignment(server, orderApp, "runs on")
+Rel_Serving(db, server, "stores data")
+@enduml
+```
+
+---
+
+## BPMN (Business Process)
+
+### Stencil Families
+
+| Family | Prefix | Use For |
+|--------|--------|---------|
+| BPMN | `mxgraph.bpmn.*` | Events, gateways, tasks, data objects |
+| EIP | `mxgraph.eip.*` | Enterprise Integration Patterns (routing, transformation) |
+| Lean Mapping | `mxgraph.lean_mapping.*` | Value stream symbols, kanban |
+
+### Connection Types
+- `-->` Sequence flow
+- `..>` Message flow (across pools)
+
+### Patterns
+Order processing, approval workflows, EIP messaging, ETL pipelines, value streams, microservice orchestration, event-driven architectures
+
+---
+
+## Data Analytics
+
+### Key Stencils
+
+| Category | Examples |
+|----------|----------|
+| Analytics & ETL | `athena`, `glue`, `kinesis`, `emr`, `redshift`, `opensearch`, `quicksight`, `lake_formation` |
+| Databases | `aurora`, `rds`, `dynamodb`, `neptune`, `elasticache`, `documentdb` |
+
+### Connection Types
+- `-->` Batch flows
+- `..>` Streaming/async
+
+### Patterns
+Data lake, real-time streaming, data warehouse, ETL workflow, log analytics, ML feature store, CDC pipeline, multi-source BI
+
+---
+
+## IoT
+
+### Key Stencils
+`iot_core`, `greengrass`, `sensor`, `thermostat`, `camera`, `factory`, `iot_thing_plc`, `iot_fleetwise`
+
+### Patterns
+Smart factory, smart home, fleet telemetry, edge computing, digital twins, sensor networks, device management, robotics

--- a/claude/.claude/skills/diagrams/references/vega.md
+++ b/claude/.claude/skills/diagrams/references/vega.md
@@ -1,0 +1,214 @@
+# Vega / Vega-Lite Visualization Reference
+
+Create data-driven charts using Vega-Lite (simpler, 90% of use cases) or Vega (advanced). Best for bar, line, scatter, heatmap, area charts, and multi-series analytics.
+
+**Code fence:** ` ```vega-lite ` (simpler) or ` ```vega ` (advanced)
+
+## Critical Syntax Rules
+
+1. **Always include the schema**: `"$schema": "https://vega.github.io/schema/vega-lite/v5.json"`
+2. **Valid JSON only**: Double quotes, no trailing commas
+3. **Field names are case-sensitive**: Must match your data exactly
+4. **Valid type declarations**: `quantitative`, `nominal`, `ordinal`, or `temporal`
+
+## When to Use Each
+
+- **Vega-Lite**: ~90% of charts. Simpler, declarative, handles layout automatically
+- **Vega**: Radar charts, word clouds, custom interactions, fine-grained control
+
+## Common Pitfalls
+
+| Issue | Solution |
+|-------|----------|
+| Chart won't render | Validate JSON, check for missing schema |
+| Data not visible | Field names must match data exactly (case-sensitive) |
+| Wrong chart type | Verify mark type matches data structure |
+| Colors too similar | Use named color schemes with sufficient contrast |
+
+---
+
+## Basic Bar Chart
+
+```vega-lite
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+  "description": "A simple bar chart",
+  "data": {
+    "values": [
+      {"category": "A", "value": 28},
+      {"category": "B", "value": 55},
+      {"category": "C", "value": 43}
+    ]
+  },
+  "mark": "bar",
+  "encoding": {
+    "x": {"field": "category", "type": "nominal"},
+    "y": {"field": "value", "type": "quantitative"}
+  }
+}
+```
+
+## Line Chart
+
+```vega-lite
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+  "data": {
+    "values": [
+      {"month": "Jan", "value": 30},
+      {"month": "Feb", "value": 45},
+      {"month": "Mar", "value": 60},
+      {"month": "Apr", "value": 52}
+    ]
+  },
+  "mark": "line",
+  "encoding": {
+    "x": {"field": "month", "type": "ordinal"},
+    "y": {"field": "value", "type": "quantitative"}
+  }
+}
+```
+
+## Scatter Plot
+
+```vega-lite
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+  "data": {
+    "values": [
+      {"x": 1, "y": 2, "group": "A"},
+      {"x": 3, "y": 5, "group": "A"},
+      {"x": 2, "y": 8, "group": "B"},
+      {"x": 4, "y": 3, "group": "B"}
+    ]
+  },
+  "mark": "point",
+  "encoding": {
+    "x": {"field": "x", "type": "quantitative"},
+    "y": {"field": "y", "type": "quantitative"},
+    "color": {"field": "group", "type": "nominal"}
+  }
+}
+```
+
+## Heatmap
+
+```vega-lite
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+  "data": {
+    "values": [
+      {"day": "Mon", "hour": "9am", "value": 5},
+      {"day": "Mon", "hour": "10am", "value": 8},
+      {"day": "Tue", "hour": "9am", "value": 3},
+      {"day": "Tue", "hour": "10am", "value": 9}
+    ]
+  },
+  "mark": "rect",
+  "encoding": {
+    "x": {"field": "hour", "type": "ordinal"},
+    "y": {"field": "day", "type": "ordinal"},
+    "color": {"field": "value", "type": "quantitative"}
+  }
+}
+```
+
+## Multi-Series Line Chart
+
+```vega-lite
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+  "data": {
+    "values": [
+      {"month": "Jan", "value": 30, "series": "Revenue"},
+      {"month": "Feb", "value": 45, "series": "Revenue"},
+      {"month": "Jan", "value": 20, "series": "Cost"},
+      {"month": "Feb", "value": 25, "series": "Cost"}
+    ]
+  },
+  "mark": "line",
+  "encoding": {
+    "x": {"field": "month", "type": "ordinal"},
+    "y": {"field": "value", "type": "quantitative"},
+    "color": {"field": "series", "type": "nominal"}
+  }
+}
+```
+
+## Stacked Bar Chart
+
+```vega-lite
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+  "data": {
+    "values": [
+      {"quarter": "Q1", "region": "North", "sales": 120},
+      {"quarter": "Q1", "region": "South", "sales": 80},
+      {"quarter": "Q2", "region": "North", "sales": 150},
+      {"quarter": "Q2", "region": "South", "sales": 90}
+    ]
+  },
+  "mark": "bar",
+  "encoding": {
+    "x": {"field": "quarter", "type": "nominal"},
+    "y": {"field": "sales", "type": "quantitative"},
+    "color": {"field": "region", "type": "nominal"}
+  }
+}
+```
+
+## Area Chart
+
+```vega-lite
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+  "data": {
+    "values": [
+      {"date": "2024-01", "value": 100},
+      {"date": "2024-02", "value": 130},
+      {"date": "2024-03", "value": 115},
+      {"date": "2024-04", "value": 160}
+    ]
+  },
+  "mark": "area",
+  "encoding": {
+    "x": {"field": "date", "type": "temporal"},
+    "y": {"field": "value", "type": "quantitative"}
+  }
+}
+```
+
+## Mark Types
+
+| Mark | Usage |
+|------|-------|
+| `bar` | Bar/column charts |
+| `line` | Line charts, trends |
+| `point` | Scatter plots |
+| `area` | Area charts |
+| `rect` | Heatmaps, matrices |
+| `circle` | Bubble charts |
+| `tick` | Strip plots |
+| `text` | Label overlays |
+| `arc` | Pie/donut charts |
+
+## Encoding Channels
+
+| Channel | Usage |
+|---------|-------|
+| `x`, `y` | Position |
+| `color` | Hue differentiation |
+| `size` | Area scaling |
+| `shape` | Point shape |
+| `opacity` | Transparency |
+| `text` | Text labels |
+| `tooltip` | Hover info |
+
+## Data Types
+
+| Type | Usage |
+|------|-------|
+| `quantitative` | Numbers (continuous) |
+| `nominal` | Categories (unordered) |
+| `ordinal` | Categories (ordered) |
+| `temporal` | Dates/times |


### PR DESCRIPTION
## Summary

- Adds a single `diagrams` skill that consolidates 15 upstream diagram/visualization skills from [markdown-viewer/skills](https://github.com/markdown-viewer/skills) (MIT licensed) into one directory with a decision-tree router and 8 reference files
- Covers Mermaid, Graphviz, Vega-Lite, PlantUML (UML, cloud, network, security, ArchiMate, BPMN, data analytics, IoT), Infographic, JSON Canvas, Architecture (HTML), and Infocard (HTML)
- Includes `examples.md` with 15 rendered diagram samples — open in a Markdown viewer to preview

### Structure

```
claude/.claude/skills/diagrams/
├── SKILL.md            (decision tree router)
├── LICENSE             (MIT attribution)
├── examples.md         (15 rendered examples)
└── references/
    ├── mermaid.md
    ├── graphviz.md
    ├── vega.md
    ├── plantuml.md     (UML + cloud + network + security + ArchiMate + BPMN + data + IoT)
    ├── infographic.md
    ├── canvas.md
    ├── architecture.md
    └── infocard.md
```

## Test plan

- [ ] Verify skill loads: invoke `diagrams` skill in Claude Code
- [ ] Open `examples.md` in Markdown Viewer extension to confirm diagrams render
- [ ] Test Mermaid examples render on GitHub (flowchart, sequence, ER)
- [ ] Confirm decision guide routes to correct reference files

🤖 Generated with [Claude Code](https://claude.com/claude-code)