### PR TITLE
fix(find-gaps): use AskUserQuestion for enumerable decisions

### DIFF
--- a/.changeset/find-gaps-ask-user-question.md
+++ b/.changeset/find-gaps-ask-user-question.md
@@ -1,0 +1,21 @@
+---
+"@paulhammond/dotfiles": patch
+---
+
+fix(find-gaps): use `AskUserQuestion` for enumerable decisions
+
+Weave the `AskUserQuestion` tool into the find-gaps loop wherever the **choice space is the value** (failure strategies, severity re-triage, state-variance scoping, parking decisions, write-back confirmation, variant comparison via `preview`) — while keeping free text for questions where the **user's specific words are the value** (microcopy, domain vocabulary, novel decisions).
+
+**Why it matters:** structured options surface trade-offs the user might not have thought through (*"silent retry once"* is rarely what they say first, but often the right call), speed up picking vs. generating, and let you batch 2–4 tightly-related sub-questions in one turn without reverting to a gap dump.
+
+**What's added:**
+- New **Asking with Structure** section with the core heuristic, good-fit table, bad-fit list, structural rules, and a worked payment-decline example showing how to batch two related sub-questions in one `AskUserQuestion` call
+- Step 4 of the gap-closing loop now routes enumerable questions to `AskUserQuestion` and uses it for the *write as-is / edit inline / discard* close, with optional `preview` for comparing two G/W/T drafts side-by-side
+- "One question per turn" rule clarified: a structured call with 2–4 tightly-related sub-questions is still one turn; batching *unrelated* gaps is a gap dump wearing a hat
+
+**What's forbidden:**
+- Inventing options just to use the tool (fabricated options anchor the user to guesses and hide their real answer)
+- Using `AskUserQuestion` for microcopy (destroys the exact wording that is the point)
+- Batching unrelated gaps into one call
+
+No other docs change — this is an internal refinement of how the skill interacts with the user. README/CLAUDE.md entries are unchanged.

--- a/claude/.claude/skills/find-gaps/SKILL.md
+++ b/claude/.claude/skills/find-gaps/SKILL.md
@@ -78,10 +78,10 @@ Get explicit agreement to proceed ("shall we start with the payment errors?" or 
 For each gap:
 
 1. **State the gap** in one sentence. No preamble, no justification.
-2. **Ask the concrete question.** Never bundle unrelated questions.
-3. **If the answer is vague, ask the follow-up that makes it testable.** "The user sees an error" → "What message, and can they retry?"
+2. **Ask the concrete question.** Never bundle unrelated questions. When the answer space is enumerable — failure strategies, severity classifications, state-variance scoping, parking decisions — ask via the `AskUserQuestion` tool with structured options rather than free text. See **Asking with Structure** below for the heuristic and worked examples.
+3. **If the answer is vague, ask the follow-up that makes it testable.** "The user sees an error" → "What message, and can they retry?" Follow-ups on microcopy stay free-text; follow-ups that narrow between a small set of behaviours become structured.
 4. **Convert the refined answer into an artifact update** using the patterns below.
-5. **Show the proposed update** verbatim and ask "write this as-is, or edit?"
+5. **Show the proposed update** verbatim, then offer *write as-is / edit inline / discard and redo* via `AskUserQuestion`. If you have two phrasings worth comparing, put them in option `preview` fields for side-by-side review.
 6. **Write it** to the source of truth once confirmed.
 7. **Move on.** Don't linger.
 
@@ -192,7 +192,7 @@ For every missed state, capture **name / trigger / visual / behaviour / exit** s
 
 **Ask only what the user can answer.** "What's the error-handling strategy?" is a design spike. "When the payment declines, what message should the user see?" is a decision.
 
-**One question per turn** — unless two are tightly coupled ("what's the error, and can the user retry from it?"). If you find yourself typing "Also," stop and pick the most important one.
+**One question per turn** — unless two are tightly coupled ("what's the error, and can the user retry from it?"). A structured `AskUserQuestion` call with 2–4 tightly-related sub-questions counts as one turn; batching *unrelated* gaps into a single call reverts to a gap dump. If you find yourself typing "Also," stop and pick the most important one.
 
 **Mirror the user's vocabulary.** If they say "buyer," the AC says "buyer." Do not silently promote it to "user" or "customer." Domain language is a feature.
 
@@ -203,6 +203,73 @@ For every missed state, capture **name / trigger / visual / behaviour / exit** s
 **Know when to escalate.** If a gap needs a decision the user can't make alone, name the actual owner, park it explicitly with a question and owner, and continue.
 
 **Don't re-ask triage.** You've already decided each gap is a Blocker / Should-address / Nice-to-have. Don't ask "do you want to address this?" for every one — just ask the concrete question. The user can say "skip" if they want.
+
+---
+
+## Asking with Structure
+
+Every question you put to the user is either free-text or structured via the `AskUserQuestion` tool. Pick based on where the value lives:
+
+- **The options are the value** → `AskUserQuestion`. Picking is faster than generating, the user benefits from seeing the choice space, and the common answers are knowable.
+- **The user's specific words are the value** → free text. Domain vocabulary, microcopy, novel decisions, anything that will be copied verbatim into the artifact.
+
+### Good fits
+
+Use `AskUserQuestion` when the answer space is genuinely enumerable and recurs across projects:
+
+| Situation                  | Why a structured question helps                                                                       |
+| -------------------------- | ----------------------------------------------------------------------------------------------------- |
+| Failure strategy           | Retry / fail fast / queue / fail-over — each has a named trade-off worth surfacing                    |
+| Severity re-triage         | Blocker / Should / Nice — useful when your triage and the user's disagree                             |
+| State-variance scoping     | Which states matter for v1 — `multiSelect: true` fits perfectly                                       |
+| Parking decisions          | Park with owner / escalate now / keep working — closes the gap-handling loop                          |
+| Write-back confirmation    | Write as-is / edit inline / discard — classic 3-option close after you've drafted the update          |
+| Variant comparison         | Two G/W/T drafts or two state specs in `preview` fields — side-by-side review beats prose walkthrough |
+
+### Bad fits
+
+Don't force structure where it doesn't belong:
+
+- **Microcopy** — "what error message should appear?" needs the user's exact words.
+- **Truly open questions** — "what are you trying to achieve here?" You'd be inventing the options.
+- **Domain-expert questions** — "what does 'confirmed' mean in our pricing flow?" The user knows things you don't; structured options anchor them to your guesses.
+- **Performative prompts** — if the right answer is already obvious, don't ask. Just propose it.
+
+### Structural rules
+
+- Batch **tightly-related** sub-questions in one call (up to 4). Batching unrelated gaps is a gap dump wearing a hat.
+- Option labels 1–5 words. Put the trade-off in the `description`.
+- If one option is the recommendation, put it first, add *"(Recommended)"* to the label, and name the reason in the description.
+- *"Other"* is added automatically — trust it. Don't add a synthetic "Custom…" option.
+- Use `preview` only for comparable artifacts (AC drafts, state specs, code snippets). Simple preferences don't need side-by-side layout.
+
+### Worked example — payment decline, structured
+
+**Gap:** "No spec for payment decline behaviour."
+
+Instead of free-text back-and-forth, issue one `AskUserQuestion` call with two tightly-coupled sub-questions:
+
+```
+Q1 — header: "On decline"
+  question: "What should happen when the payment provider returns a decline?"
+  options:
+    - label: "Keep card field populated (Recommended)"
+      description: "User can edit digits and retry without re-entering everything. Matches Stripe / Shopify default."
+    - label: "Clear card field"
+      description: "Forces re-entry; lower risk of accidentally retrying a stolen card but worse UX."
+    - label: "Silent retry once, then error"
+      description: "Can mask transient failures but adds ~1s latency to every decline."
+
+Q2 — header: "Telemetry"
+  question: "Should we emit a telemetry event on decline?"
+  options:
+    - label: "Emit payment.declined (Recommended)"
+      description: "With provider reason code. Supports fraud dashboards and funnel analysis."
+    - label: "No event"
+      description: "Reduces data volume; only fine if decline rate isn't a tracked metric."
+```
+
+After the user picks, draft the AC using the chosen options (plus any "Other" text verbatim for the user's own language). Then issue a second `AskUserQuestion` offering *write as-is / edit inline / discard* on the proposed G/W/T — with two drafts in `preview` fields if the scoping or event shape was worth comparing.
 
 ---
 
@@ -246,6 +313,9 @@ The log goes in the PR description, release notes, or wherever the work is being
 - **Stopping at three gaps.** If three surfaced in five minutes, there are probably thirty. Finish the checklist.
 - **Treating taste as a gap.** Stylistic preferences aren't gaps. Absence of decision is.
 - **Reviewing the artifact in isolation.** Cross-check plan ↔ AC ↔ mocks — gaps often appear as contradictions between two of them, not as absences in one.
+- **Inventing options just to use `AskUserQuestion`.** If you don't know the real choice space, ask free-text instead — fabricated options anchor the user to your guesses and hide their actual answer.
+- **Using `AskUserQuestion` for microcopy.** "What error message should appear?" must stay free-text. The user's exact words are the value; structured options destroy them.
+- **Batching unrelated gaps into one `AskUserQuestion` call.** Four sub-questions about the same gap is one turn. Four sub-questions about four different gaps is a gap dump in disguise.
 
 ## Quick reference
 


### PR DESCRIPTION
## Summary

Weaves the `AskUserQuestion` tool into the find-gaps gap-closing loop wherever the **choice space is the value** (failure strategies, severity re-triage, state-variance scoping, parking decisions, write-back confirmation, variant comparison via `preview`) — while keeping free text for questions where the **user's specific words are the value** (microcopy, domain vocabulary, novel decisions).

## Why it matters

Free-text back-and-forth on a decision like "what should happen when payment declines?" often gets the user's first-thought answer rather than their best one. Structured options let you surface the trade-offs ("silent retry once" adds ~1s latency on every decline) in a way prose doesn't, and the user picks in seconds instead of generating prose. `AskUserQuestion` also supports batching 2–4 tightly-related sub-questions in one turn — which is still one turn — so we can resolve a gap more completely per round without reverting to a gap dump.

## What's added to `SKILL.md`

- **New "Asking with Structure" section** with the core heuristic (options = value vs specific words = value), a good-fit table, a bad-fit list, structural rules (option labels, Recommended placement, `preview` usage), and a worked payment-decline example showing two sub-questions batched in one call
- **Step 4 of the loop** now routes enumerable questions to `AskUserQuestion` and uses it for the *write as-is / edit inline / discard* close, with optional `preview` for comparing two G/W/T drafts side-by-side
- **"One question per turn" rule clarified** — a structured call with 2–4 tightly-related sub-questions is still one turn; batching *unrelated* gaps into one call is a gap dump wearing a hat
- **Three new anti-patterns:**
  - Inventing options just to use the tool (fabricated options anchor the user to guesses)
  - Using `AskUserQuestion` for microcopy (destroys the exact wording that is the point)
  - Batching unrelated gaps into one call

## What's not changed

- README.md and CLAUDE.md — this is an internal refinement of how the skill interacts with the user; the entry points and framing are unchanged
- Discovery checklists — same three per-artifact lists
- Output format — still a tightened artifact + resolution log

## Test plan

- [ ] Read the worked payment-decline example and confirm the sub-question bundling feels natural (two sub-questions on the same gap, not two gaps)
- [ ] Confirm the skill will use free text for microcopy questions after reading the bad-fits list and anti-patterns
- [ ] Validate `preview`-based draft comparison by trying it on a real AC review

🤖 Generated with [Claude Code](https://claude.com/claude-code)