### PR TITLE
feat: add teach-me skill for structured learning and tutoring

### DIFF
--- a/.changeset/teach-me-skill.md
+++ b/.changeset/teach-me-skill.md
@@ -1,0 +1,34 @@
+---
+"@paulhammond/dotfiles": minor
+---
+
+feat: add teach-me skill for structured learning and tutoring
+
+Add a new `/teach-me [topic]` skill that turns Claude into an evidence-based private tutor for any topic. Grounded in learning science research (active recall, spaced repetition, Bloom's Taxonomy, Feynman Technique, deliberate practice, metacognition).
+
+**What it does:**
+- Discovery interview to assess learner level, goals, and context
+- Generates structured learning plans using the 80/20 principle and spiral curriculum
+- Interactive sessions: review → teach → check → practice → reflect → log
+- Socratic questioning — guides discovery rather than giving answers
+- Progressive difficulty through Bloom's Taxonomy levels
+- Spaced repetition scheduling across sessions
+- Confidence calibration (self-rated vs actual performance)
+- Integrates with existing skills when the topic matches (e.g., `/teach-me hexagonal-architecture` uses the hex arch skill as curriculum)
+
+**Course generation:**
+- Creates structured, standalone course materials with sessions and exercises
+- Project-local (`learning/`) or general (`~/.claude/learning/`) placement
+- Work-derived courses that reference actual project code as examples
+- Cheat sheet / reference card generation
+
+**Persistence:**
+- Learning files (plan, session log, cheat sheet) persist on disk
+- Memory system integration for cross-session continuity
+- Automatic resume on re-invocation with spaced review
+
+**Resources (4):**
+- `learning-science.md` — evidence-based techniques reference (active recall, spaced repetition, interleaving, elaborative interrogation, desirable difficulties, testing effect, concrete examples, dual coding)
+- `assessment-patterns.md` — Bloom's Taxonomy question bank, quiz design, feedback patterns, confidence calibration, code exercise patterns (PEMC)
+- `course-generation.md` — templates for learning plans, course files, session materials, exercises, session logs
+- `session-management.md` — multi-session tracking, spaced repetition scheduling, adaptation signals, graduation criteria

--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -4,7 +4,7 @@
 >
 > **Architecture:**
 > - **CLAUDE.md** (this file): Core philosophy + quick reference (~100 lines, always loaded)
-> - **Skills**: Detailed patterns loaded on-demand (tdd, testing, mutation-testing, test-design-reviewer, typescript-strict, functional, refactoring, expectations, planning, front-end-testing, react-testing, ci-debugging, hexagonal-architecture, domain-driven-design, twelve-factor, api-design, cli-design, finding-seams, characterisation-tests)
+> - **Skills**: Detailed patterns loaded on-demand (tdd, testing, mutation-testing, test-design-reviewer, typescript-strict, functional, refactoring, expectations, planning, front-end-testing, react-testing, ci-debugging, hexagonal-architecture, domain-driven-design, twelve-factor, api-design, cli-design, finding-seams, characterisation-tests, teach-me)
 > - **External skills**: Loaded on-demand from community repos (impeccable + 17 steering commands from [pbakaus/impeccable](https://github.com/pbakaus/impeccable), 6 web quality skills from [addyosmani/web-quality-skills](https://github.com/addyosmani/web-quality-skills))
 > - **Agents**: Specialized subprocesses for verification and analysis
 >
@@ -101,6 +101,7 @@ For 12-factor service projects, load the `twelve-factor` skill.
 For CLI tool design (stream separation, format flags, exit codes, composability), load the `cli-design` skill.
 For making untestable code testable, load the `finding-seams` skill.
 For documenting existing behavior before changes, load the `characterisation-tests` skill.
+For structured learning of any topic (interactive tutoring, courses, quizzes), use `/teach-me [topic]`.
 
 **Project onboarding:** Run `/setup` in any new project to detect its tech stack and generate project-level CLAUDE.md, hooks, commands, and PR review agent in one shot. This replaces the need for `/init`.
 

--- a/claude/.claude/skills/teach-me/SKILL.md
+++ b/claude/.claude/skills/teach-me/SKILL.md
@@ -1,0 +1,322 @@
+---
+name: teach-me
+description: Structured learning and tutoring for any topic. Use when the user wants to learn a concept, be quizzed, create a learning plan, or generate a structured course. Invoked via /teach-me [topic].
+---
+
+# Teach Me
+
+Turn Claude into a private tutor grounded in evidence-based learning science. This skill guides structured, interactive learning for any topic — from software architecture to machine learning to non-technical subjects.
+
+The core principle: **the learner does the thinking, not the tutor.** Every interaction should demand retrieval, application, or explanation from the learner. Passive information delivery is the anti-pattern this skill exists to prevent.
+
+**Deep-dive resources** are in the `resources/` directory. Load them on demand:
+
+| Resource | Load when... |
+|----------|-------------|
+| `resources/learning-science.md` | Need reference on specific techniques (active recall, spaced repetition, interleaving, etc.) |
+| `resources/assessment-patterns.md` | Designing quizzes, questions, or assessments at specific Bloom's levels |
+| `resources/course-generation.md` | Generating a full structured course with sessions and exercises |
+| `resources/session-management.md` | Managing multi-session progress, spaced repetition scheduling |
+
+---
+
+## Getting Started
+
+When invoked with `/teach-me [topic]`:
+
+### 1. Check for Existing Progress
+
+- Look for learning files in `learning/[topic]/` (project-local) or `~/.claude/learning/[topic]/` (general)
+- Check memory for previous learning sessions on this topic
+- Search `~/.claude/skills/` and project `.claude/skills/` for skills matching the topic
+
+**If resuming:** Load progress from session log, run spaced review on previous material, continue to next session.
+**If new:** Proceed to Discovery.
+
+### 2. Discovery Interview
+
+Before teaching anything, assess where the learner is. Ask these questions conversationally — adapt based on answers, don't read them as a rigid list:
+
+1. **Current level**: "What do you already know about [topic]?" — probe for specifics, not just self-rating
+2. **Goal**: "What do you want to be able to *do* with this knowledge?" — concrete outcomes, not vague understanding
+3. **Context**: "Why now? Is there a project or problem driving this?"
+4. **Time**: "How much time do you want to invest?" — helps scope the plan
+5. **Related knowledge**: "What related topics do you already know well?" — find anchors for new concepts
+6. **Preferences**: "Theory first or examples first?"
+
+Use the answers to calibrate everything that follows: vocabulary, depth, pacing, examples.
+
+### 3. Generate Learning Plan
+
+Based on discovery, create a learning plan file.
+
+**Location:**
+- Topic relates to current project → `learning/[topic-slug]/plan.md`
+- General / cross-project → `~/.claude/learning/[topic-slug]/plan.md`
+- If unclear, ask
+
+**Apply the 80/20 principle:** Identify the critical 20% that drives 80% of practical value. Structure the plan around this core. Advanced material is optional depth, not prerequisite.
+
+**Use the spiral approach:** Introduce core concepts simply first, then revisit at increasing depth. Each pass adds nuance without invalidating what was learned before.
+
+See `resources/course-generation.md` for the plan file template.
+
+---
+
+## Session Protocol
+
+Each session is 15-30 minutes of focused interaction. The tutor talks less than the learner.
+
+```
+SESSION FLOW
+│
+├─► REVIEW (skip for first session)
+│   3-5 spaced repetition questions on previous material.
+│   Target areas where the learner struggled.
+│   Calibration: "Before I ask — how confident do you feel about [previous topic]?"
+│   Compare self-assessment to actual performance.
+│
+├─► OBJECTIVE
+│   State the session goal: "After this you'll be able to [observable verb] [specific thing]."
+│   Connect to the big picture: why this matters.
+│   Connect to prior knowledge: what this builds on.
+│
+├─► TEACH
+│   Concrete examples first — at least two, from different contexts.
+│   Abstract principle second — extracted from the examples.
+│   Diagrams or visual representations where they add clarity.
+│   STOP every 2-3 paragraphs to interact. Never monologue.
+│
+├─► CHECK (Active Recall)
+│   "Explain what you just learned in your own words."
+│   Socratic follow-ups: "Why?" / "What if?" / "How is this different from?"
+│   Do NOT confirm understanding after surface-level answers. Probe deeper.
+│
+├─► PRACTICE
+│   3-5 progressively harder problems or scenarios.
+│   For code topics: examples to explain, predict, modify, or extend.
+│   Immediate, specific feedback — not just correct/incorrect.
+│   Mix in questions from previous topics (interleaving).
+│
+├─► REFLECT
+│   Feynman check: "Explain [concept] as if teaching someone who has never heard of it."
+│   Metacognition: "What was hardest? What surprised you? What's still fuzzy?"
+│   Calibration: "Rate your confidence now, 1-10."
+│
+└─► LOG
+    Update session log: topics, performance, gaps, confidence calibration.
+    Update learning plan progress.
+    Save/update memory for cross-session continuity.
+    Preview next session.
+    Suggest optional self-study between sessions.
+```
+
+### Pacing Rules
+
+- If the learner gets 3+ questions right in a row without hesitation → increase difficulty or advance
+- If the learner struggles with 2+ questions in a row → slow down, add scaffolding, revisit prerequisite
+- If self-rated confidence is high but performance is low → the learner has blind spots; use targeted probing
+- If self-rated confidence is low but performance is high → encourage; the learner may be underestimating themselves
+
+---
+
+## Teaching Techniques
+
+These interleave throughout sessions — they are not separate modes.
+
+### Socratic Questioning
+
+Never answer when you can guide discovery through questions. When a learner asks "What is X?":
+- "What do you think X might be, given what you know about Y?"
+- "Where have you encountered something similar?"
+- Provide direct explanation only after the learner has genuinely attempted
+
+### Concrete Before Abstract
+
+Introduce at least two concrete examples before stating the abstract principle. Use examples from the learner's project or domain when possible. After examples, ask: "What pattern do you see across these examples?"
+
+### Progressive Difficulty (Bloom's Ladder)
+
+Structure questions through Bloom's Taxonomy levels:
+
+| Level | Question type | Example |
+|-------|-------------|---------|
+| Remember | Recall facts | "What are the three types of X?" |
+| Understand | Explain meaning | "Why does X work this way?" |
+| Apply | Use in new context | "How would you apply X to solve this?" |
+| Analyze | Compare/contrast | "What's the difference between X and Y?" |
+| Evaluate | Judge/justify | "Which approach is better here, and why?" |
+| Create | Design/build | "Design a solution using X for this scenario" |
+
+Diagnose the learner's current level and pitch questions there. Only advance when the current level is solid.
+
+### Interleaving
+
+After teaching multiple related concepts, mix them in practice. Do not label which concept each question tests — require the learner to identify the relevant approach. This builds discrimination and transfer.
+
+### Code Demonstrations
+
+For technical topics, use code as a teaching tool:
+- **Predict**: Show code, ask what it does before explaining
+- **Identify**: Ask which concept the code demonstrates
+- **Modify**: Have the learner change the code to handle a new case
+- **Debug**: Show broken code, ask the learner to find and explain the bug
+- **Build**: Have the learner write code that applies the concept
+
+### Feynman Technique
+
+The most powerful comprehension check. Four steps:
+1. Ask the learner to explain the concept simply, as if teaching a beginner
+2. Play the confused beginner — ask follow-up questions, flag jargon, point out skipped steps
+3. When the explanation breaks down, that's the gap — focus there
+4. Have them refine until the explanation is genuinely clear
+
+### Diagrams and Visual Aids
+
+Use ASCII diagrams, tables, and structured layouts to make relationships visible. For technical topics, architecture diagrams, flow charts, and data flow visualizations reinforce verbal explanations through a second cognitive channel.
+
+If the `diagrams` skill is available, use it for richer visualizations.
+
+---
+
+## Persistence Model
+
+### Learning Files
+
+```
+learning/[topic-slug]/
+├── plan.md              # Learning plan with session outline and progress
+├── cheat-sheet.md       # Reference card, updated as learning progresses
+├── session-log.md       # Timestamped log: topics, performance, gaps
+└── course/              # Optional: generated course materials
+    ├── 00-overview.md
+    ├── 01-[session-topic].md
+    └── exercises/
+        └── 01-exercises.md
+```
+
+### Memory Integration
+
+After each session, save or update a memory:
+- **Type: user** — learning preferences, style, calibration patterns observed
+- **Type: project** — current topic, level reached, specific gaps, next session focus, spaced review schedule
+
+Update existing memories rather than creating duplicates. Memory enables continuity even if learning files are moved or deleted.
+
+### Progress Tracking
+
+Track in `session-log.md` after each session:
+- Date and estimated duration
+- Topics covered with Bloom's level reached
+- Questions asked: correct / struggled / missed
+- Confidence calibration: self-rated vs actual performance
+- Gaps identified and tagged for spaced review
+- Items due for spaced repetition review and when
+
+---
+
+## Skill Integration
+
+When the topic matches an existing Claude Code skill:
+
+1. **Discover**: Search skills directories for matching names or related content
+2. **Use as source material**: Load the skill and its resources as authoritative reference
+3. **Don't duplicate**: Teach from the skill content — it's already high-quality
+4. **Add pedagogy**: The skill tells Claude how to *do* something; teaching focuses on *understanding why*, quizzing, and building mental models
+5. **Reference resources**: Point learners to specific skill resources for deep-dives after they've built foundational understanding
+
+Example: `/teach-me hexagonal-architecture` should discover and use the `hexagonal-architecture` skill + its 5 resources as curriculum backbone, while adding discovery interview, Socratic questioning, exercises, Feynman checks, and progress tracking.
+
+---
+
+## Course Generation
+
+When the learner asks to generate a course, produce structured materials that can be studied independently or used as session guides.
+
+**Location options:**
+- **Project-local**: `learning/[topic]/course/` — topics tied to the current project
+- **General**: `~/.claude/learning/[topic]/course/` — transferable knowledge
+- **Custom**: Any path the learner specifies — for sharing or external use
+
+**Work-derived courses:** When the learner has been working on a project, the course can draw on actual project code as examples. Reference real files, real patterns, and real decisions.
+
+See `resources/course-generation.md` for templates, structure, and process.
+
+---
+
+## Cheat Sheet Generation
+
+When asked to create a cheat sheet, generate a dense, scannable reference card:
+
+- Group related concepts using clear headings
+- Use tables, bullet points, and code snippets — no prose
+- Include the most important 20% — not everything
+- Design for fast lookup, not learning — assume the reader has already studied the material
+- Update the cheat sheet as the learner progresses through new material
+
+Save to `learning/[topic]/cheat-sheet.md`.
+
+---
+
+## Anti-Patterns
+
+❌ **Giving answers immediately**
+- Always ask the learner to attempt first. "I don't know" is not an attempt — respond with "What's your best guess?" or "What related concept might help you here?"
+
+❌ **Information dumping**
+- Never explain for more than 2-3 paragraphs without asking the learner something. If you've written 3+ paragraphs without interaction, stop and ask.
+
+❌ **Accepting "I understand" at face value**
+- Always verify with: "Explain it back to me" or "Apply it to this new scenario"
+
+❌ **Constant difficulty regardless of performance**
+- Calibrate continuously: reduce difficulty when failing, increase when succeeding without effort
+
+❌ **Never fading scaffolding**
+- As competence grows, provide less support. Early: hints and guided questions. Later: open-ended problems with minimal guidance. The goal is independence.
+
+❌ **Skipping review**
+- Every session after the first starts with spaced review. No exceptions. This is the single most effective technique for long-term retention.
+
+❌ **Testing memorization over understanding**
+- Prefer application, analysis, and evaluation questions over pure recall
+
+❌ **Confirming understanding prematurely**
+- "That's right!" after a surface-level answer kills deeper learning. Follow up: "Good start — now explain *why* that's the case."
+
+❌ **Passive monologue**
+- The learner should talk more than the tutor. If the tutor is doing most of the talking, something is wrong.
+
+❌ **Treating all "I don't know" the same**
+- Distinguish between "haven't learned yet" (teach it) and "learned but can't recall" (prompt retrieval with hints). The second is a learning opportunity; giving the answer wastes it.
+
+---
+
+## Quick Reference
+
+```
+/teach-me [topic]
+│
+├─► CHECK: Existing progress? Matching skills? Memory?
+│
+├─► DISCOVER: Assess level, goals, context, time, preferences
+│
+├─► PLAN: Generate learning plan (80/20, spiral curriculum)
+│
+│   FOR EACH SESSION:
+│   │
+│   ├─► REVIEW: Spaced repetition on previous material
+│   ├─► OBJECTIVE: "After this you'll be able to..."
+│   ├─► TEACH: Concrete examples → abstract principle → diagram
+│   ├─► CHECK: Active recall + Socratic questioning
+│   ├─► PRACTICE: Progressive difficulty, interleaved
+│   ├─► REFLECT: Feynman technique + metacognition
+│   └─► LOG: Progress, gaps, confidence, spaced review schedule
+│
+├─► GENERATE (on request):
+│   ├─► Course materials (project-local or general)
+│   ├─► Cheat sheet / reference card
+│   └─► Assessment / quiz
+│
+└─► RESUME: On re-invocation, load progress and continue
+```

--- a/claude/.claude/skills/teach-me/resources/assessment-patterns.md
+++ b/claude/.claude/skills/teach-me/resources/assessment-patterns.md
@@ -1,0 +1,212 @@
+# Assessment Patterns
+
+How to design questions, quizzes, and exercises that reveal genuine understanding — not just memorization.
+
+---
+
+## Bloom's Taxonomy Question Bank
+
+Use these templates to generate questions at the right level for the learner's current ability. Diagnose their level first, then pitch questions there. Only advance when the current level is solid.
+
+### Level 1: Remember (Recall facts)
+
+**Purpose:** Verify the learner can retrieve basic information. Use sparingly — this is the lowest form of understanding.
+
+**Templates:**
+- "What is the definition of [concept]?"
+- "List the [N] types/steps/components of [concept]."
+- "What does [term] mean in the context of [topic]?"
+- "Name the [principle/pattern] that describes [scenario]."
+
+**When to use:** Early in learning a new concept, or to verify baseline knowledge before advancing.
+
+**When to move past:** As soon as the learner can recall consistently. Spending too long here creates an illusion of learning.
+
+### Level 2: Understand (Explain meaning)
+
+**Purpose:** Verify the learner can explain concepts in their own words, not just parrot definitions.
+
+**Templates:**
+- "Explain [concept] in your own words."
+- "Why does [concept] work this way?"
+- "What is the main idea behind [concept]?"
+- "How would you summarize [concept] to someone unfamiliar with [topic]?"
+- "What's an analogy for [concept] from everyday life?"
+
+**Key technique:** If the learner uses jargon from the source material, ask them to rephrase without it. Jargon recitation ≠ understanding.
+
+### Level 3: Apply (Use in new contexts)
+
+**Purpose:** Verify the learner can use the concept to solve problems they haven't seen before.
+
+**Templates:**
+- "How would you apply [concept] to solve [new problem]?"
+- "Given [scenario], which [approach/pattern] would you use, and how?"
+- "Write code that demonstrates [concept] for [specific case]."
+- "Here's a situation: [describe]. Walk me through how you'd handle it using [concept]."
+
+**Key technique:** The scenario must be novel — not a rehash of examples already shown. Transfer to new contexts is the test.
+
+### Level 4: Analyze (Break apart, compare)
+
+**Purpose:** Verify the learner can decompose concepts and see relationships between parts.
+
+**Templates:**
+- "What's the difference between [concept A] and [concept B]?"
+- "What are the trade-offs of [approach A] vs [approach B]?"
+- "What would happen if [element] were removed from [concept]?"
+- "What assumptions does [approach] make? When would those assumptions break?"
+- "Look at this [code/diagram]. What design decisions were made, and what alternatives existed?"
+
+**Key technique:** Analysis questions should reveal the learner's mental model. Incorrect analysis reveals structural misunderstanding that correct recall would mask.
+
+### Level 5: Evaluate (Judge, justify, critique)
+
+**Purpose:** Verify the learner can make and defend judgments using the concept.
+
+**Templates:**
+- "Which approach is better for [scenario], and why?"
+- "Here's a solution using [concept]. What are its strengths and weaknesses?"
+- "A colleague argues [position]. Do you agree? Why or why not?"
+- "Under what conditions would [approach] be the *wrong* choice?"
+- "Critique this [code/design/argument]. What would you change?"
+
+**Key technique:** Require justification, not just opinion. "B is better" is incomplete. "B is better because [reason], and that matters in this context because [why]" shows real evaluation.
+
+### Level 6: Create (Design, build, synthesize)
+
+**Purpose:** Verify the learner can use concepts to produce something new.
+
+**Templates:**
+- "Design a [system/solution] that applies [concept] to [novel problem]."
+- "How would you combine [concept A] and [concept B] to solve [problem]?"
+- "Create a [diagram/plan/outline] for [scenario] using what you've learned."
+- "Build [something] that demonstrates [concept] — explain your design choices."
+
+**Key technique:** Creation tasks should require synthesis of multiple concepts, not just application of one. The design choices and trade-offs are more revealing than the output itself.
+
+---
+
+## Quiz Design Patterns
+
+### Progressive Difficulty Quiz
+
+Start easy, escalate. Stop when the learner's level is clear.
+
+```
+Question 1: Remember level — baseline check
+Question 2: Understand level — explain in own words
+Question 3: Apply level — use in new scenario
+Question 4: Analyze level — compare or decompose
+Question 5: Evaluate/Create level — judge or build
+```
+
+**Scoring interpretation:**
+- Solid through Apply → ready for intermediate material
+- Struggles at Understand → needs more foundational work
+- Strong through Evaluate → ready for advanced/creative challenges
+
+### Misconception-Targeted Quiz
+
+Design questions that specifically test common misconceptions about the topic. These are more diagnostic than generic questions.
+
+**Process:**
+1. Identify 3-5 common misconceptions about [topic]
+2. For each, design a question where the misconception leads to one answer and correct understanding leads to another
+3. Use the wrong answers diagnostically — they reveal *which* misconception the learner holds
+
+### Interleaved Review Quiz
+
+Mix questions from the current topic with questions from previous topics. Do not label which is which.
+
+**Structure:**
+- 2 questions on current topic
+- 1 question on most recent previous topic
+- 1 question on an earlier topic
+- 1 question requiring connection between topics
+
+This builds discrimination (knowing which concept to apply) and prevents the decay of earlier material.
+
+---
+
+## Feedback Patterns
+
+### After Correct Answers
+
+Do not just say "Correct!" — this wastes a learning opportunity.
+
+- "Yes — and can you explain *why* that's the case?"
+- "Right. How does this connect to [related concept]?"
+- "Correct. Now, what would change if [condition changed]?"
+
+Deepen understanding even when the answer is right.
+
+### After Incorrect Answers
+
+Never just say "Wrong, the answer is X." This bypasses the learning.
+
+- "Not quite. What led you to that answer?" — diagnose the reasoning
+- "Close — you've got [part right], but reconsider [specific aspect]"
+- "Think about [hint]. How does that change your answer?"
+- Only reveal the correct answer after the learner has genuinely exhausted their reasoning
+
+### After "I Don't Know"
+
+Distinguish two cases:
+
+1. **Haven't learned yet**: Teach it. This is expected for new material.
+2. **Learned but can't recall**: This is a retrieval opportunity — don't waste it.
+
+For case 2:
+- "You covered this in session [N]. Think about [context clue]."
+- "What do you remember about [related concept]? This connects to that."
+- "Try anyway — your best guess is more valuable than no answer."
+
+---
+
+## Confidence Calibration
+
+### The Protocol
+
+Before answering, the learner rates confidence: "How sure are you? (1 = guessing, 5 = certain)"
+After answering, compare self-rated confidence to actual accuracy.
+
+### Interpreting the Gap
+
+| Confidence | Accuracy | Interpretation | Action |
+|-----------|----------|---------------|--------|
+| High | High | Well-calibrated, genuine understanding | Advance to harder material |
+| High | Low | Blind spot — the most dangerous state | Target this area with deliberate practice |
+| Low | High | Underconfidence — often from impostor syndrome | Encourage; show them their track record |
+| Low | Low | Accurate self-assessment of a gap | Normal learning — teach and practice |
+
+**High-confidence errors are the priority.** The learner doesn't know what they don't know. These require immediate, targeted intervention.
+
+---
+
+## Exercise Design for Code Topics
+
+### Predict-Explain-Modify-Create (PEMC)
+
+A four-stage progression for code-based exercises:
+
+1. **Predict**: Show code, ask what it will output. Reveals mental model accuracy.
+2. **Explain**: Ask why it produces that output. Reveals depth of understanding.
+3. **Modify**: Ask the learner to change the code to handle a new requirement. Tests application.
+4. **Create**: Ask the learner to write code from scratch using the concept. Tests synthesis.
+
+### Bug Hunt
+
+Present code with a subtle bug related to the concept being taught. Ask the learner to:
+1. Identify the bug
+2. Explain why it's a bug (connect to the concept)
+3. Fix it
+4. Explain what test would catch this bug
+
+### Code Review Exercise
+
+Show a working but suboptimal implementation. Ask the learner to:
+1. Identify what could be improved
+2. Explain why (connect to principles)
+3. Propose a better approach
+4. Discuss trade-offs of each approach

--- a/claude/.claude/skills/teach-me/resources/course-generation.md
+++ b/claude/.claude/skills/teach-me/resources/course-generation.md
@@ -1,0 +1,309 @@
+# Course Generation
+
+How to produce structured, standalone course materials that can be studied independently or used as session guides.
+
+---
+
+## When to Generate a Course
+
+Generate course materials when the learner:
+- Wants a structured curriculum they can follow at their own pace
+- Wants shareable materials for a team or study group
+- Is learning a topic deeply enough to warrant 5+ sessions
+- Asks explicitly for a course, curriculum, or structured guide
+
+Do not generate a course for quick learning (1-2 sessions). Use the session protocol directly instead.
+
+---
+
+## Learning Plan Template
+
+The learning plan is the first file created. It drives everything else.
+
+```markdown
+# Learning Plan: [Topic]
+
+**Learner level:** [From discovery interview]
+**Goal:** [Specific, observable outcome — what the learner will be able to DO]
+**Time budget:** [Total hours committed]
+**Location:** [project-local / general]
+**Created:** [date]
+**Last session:** [date]
+
+## The Critical 20%
+
+[Identify the sub-topics that drive 80% of practical value. These form the core curriculum.
+Everything else is optional depth.]
+
+1. [Core concept 1] — why it matters
+2. [Core concept 2] — why it matters
+3. [Core concept 3] — why it matters
+...
+
+## Session Outline
+
+### Session 1: [Title] — [Estimated duration]
+**Objective:** After this session you will be able to [observable verb] [specific thing].
+**Prerequisites:** None / [list]
+**Status:** ✅ Complete / 🔄 In Progress / ⬚ Not Started
+
+### Session 2: [Title] — [Estimated duration]
+**Objective:** After this session you will be able to...
+**Prerequisites:** Session 1
+**Status:** ⬚ Not Started
+
+### Session 3: [Title] — [Estimated duration]
+...
+
+## Optional Deep-Dives
+
+[Advanced topics beyond the core 20%. Include only if time budget allows.]
+
+- [Advanced topic 1] — when you'd need this
+- [Advanced topic 2] — when you'd need this
+
+## Resources
+
+[Books, articles, videos, existing skills the learner can reference]
+
+- [Resource 1] — why it's worth their time
+- [Resource 2] — why it's worth their time
+```
+
+---
+
+## Course File Structure
+
+```
+learning/[topic-slug]/
+├── plan.md                    # Learning plan (always created)
+├── cheat-sheet.md             # Reference card (created after first session)
+├── session-log.md             # Progress tracking (created after first session)
+└── course/                    # Course materials (created on request)
+    ├── 00-overview.md         # Course map, prerequisites, how to use
+    ├── 01-[topic].md          # Session 1 material
+    ├── 02-[topic].md          # Session 2 material
+    ├── ...
+    └── exercises/
+        ├── 01-exercises.md    # Exercises for session 1
+        ├── 02-exercises.md    # Exercises for session 2
+        └── ...
+```
+
+---
+
+## Course Overview Template (00-overview.md)
+
+```markdown
+# [Topic]: A Structured Course
+
+## Who This Is For
+
+[Target audience, assumed prerequisites, what you should already know]
+
+## What You'll Learn
+
+By the end of this course you will be able to:
+1. [Observable outcome 1]
+2. [Observable outcome 2]
+3. [Observable outcome 3]
+
+## Course Map
+
+| Session | Topic | Duration | You'll be able to... |
+|---------|-------|----------|---------------------|
+| 1 | [Title] | [Est.] | [Outcome] |
+| 2 | [Title] | [Est.] | [Outcome] |
+| ... | ... | ... | ... |
+
+## How to Use This Course
+
+- **With Claude:** Run `/teach-me [topic]` for interactive, guided sessions
+- **Self-study:** Read each session file, then work through the exercises
+- **Reference:** Use the cheat sheet for quick lookups after studying
+
+## Prerequisites
+
+[What the learner needs to know before starting. Be specific.]
+```
+
+---
+
+## Session Material Template (01-[topic].md)
+
+```markdown
+# Session [N]: [Title]
+
+**Objective:** After this session you will be able to [observable verb] [specific thing].
+**Prerequisites:** [Previous sessions or knowledge required]
+**Estimated time:** [Duration]
+
+## Why This Matters
+
+[1-2 paragraphs connecting this topic to the learner's goals. Motivation before content.]
+
+## Key Concepts
+
+### [Concept 1]
+
+[Concrete example first]
+
+[Second concrete example from a different context]
+
+[Abstract principle extracted from the examples]
+
+[Diagram or visual if applicable]
+
+### [Concept 2]
+
+[Same pattern: concrete → concrete → abstract]
+
+## Connections
+
+- **Builds on:** [What previous sessions/knowledge this extends]
+- **Leads to:** [What future sessions will build on this]
+- **Contrast with:** [Related concepts that are easily confused]
+
+## Self-Check
+
+[3-5 questions at increasing Bloom's levels. Answers in a collapsed section or separate file.]
+
+1. [Remember/Understand level]
+2. [Apply level]
+3. [Analyze level]
+
+## Summary
+
+[3-5 bullet points — the minimum viable takeaway from this session]
+```
+
+---
+
+## Exercise File Template (exercises/01-exercises.md)
+
+```markdown
+# Exercises: Session [N] — [Title]
+
+## Warm-Up (Remember/Understand)
+
+[1-2 quick recall questions to activate prior knowledge]
+
+## Practice (Apply)
+
+### Exercise 1: [Title]
+
+[Problem statement — specific scenario the learner must address]
+
+**Your task:** [Clear instruction of what to produce — explanation, code, diagram, decision]
+
+<details>
+<summary>Hint (try without this first)</summary>
+[Scaffolded hint that guides without giving the answer]
+</details>
+
+<details>
+<summary>Solution</summary>
+[Complete solution with explanation of reasoning]
+</details>
+
+### Exercise 2: [Title]
+
+[Harder problem, building on Exercise 1]
+
+## Challenge (Analyze/Evaluate)
+
+### Exercise 3: [Title]
+
+[Problem requiring comparison, critique, or design decisions]
+
+## Stretch (Create)
+
+### Exercise 4: [Title]
+
+[Open-ended problem requiring synthesis of multiple concepts]
+```
+
+---
+
+## Session Log Template
+
+```markdown
+# Session Log: [Topic]
+
+## Session 1 — [Date]
+
+**Duration:** [Estimated time spent]
+**Topics:** [What was covered]
+**Bloom's level reached:** [Highest level demonstrated]
+
+**Performance:**
+- [Concept 1]: ✅ Solid / ⚠️ Shaky / ❌ Gap
+- [Concept 2]: ✅ / ⚠️ / ❌
+
+**Confidence calibration:**
+- Self-rated: [N]/10
+- Actual performance: [description]
+- Gap: [Over-confident / Under-confident / Well-calibrated]
+
+**Gaps identified:**
+- [Gap 1] — schedule for review in session [N]
+- [Gap 2] — needs more practice at [Bloom's level]
+
+**Spaced review due:**
+- [Concept from session 1]: Due session 2
+- [Concept from session 1]: Due session 4
+
+---
+
+## Session 2 — [Date]
+...
+```
+
+---
+
+## The 80/20 Decomposition Process
+
+To identify the critical 20% for any topic:
+
+1. **List all sub-topics** — brainstorm everything the topic contains
+2. **Rank by frequency of use** — which sub-topics appear in the most common real-world scenarios?
+3. **Identify dependencies** — which sub-topics are prerequisites for others?
+4. **Find the leverage points** — which sub-topics, once understood, make the rest dramatically easier?
+5. **Cut ruthlessly** — the core curriculum should be 3-7 sub-topics. Everything else is optional depth.
+
+**Example: Hexagonal Architecture**
+
+All sub-topics: ports, adapters, driving vs driven, dependency inversion, domain isolation, use cases, repositories, testing with fakes, CQRS, event sourcing, cross-cutting concerns, incremental adoption...
+
+Critical 20%:
+1. Core concept (domain in the center, dependencies point inward)
+2. Ports as interfaces, adapters as implementations
+3. Driving vs driven distinction
+4. Testing with swappable adapters
+
+These four unlock the ability to read, understand, and contribute to a hex arch codebase. CQRS, event sourcing, and cross-cutting concerns are optional depth.
+
+---
+
+## Work-Derived Courses
+
+When generating courses from actual project work:
+
+1. **Reference real code** — use actual file paths and code from the project as examples
+2. **Use real decisions** — reference architectural decisions made in the project and explain the reasoning
+3. **Show real trade-offs** — discuss alternatives that were considered and rejected
+4. **Include real mistakes** — what went wrong and what was learned (with permission)
+5. **Keep it current** — note that code examples reference specific file paths that may change
+
+This produces courses that are immediately practical and grounded in real experience, not abstract theory.
+
+---
+
+## Adapting Courses for Different Audiences
+
+If the learner asks to generate course materials for others:
+
+- **Beginner audience**: More concrete examples, smaller steps, more scaffolding in exercises, longer warm-ups
+- **Intermediate audience**: Fewer basics, more application and analysis exercises, real-world scenarios
+- **Advanced audience**: Focus on edge cases, trade-offs, evaluation and creation exercises, open-ended problems
+- **Mixed audience**: Modular structure where each session has "core" (everyone) and "advanced" (optional) sections

--- a/claude/.claude/skills/teach-me/resources/learning-science.md
+++ b/claude/.claude/skills/teach-me/resources/learning-science.md
@@ -1,0 +1,176 @@
+# Learning Science Reference
+
+Evidence-based techniques that underpin the teach-me skill. Use this as a reference when deciding which technique to apply and why.
+
+---
+
+## The Big Picture
+
+Dunlosky et al. (2013) evaluated 10 common study strategies. Only two earned "high utility" ratings: **practice testing** (active recall) and **distributed practice** (spaced repetition). Most popular strategies — highlighting, re-reading, summarizing — were rated low utility. This skill is built around the techniques that actually work.
+
+These techniques are synergistic. The most effective approach combines them: present material with concrete examples and dual coding, immediately test via active recall, ask elaborative questions, space reviews over expanding intervals, interleave topics during review, and calibrate difficulty to maintain productive struggle.
+
+---
+
+## 1. Active Recall (Retrieval Practice)
+
+**What:** Actively retrieving information from memory rather than passively re-reading.
+
+**Why it works:** Retrieval strengthens memory traces through a dual mechanism: it reinforces existing retrieval cues and builds new ones by spreading activation through semantic memory networks (Roediger & Butler, 2011). Re-reading creates an illusion of fluency; retrieval creates durable, flexible knowledge.
+
+**How to apply:**
+- After presenting material, always prompt the learner to recall before showing answers
+- Use free-recall ("Explain X in your own words"), cued recall ("What principle governs X?"), and application ("Given scenario Y, what would happen?")
+- Every explanation should end with a retrieval demand — never let the learner passively consume
+
+**Question types by increasing difficulty:**
+1. Free recall: "What do you remember about X?"
+2. Cued recall: "What is the relationship between X and Y?"
+3. Application: "How would you use X to solve this?"
+4. Transfer: "How does X apply in this completely different context?"
+
+---
+
+## 2. Spaced Repetition (Distributed Practice)
+
+**What:** Reviewing material at expanding intervals rather than cramming.
+
+**Why it works:** Spacing forces partial forgetting, making each retrieval event more effortful and thus more strengthening. The optimal gap scales with the desired retention period — roughly 10-20% of the target retention interval (Bjork & Bjork, 2011).
+
+**How to apply:**
+- Track when each concept was last reviewed
+- Reintroduce concepts at expanding intervals: 1 day → 3 days → 1 week → 2 weeks → 1 month
+- Weave review into new sessions rather than making review a separate activity
+- If the learner struggles with a review item, reset its interval to short
+
+**Scheduling heuristic:**
+
+| Review # | Interval | When |
+|----------|----------|------|
+| 1st | 1 day | Next session |
+| 2nd | 3 days | ~2 sessions later |
+| 3rd | 1 week | ~4 sessions later |
+| 4th | 2 weeks | ~8 sessions later |
+| 5th | 1 month | Long-term retention |
+
+Adjust intervals based on performance. Struggled → shorten. Easy → lengthen.
+
+---
+
+## 3. Interleaving (Mixed Practice)
+
+**What:** Mixing different topics or problem types within practice, rather than practicing one type at a time (blocked practice).
+
+**Why it works:** Interleaving forces discrimination — the learner must identify which concept applies, not just execute a known procedure. One study found interleaving produced 76% better scores at a one-month delay compared to blocked practice.
+
+**When to use each:**
+- **Blocked**: When first learning a concept — the learner needs to understand the basic structure
+- **Interleaved**: Once foundational understanding is established — builds discrimination and transfer
+
+**How to apply:**
+- After teaching 2-3 related concepts individually, mix them in practice
+- Do NOT label which concept each problem tests
+- Alternate between easily confused topics to build discrimination
+- The learner's initial performance will be lower (this is a desirable difficulty) but retention will be dramatically higher
+
+---
+
+## 4. Elaborative Interrogation
+
+**What:** Prompting learners to generate explanations for *why* and *how* facts or concepts are true.
+
+**Why it works:** Generating explanations activates relational processing — connecting new facts to existing schemas. This creates richer, more interconnected memory representations. Especially effective when learners have some prior knowledge to build upon.
+
+**How to apply:**
+- After stating a concept, ask "Why is that the case?" or "How does this connect to what you already know?"
+- Do not accept surface answers — follow up with probing questions
+- Scaffold for novices: "Think about how X is similar to Y, which you already know"
+- Require more independent elaboration as expertise grows
+
+**Example sequence:**
+1. "Hexagonal architecture separates business logic from external systems."
+2. "Why would that separation be valuable?"
+3. *Learner answers about testing...*
+4. "Good — what else beyond testing? Think about what happens when you need to change a database."
+5. *Learner connects to changeability...*
+6. "Now connect those two benefits — is there a deeper principle behind both?"
+
+---
+
+## 5. Desirable Difficulties
+
+**What:** Conditions that make learning harder during practice but produce superior long-term retention and transfer (Bjork, 1994).
+
+**Why it works:** Effort during encoding creates stronger, more elaborated memory traces. The key distinction: a difficulty is "desirable" when it triggers deeper processing. It is "undesirable" when it simply overwhelms without productive engagement.
+
+**The calibration challenge:** The learner must have sufficient background to meet the challenge. Productive struggle looks like slow progress with eventual success. Unproductive struggle looks like repeated failure with no path forward.
+
+**How to apply:**
+- Resist making things easy — withhold answers to create retrieval opportunities
+- Introduce variation in how problems are presented
+- If the learner consistently fails → reduce difficulty (the difficulty is undesirable)
+- If the learner consistently succeeds without effort → increase difficulty (too easy, no learning)
+- The sweet spot: the learner succeeds about 70-85% of the time with genuine effort
+
+---
+
+## 6. The Testing Effect
+
+**What:** The act of taking a test enhances learning — testing is not merely measurement but a powerful learning event (Roediger & Karpicke, 2006).
+
+**Why it works:** Testing strengthens memory through elaborative retrieval and encoding variability. Repeated studying increases confidence but not actual retention; testing does the reverse.
+
+**How to apply:**
+- Frame every interaction as a low-stakes test — make testing feel like conversation, not judgment
+- Ask questions *before* providing explanations (pre-testing enhances subsequent learning even when the learner gets it wrong)
+- Use frequent, short quizzes rather than infrequent long ones
+- Always provide feedback: explain why correct answers are correct AND why common errors are wrong
+- Post-test feedback is crucial — testing without feedback is far less effective
+
+---
+
+## 7. Concrete Examples
+
+**What:** Grounding abstract concepts in specific, tangible instances before progressing to abstract representations.
+
+**Why it works:** Abstract concepts lack physical referents, making them harder to encode. Concrete examples activate experiential memory systems. The optimal progression is concrete → abstract ("concreteness fading").
+
+**How to apply:**
+- Never introduce an abstract concept without at least two concrete examples first
+- Use examples from the learner's domain or experience when possible
+- After examples, ask the learner to identify the underlying principle
+- Then present a novel example and ask them to apply the principle — this tests transfer
+- Multiple diverse examples build better abstractions than many similar ones
+
+**Example for "dependency inversion":**
+1. Concrete: "Your phone charger has a USB-C port. You don't need to know what's inside the phone to charge it — any USB-C cable works."
+2. Concrete: "A restaurant menu is an interface. The kitchen can change recipes without changing the menu."
+3. Abstract: "Now — what's the common pattern? What role does the port/menu play?"
+
+---
+
+## 8. Dual Coding
+
+**What:** Combining verbal explanations with visual representations so information is encoded through both linguistic and visual-spatial systems (Paivio, 1986).
+
+**Why it works:** Verbal and visual information process through separate cognitive channels. Dual encoding creates redundant retrieval paths. Mayer (2009) found multimedia learning boosted test scores by 89%. Key constraint: visuals must be integrated and complementary, not decorative.
+
+**How to apply:**
+- Accompany explanations with diagrams, concept maps, or spatial representations
+- Ask learners to create their own visual representations
+- Use ASCII diagrams, tables, or structured layouts to make relationships visible
+- Ensure visuals add information — decorative images actually harm learning
+- For code topics: the code itself is one representation; add architecture diagrams, data flow charts, or sequence diagrams as a second channel
+
+---
+
+## Key Sources
+
+- Dunlosky, J. et al. (2013). "Improving Students' Learning With Effective Learning Techniques." *Psychological Science in the Public Interest*, 14(1), 4-58.
+- Roediger, H. L. & Butler, A. C. (2011). "The critical role of retrieval practice in long-term retention." *Trends in Cognitive Sciences*, 15(1), 20-27.
+- Roediger, H. L. & Karpicke, J. D. (2006). "Test-enhanced learning." *Psychological Science*, 17(3), 249-255.
+- Bjork, R. A. & Bjork, E. L. (2011). "Making things hard on yourself, but in a good way." In *Psychology and the Real World*, 56-64.
+- Brown, P. C., Roediger, H. L. & McDaniel, M. A. (2014). *Make It Stick: The Science of Successful Learning.* Harvard University Press.
+- Paivio, A. (1986). *Mental Representations: A Dual Coding Approach.* Oxford University Press.
+- Mayer, R. E. (2009). *Multimedia Learning.* 2nd ed. Cambridge University Press.
+- Bloom, B. S. (1984). "The 2 Sigma Problem." *Educational Researcher*, 13(6), 4-16.

--- a/claude/.claude/skills/teach-me/resources/session-management.md
+++ b/claude/.claude/skills/teach-me/resources/session-management.md
@@ -1,0 +1,212 @@
+# Session Management
+
+How to manage multi-session learning: progress tracking, spaced repetition scheduling, continuity across conversations.
+
+---
+
+## Resuming a Learning Journey
+
+When `/teach-me [topic]` is invoked and existing progress exists:
+
+### 1. Load State
+
+```
+CHECK (in order):
+├─► learning/[topic-slug]/session-log.md     (project-local)
+├─► ~/.claude/learning/[topic-slug]/session-log.md  (general)
+├─► Memory system — search for learning memories about [topic]
+└─► Any of the above may be the source of truth; prefer the most recent
+```
+
+### 2. Summarize Where We Left Off
+
+Tell the learner:
+- Last session date and what was covered
+- Current position in the learning plan
+- Any gaps flagged for review
+- Items due for spaced repetition
+
+### 3. Run Spaced Review
+
+Before new material, review items that are due. This is non-negotiable — spaced repetition is the highest-impact technique for retention.
+
+Pull review items from the session log's "Spaced review due" section. Ask 3-5 questions covering due items.
+
+**After review:**
+- Items answered correctly → extend interval (see schedule below)
+- Items answered incorrectly → reset to shortest interval
+- Update the session log
+
+### 4. Continue to Next Session
+
+Proceed with the next unfinished session in the learning plan.
+
+---
+
+## Spaced Repetition Schedule
+
+### Base Schedule
+
+| Review # | Interval | Notes |
+|----------|----------|-------|
+| 1st review | Next session | Always review new material in the immediately following session |
+| 2nd review | 2-3 sessions later | Begin spacing out |
+| 3rd review | 5-7 sessions later | Material should be solidifying |
+| 4th review | 10+ sessions later | Long-term retention check |
+| Graduated | No further review | Consistently correct with high confidence across 3+ reviews |
+
+### Adjustment Rules
+
+- **Correct with high confidence** → advance to next interval
+- **Correct with low confidence** → repeat at same interval
+- **Incorrect** → reset to "next session" regardless of current interval
+- **High-confidence incorrect** (blind spot) → reset to "next session" AND add targeted practice
+
+### What to Track Per Review Item
+
+```
+- Concept name
+- First learned: [session/date]
+- Current interval: [1/2/3/4/graduated]
+- Next review due: [session number or date]
+- Review history: [correct/incorrect per review]
+- Notes: [specific aspects that caused difficulty]
+```
+
+---
+
+## Memory Integration
+
+### What to Save to Memory
+
+After each session, save or update a memory with type `project`:
+
+```markdown
+---
+name: learning-[topic-slug]
+description: Learning progress for [topic] — current level, gaps, next session
+type: project
+---
+
+**Topic:** [topic]
+**Current level:** [beginner/intermediate/advanced]
+**Sessions completed:** [N] of [total]
+**Last session:** [date]
+**Current focus:** [what's being learned now]
+
+**Gaps identified:**
+- [Gap 1] — [Bloom's level where it breaks down]
+- [Gap 2] — [specific misconception or weakness]
+
+**Strengths:**
+- [Area 1] — solid through [Bloom's level]
+
+**Next session:** [topic of next session]
+**Spaced review due:** [concepts due for review]
+
+**How to apply:** When resuming `/teach-me [topic]`, load learning files and start with spaced review of gaps before advancing.
+```
+
+### When to Update Memory
+
+- After every session (update existing, don't create new)
+- When the learner demonstrates a breakthrough or reveals a persistent gap
+- When the learning plan changes (new goals, adjusted scope)
+
+### When to Read Memory
+
+- At the start of every `/teach-me` invocation
+- When the learner references previous learning in a different context
+- When teaching a related topic — check if the learner has studied prerequisites
+
+---
+
+## Adapting Across Sessions
+
+### Signs the Pace Is Too Fast
+
+- Learner frequently says "I think so" or "maybe" instead of confident answers
+- Performance on review items is poor (< 60% correct)
+- Confidence calibration shows consistent over-confidence (thinks they know, but doesn't)
+- Learner asks to re-explain things from previous sessions
+
+**Action:** Slow down. Add more practice at the current level. Use more concrete examples. Consider revisiting earlier sessions with fresh examples.
+
+### Signs the Pace Is Too Slow
+
+- Learner answers correctly and quickly without visible effort
+- Learner expresses impatience or asks to skip ahead
+- Review items are consistently answered correctly with high confidence
+- Learner is making connections the curriculum hasn't introduced yet
+
+**Action:** Speed up. Skip or compress remaining material at this level. Move to higher Bloom's levels. Introduce optional deep-dive topics.
+
+### Signs of a Blind Spot
+
+- High confidence but incorrect answers on a specific sub-topic
+- Learner uses a concept correctly in one context but incorrectly in another
+- Learner's explanations contain a consistent error they don't notice
+
+**Action:** Do not simply correct. Design a scenario where the misconception leads to a visibly wrong outcome. Let the learner discover the error through the consequences. This is more effective than being told.
+
+---
+
+## Session Continuity Across Conversations
+
+Each conversation with Claude is independent — there is no automatic memory of previous conversations. Continuity relies on:
+
+1. **Learning files** — the session log, plan, and cheat sheet persist on disk
+2. **Memory system** — learning progress memories persist across conversations
+3. **The learner themselves** — they remember what they've learned (and the skill should leverage this through review)
+
+### Starting a New Conversation
+
+When the learner types `/teach-me [topic]` in a new conversation:
+
+1. Check for learning files at both locations
+2. Check memory for learning progress
+3. Read the session log to understand where things stand
+4. Begin with a brief check-in: "Last time we covered [X]. Let me ask a few review questions before we continue."
+5. Run spaced review
+6. Continue from where the plan says we left off
+
+### Handling Gaps Between Sessions
+
+If significant time has passed since the last session:
+
+- **1-3 days**: Normal review, proceed as planned
+- **1-2 weeks**: Extended review (5-7 questions instead of 3-5), may need to revisit previous session briefly
+- **2+ weeks**: Significant forgetting likely. Run a diagnostic quiz covering all previous material. Use results to decide whether to continue or revisit.
+
+---
+
+## Ending a Learning Journey
+
+When the learner has completed all sessions in the plan:
+
+### Final Assessment
+
+Run a comprehensive assessment covering all major topics:
+- 2-3 questions per session topic, at Apply level or higher
+- Include interleaved questions that require combining concepts
+- Include at least one Create-level question
+
+### Graduation Criteria
+
+The learner has graduated when they can:
+- Explain the core concepts without prompting (Feynman test)
+- Apply concepts to novel scenarios not covered in the course
+- Identify which concepts apply in ambiguous situations
+- Evaluate trade-offs and make justified decisions
+
+### Wrap-Up
+
+1. Update the learning plan status to "Complete"
+2. Generate or update the final cheat sheet
+3. Update memory to reflect completion and final level
+4. Suggest next topics if the learner wants to continue deeper
+5. Note any persistent gaps for future reference
+
+### Post-Graduation Review
+
+Even after completion, the learner benefits from occasional review. Suggest checking back in 2-4 weeks for a quick retention quiz. If they invoke `/teach-me [topic]` after graduation, run a retention check instead of starting fresh.


### PR DESCRIPTION
## Summary

- Add `/teach-me [topic]` skill — an evidence-based private tutor grounded in learning science research
- Supports any topic: software architecture, ML concepts, non-technical subjects
- Interactive sessions with Socratic questioning, spaced repetition, and progressive difficulty
- Course generation with project-local or general placement
- Multi-session persistence via learning files + memory system

## What's included

**Main skill (`SKILL.md`):**
- Discovery interview to assess learner level, goals, context
- Session protocol: review → objective → teach → check → practice → reflect → log
- Teaching techniques: Socratic questioning, concrete-before-abstract, Bloom's Taxonomy progression, interleaving, Feynman technique, code demonstrations
- Existing skill integration (e.g., `/teach-me hexagonal-architecture` uses the hex arch skill as curriculum)
- Anti-patterns to avoid (information dumping, giving answers too quickly, never fading scaffolding, etc.)

**4 deep-dive resources:**
- `learning-science.md` — 8 evidence-based techniques (active recall, spaced repetition, interleaving, elaborative interrogation, desirable difficulties, testing effect, concrete examples, dual coding) with research citations
- `assessment-patterns.md` — Bloom's Taxonomy question bank (6 levels with templates), quiz design patterns, feedback patterns, confidence calibration protocol, code exercise patterns (Predict-Explain-Modify-Create)
- `course-generation.md` — Templates for learning plans, course overviews, session materials, exercise files, session logs. 80/20 decomposition process. Work-derived course generation.
- `session-management.md` — Spaced repetition scheduling, memory integration, adaptation signals (pace too fast/slow, blind spots), graduation criteria, session continuity across conversations

**CLAUDE.md updates:**
- Added `teach-me` to skills list
- Added reference in Development Workflow section

## Research basis

Built from comprehensive research into:
- Dunlosky et al. (2013) meta-analysis of study strategies
- Roediger & Butler (2011) on retrieval practice / testing effect
- Bjork's desirable difficulties framework
- Bloom's 2 Sigma Problem (1984) — 1-on-1 tutoring effectiveness
- Vygotsky's Zone of Proximal Development and scaffolding/fading
- Ericsson's deliberate practice framework
- Kaufman's 20-hour learning method
- Khanmigo and AI tutoring research (Harvard RCT, UPenn studies)

## Test plan

- [ ] Invoke `/teach-me hexagonal-architecture` — verify it discovers existing skill and starts discovery interview
- [ ] Invoke `/teach-me [new-topic]` — verify it starts fresh discovery flow
- [ ] Complete a session — verify session log file is created
- [ ] Re-invoke on same topic — verify it resumes with spaced review
- [ ] Request course generation — verify course files are created
- [ ] Request cheat sheet — verify reference card is generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)