### PR TITLE
Install skills via skills.sh CLI

### DIFF
--- a/.changeset/skills-sh-install.md
+++ b/.changeset/skills-sh-install.md
@@ -1,0 +1,19 @@
+---
+"@paulhammond/dotfiles": minor
+---
+
+feat(install): install skills via the skills.sh CLI
+
+Replace the three direct-`curl` skill install blocks (own, web-quality-skills, impeccable) in `install-claude.sh` with `npx skills add -g -a claude-code -s '*' -y` calls against [skills.sh](https://skills.sh). The installer shrinks from ~700 to ~370 lines and skills can now be managed with `npx skills list/update/find/remove` after install instead of re-running the installer.
+
+**Why it matters:**
+- **Multi-agent portability** — the same skills are now installable against [40+ coding agents](https://github.com/vercel-labs/skills) (Claude Code, Cursor, Codex, Copilot, OpenCode, Gemini CLI, Cline, Continue, Windsurf, …) via the `-a <agent>` flag. `--with-opencode` is now just an extra `-a opencode` on the existing install rather than a duplicated tree.
+- **Lifecycle management** — `npx skills update -g` propagates upstream changes instead of requiring a full reinstall, and `npx skills find <query>` surfaces skills beyond this repo from the open ecosystem.
+- **Installer no longer grows with the skill list** — three `curl` loops with hard-coded file lists (including every `resources/*.md` and `references/*.md`) collapsed into three `npx skills add` calls; adding a new skill to `claude/.claude/skills/` no longer requires a matching installer edit.
+
+**Trade-offs (documented in the README):**
+- `--skills-only` now requires Node.js for `npx`. The script preflights and errors clearly if Node is missing; `--claude-only` and `--agents-only` still work without it.
+- The skills CLI doesn't surface ref pinning yet, so skills always install from the latest upstream commit. `--version` still pins `CLAUDE.md`, commands, and agents.
+- On an existing install that used the old `curl` mechanism, re-running backs up and replaces existing skill directories with CLI-managed symlinks — expected, but worth flagging before first run.
+
+`CLAUDE.md`, slash commands, and agents continue to download directly from this repo — they aren't skills and aren't part of the skills.sh ecosystem.

--- a/.changeset/skills-sh-install.md
+++ b/.changeset/skills-sh-install.md
@@ -8,6 +8,7 @@ Replace the three direct-`curl` skill install blocks (own, web-quality-skills, i
 
 **Why it matters:**
 - **Multi-agent portability** — the same skills are now installable against [40+ coding agents](https://github.com/vercel-labs/skills) (Claude Code, Cursor, Codex, Copilot, OpenCode, Gemini CLI, Cline, Continue, Windsurf, …) via the `-a <agent>` flag. `--with-opencode` is now just an extra `-a opencode` on the existing install rather than a duplicated tree.
+- **New `--agent <name>` flag** — repeatable, lets you target any supported agent without knowing the `npx skills add` syntax (e.g. `--agent codex --agent cursor`). Paired with `--no-claude-code` to target only non-Claude agents. Default remains claude-code.
 - **Lifecycle management** — `npx skills update -g` propagates upstream changes instead of requiring a full reinstall, and `npx skills find <query>` surfaces skills beyond this repo from the open ecosystem.
 - **Installer no longer grows with the skill list** — three `curl` loops with hard-coded file lists (including every `resources/*.md` and `references/*.md`) collapsed into three `npx skills add` calls; adding a new skill to `claude/.claude/skills/` no longer requires a matching installer edit.
 

--- a/.changeset/skills-sh-install.md
+++ b/.changeset/skills-sh-install.md
@@ -12,9 +12,10 @@ Replace the three direct-`curl` skill install blocks (own, web-quality-skills, i
 - **Lifecycle management** — `npx skills update -g` propagates upstream changes instead of requiring a full reinstall, and `npx skills find <query>` surfaces skills beyond this repo from the open ecosystem.
 - **Installer no longer grows with the skill list** — three `curl` loops with hard-coded file lists (including every `resources/*.md` and `references/*.md`) collapsed into three `npx skills add` calls; adding a new skill to `claude/.claude/skills/` no longer requires a matching installer edit.
 
+**Migration from the old curl-based installer is automatic.** The installer detects any pre-existing non-symlink directories under `~/.claude/skills/` (left behind by the curl-based installer), moves them aside to `~/.claude/skills.pre-skills-sh.<timestamp>/`, then lets the skills CLI install each source through the universal `~/.agents/skills/` cache. Without this step, the skills CLI would keep the stale directories in place as Claude-Code-specific installs and **they'd stay invisible to non-Claude agents** (Codex, OpenCode, etc.), defeating the multi-agent point. After install, a verification pass warns if anything ended up as a regular directory.
+
 **Trade-offs (documented in the README):**
 - `--skills-only` now requires Node.js for `npx`. The script preflights and errors clearly if Node is missing; `--claude-only` and `--agents-only` still work without it.
 - The skills CLI doesn't surface ref pinning yet, so skills always install from the latest upstream commit. `--version` still pins `CLAUDE.md`, commands, and agents.
-- On an existing install that used the old `curl` mechanism, re-running backs up and replaces existing skill directories with CLI-managed symlinks — expected, but worth flagging before first run.
 
 `CLAUDE.md`, slash commands, and agents continue to download directly from this repo — they aren't skills and aren't part of the skills.sh ecosystem.

--- a/README.md
+++ b/README.md
@@ -1291,9 +1291,9 @@ Agents are invoked implicitly (Claude detects when to use them) or explicitly:
 **Why choose this:**
 - ✅ One-time setup applies everywhere automatically
 - ✅ No per-project configuration needed
-- ✅ Works with Claude Code and OpenCode (`--with-opencode`)
+- ✅ Skills install via [skills.sh](https://skills.sh) — works with Claude Code, Cursor, Codex, Copilot, OpenCode, Gemini CLI, and 40+ other agents
 - ✅ Modular structure loads details on-demand
-- ✅ Easy updates via git pull
+- ✅ Easy updates: `npx skills update -g` for skills, `git pull` for the rest
 
 **One-liner installation:**
 ```bash
@@ -1320,22 +1320,32 @@ chmod +x install-claude.sh
 ```bash
 ./install-claude.sh                    # Install everything (CLAUDE.md + skills + commands + agents)
 ./install-claude.sh --claude-only      # Install only CLAUDE.md
-./install-claude.sh --skills-only      # Install only skills
+./install-claude.sh --skills-only      # Install only skills (via skills.sh)
 ./install-claude.sh --no-agents        # Install without agents
 ./install-claude.sh --no-external      # Skip all external community skills (web-quality-skills + impeccable)
 ./install-claude.sh --no-impeccable    # Skip impeccable design skills only
-./install-claude.sh --with-opencode    # Also install OpenCode configuration
-./install-claude.sh --version v2.0.0   # Install v2.0.0 (modular docs)
-./install-claude.sh --version v1.0.0   # Install v1.0.0 (single file)
+./install-claude.sh --with-opencode    # Also target OpenCode for skills + install OpenCode config
+./install-claude.sh --version v2.0.0   # Version for CLAUDE.md/commands/agents (skills always latest)
 ```
 
-**What gets installed (v3.0.0):**
+**What gets installed:**
 - ✅ `~/.claude/CLAUDE.md` (~100 lines - lean core principles)
-- ✅ `~/.claude/skills/` (24 auto-discovered patterns: tdd, testing, mutation-testing, test-design-reviewer, typescript-strict, functional, refactoring, expectations, planning, front-end-testing, react-testing, ci-debugging, hexagonal-architecture, domain-driven-design, twelve-factor, api-design, cli-design, finding-seams, characterisation-tests, storyboard, teach-me, diagrams, find-skills, find-gaps)
-- ✅ `~/.claude/skills/` (18 impeccable design skills from [pbakaus/impeccable](https://github.com/pbakaus/impeccable): impeccable core + 17 steering commands)
-- ✅ `~/.claude/skills/` (6 web quality patterns from [addyosmani/web-quality-skills](https://github.com/addyosmani/web-quality-skills): accessibility, best-practices, core-web-vitals, performance, seo, web-quality-audit)
+- ✅ `~/.claude/skills/` — installed via [skills.sh](https://skills.sh) (`npx skills add`):
+  - [citypaul/.dotfiles](https://skills.sh/citypaul/.dotfiles) — 24 auto-discovered patterns (tdd, testing, mutation-testing, typescript-strict, functional, refactoring, planning, front-end-testing, react-testing, and more)
+  - [pbakaus/impeccable](https://skills.sh/pbakaus/impeccable) — frontend design vocabulary + 17 steering commands
+  - [addyosmani/web-quality-skills](https://skills.sh/addyosmani/web-quality-skills) — accessibility, performance, SEO, core-web-vitals, best-practices, web-quality-audit
 - ✅ `~/.claude/commands/` (5 slash commands: /setup, /pr, /plan, /continue, /generate-pr-review)
 - ✅ `~/.claude/agents/` (10 specialized workflow agents)
+
+**Managing skills after install:**
+```bash
+npx skills list -g              # List installed skills
+npx skills update -g            # Update all skills to latest
+npx skills find <query>         # Discover more skills on skills.sh
+npx skills remove -g <name>     # Uninstall a skill
+```
+
+> **Requires Node.js** for skills install (so `npx` is available). Use `--claude-only` or `--agents-only` if you don't have Node installed.
 
 **Optional: Enable GitHub MCP Integration**
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This repository now serves two purposes:
 
 **Most people are here for CLAUDE.md and the agents.** This README focuses primarily on those, with [dotfiles coverage at the end](#-personal-dotfiles-the-original-purpose).
 
-> **Using OpenCode?** All skills, slash commands, and agents in this repo work with both Claude Code and [OpenCode](https://opencode.ai). Install with `--with-opencode` to get full compatibility — see [OpenCode Support](#optional-enable-opencode-support) for details.
+> **Using another coding agent?** Skills install via [skills.sh](https://skills.sh), which supports 40+ coding agents (Claude Code, Cursor, Codex, Copilot, OpenCode, Gemini CLI, Cline, Continue, Windsurf, …). Pass `--agent <name>` (repeatable) to target others, or `--with-opencode` for the OpenCode config shortcut. Slash commands and Claude-Code agents are Claude-Code-specific; `--with-opencode` also copies them into OpenCode's equivalents. See [Targeting other agents](#targeting-other-agents) for details.
 
 ---
 
@@ -1331,9 +1331,18 @@ chmod +x install-claude.sh
 ./install-claude.sh --version v2.0.0                     # Version for CLAUDE.md/commands/agents (skills always latest)
 ```
 
-**Targeting other agents:**
+<a id="targeting-other-agents"></a>**Targeting other agents:**
 
-Skills.sh supports 40+ coding agents (Claude Code, Cursor, Codex, Copilot, OpenCode, Gemini CLI, Cline, Continue, Windsurf, …). Use `--agent <name>` (repeatable) to add extra targets alongside the default claude-code. Use `--no-claude-code` with `--agent` to target only non-Claude agents. After install, `npx skills list -g` shows the on-disk path per agent.
+Skills.sh supports 40+ coding agents (Claude Code, Cursor, Codex, Copilot, OpenCode, Gemini CLI, Cline, Continue, Windsurf, …). Use `--agent <name>` (repeatable) to add extra targets alongside the default `claude-code`. Use `--no-claude-code` with `--agent` to target only non-Claude agents. After install, `npx skills list -g` shows which skills each agent can see.
+
+Under the hood, the skills CLI distinguishes two kinds of agent:
+
+- **Universal agents** (Codex, OpenCode, and others whose `skillsDir` is `.agents/skills`) read directly from the shared `~/.agents/skills/` cache. Installing for these adds nothing to the agent's own config dir — the cache path is the read path.
+- **Per-agent agents** (Claude Code, Cursor, …) get a symlink into their own skills directory (e.g. `~/.claude/skills/<name> -> ~/.agents/skills/<name>`).
+
+Both patterns resolve to the same content on disk, so the first `--agent codex` install makes skills visible to Codex with no duplicate storage.
+
+**Migration from the old curl-based installer is automatic.** If `~/.claude/skills/` contains regular directories left behind by a previous install, the installer moves them to `~/.claude/skills.pre-skills-sh.<timestamp>/` before running `npx skills add`, so the CLI can route each source through the universal cache and every targeted agent (Claude Code *and* Codex, etc.) picks them up. The move is non-destructive — the timestamped backup stays on disk until you remove it.
 
 **What gets installed:**
 - ✅ `~/.claude/CLAUDE.md` (~100 lines - lean core principles)
@@ -1363,16 +1372,18 @@ The installer used to `curl` every `SKILL.md` straight from this repo into `~/.c
 
 2. **Lifecycle commands.** `npx skills list -g`, `update -g`, and `remove -g <name>` manage skills after install. Previously the only way to "update" was to re-run the whole installer and overwrite everything. `npx skills find <query>` also surfaces skills beyond this repo from the open ecosystem (Vercel's `agent-skills`, community authors, etc.).
 
-3. **One source of truth on disk.** The CLI symlinks skills from a package cache into each agent's directory, so a single `npx skills update -g` propagates everywhere a skill is wired up.
+3. **One source of truth on disk.** Skills live once at `~/.agents/skills/<name>` (the universal cache); Claude Code gets a symlink into `~/.claude/skills/<name>`; Codex and other "universal" agents read the cache directly. A single `npx skills update -g` propagates everywhere a skill is wired up.
 
 4. **Installer doesn't grow with the skill list.** Three `curl` loops with hard-coded file lists (including every `resources/*.md` and `references/*.md`) collapsed to three `npx skills add` calls. Adding a new skill to `claude/.claude/skills/` no longer requires a matching installer edit — the CLI discovers it.
+
+5. **Auto-migration from the old curl installer.** Before running `npx skills add`, the installer looks for regular directories under `~/.claude/skills/` (the shape the old curl installer wrote) and moves them to `~/.claude/skills.pre-skills-sh.<timestamp>/`. Without this step the CLI would treat the stale dirs as Claude-Code-specific installs and keep them invisible to non-Claude agents. A verification pass after install warns if anything still ended up as a regular directory.
 
 **Trade-offs:**
 - Requires Node.js for `npx`. `--claude-only` and `--agents-only` still work without it.
 - The skills CLI doesn't expose ref pinning yet, so skills always install from the latest upstream commit. `--version` still pins `CLAUDE.md`, commands, and agents.
 - Skills used to ship at the same `v3.x` tag as everything else in this repo; now they roll independently. Use `npx skills list -g --json` if you want to snapshot what's installed.
 
-`CLAUDE.md`, slash commands, and agents are still `curl`ed directly from this repo — they aren't skills and aren't part of the skills.sh ecosystem.
+`CLAUDE.md`, slash commands, and Claude-Code agents are still `curl`ed directly from this repo — they aren't skills and aren't part of the skills.sh ecosystem.
 
 </details>
 
@@ -1601,14 +1612,14 @@ This gives you the complete guidelines (1,818 lines) in a single standalone file
 - **v2.0.0 modular docs:** https://github.com/citypaul/.dotfiles/tree/v2.0.0/claude/.claude
 - **v1.0.0 single file:** https://github.com/citypaul/.dotfiles/blob/v1.0.0/claude/.claude/CLAUDE.md
 
-The installation script installs v3.0.0 by default. Use `--version v2.0.0` or `--version v1.0.0` for older versions.
+The installer pulls `CLAUDE.md`, slash commands, and Claude-Code agents from the `main` branch by default — pass `--version v2.0.0` or `--version v1.0.0` to pin those to an older tag. Skills always install from the latest upstream commit via skills.sh, independent of this flag.
 
 ---
 
 ## 📚 Documentation
 
 - **[CLAUDE.md](claude/.claude/CLAUDE.md)** - Core development principles (~100 lines)
-- **[Skills](claude/.claude/skills/)** - Auto-discovered patterns (20 built-in skills + 6 web quality skills from [addyosmani/web-quality-skills](https://github.com/addyosmani/web-quality-skills))
+- **[Skills](claude/.claude/skills/)** - Auto-discovered patterns. 24 from this repo, 6 from [addyosmani/web-quality-skills](https://github.com/addyosmani/web-quality-skills), and 17 from [pbakaus/impeccable](https://github.com/pbakaus/impeccable) — all installed via [skills.sh](https://skills.sh) for multi-agent portability.
 - **[Commands](claude/.claude/commands/)** - Slash commands (/setup, /pr, /plan, /continue, /generate-pr-review)
 - **[Agents README](claude/.claude/agents/README.md)** - Detailed agent documentation with examples
 - **[Agent Definitions](claude/.claude/agents/)** - Individual agent configuration files (10 agents: tdd-guardian, ts-enforcer, refactor-scan, docs-guardian, learn, progress-guardian, adr, pr-reviewer, use-case-data-patterns, twelve-factor-audit)

--- a/README.md
+++ b/README.md
@@ -1318,15 +1318,22 @@ chmod +x install-claude.sh
 
 **Install options:**
 ```bash
-./install-claude.sh                    # Install everything (CLAUDE.md + skills + commands + agents)
-./install-claude.sh --claude-only      # Install only CLAUDE.md
-./install-claude.sh --skills-only      # Install only skills (via skills.sh)
-./install-claude.sh --no-agents        # Install without agents
-./install-claude.sh --no-external      # Skip all external community skills (web-quality-skills + impeccable)
-./install-claude.sh --no-impeccable    # Skip impeccable design skills only
-./install-claude.sh --with-opencode    # Also target OpenCode for skills + install OpenCode config
-./install-claude.sh --version v2.0.0   # Version for CLAUDE.md/commands/agents (skills always latest)
+./install-claude.sh                                      # Install everything (CLAUDE.md + skills + commands + agents)
+./install-claude.sh --claude-only                        # Install only CLAUDE.md
+./install-claude.sh --skills-only                        # Install only skills (via skills.sh)
+./install-claude.sh --no-agents                          # Install without agents
+./install-claude.sh --no-external                        # Skip all external community skills (web-quality-skills + impeccable)
+./install-claude.sh --no-impeccable                      # Skip impeccable design skills only
+./install-claude.sh --with-opencode                      # Also target OpenCode for skills + install OpenCode config
+./install-claude.sh --agent codex --agent cursor         # Also install skills for Codex and Cursor (repeatable)
+./install-claude.sh --skills-only --no-claude-code \     # Install skills ONLY for a non-Claude agent
+                    --agent codex
+./install-claude.sh --version v2.0.0                     # Version for CLAUDE.md/commands/agents (skills always latest)
 ```
+
+**Targeting other agents:**
+
+Skills.sh supports 40+ coding agents (Claude Code, Cursor, Codex, Copilot, OpenCode, Gemini CLI, Cline, Continue, Windsurf, …). Use `--agent <name>` (repeatable) to add extra targets alongside the default claude-code. Use `--no-claude-code` with `--agent` to target only non-Claude agents. After install, `npx skills list -g` shows the on-disk path per agent.
 
 **What gets installed:**
 - ✅ `~/.claude/CLAUDE.md` (~100 lines - lean core principles)

--- a/README.md
+++ b/README.md
@@ -1347,6 +1347,28 @@ npx skills remove -g <name>     # Uninstall a skill
 
 > **Requires Node.js** for skills install (so `npx` is available). Use `--claude-only` or `--agents-only` if you don't have Node installed.
 
+<details>
+<summary><b>Why does the installer use skills.sh instead of <code>curl</code>ing skills directly?</b></summary>
+
+The installer used to `curl` every `SKILL.md` straight from this repo into `~/.claude/skills/`. It worked, but it was Claude-Code-only and the file list lived inside the installer. Switching skill installs to the [skills.sh](https://skills.sh) CLI (`npx skills add`) changes four things:
+
+1. **Multi-agent portability.** The same skills are now installable against [40+ coding agents](https://github.com/vercel-labs/skills) — Claude Code, Cursor, Codex, GitHub Copilot, OpenCode, Gemini CLI, Cline, Continue, Windsurf, and more — via the `-a <agent>` flag. Using these skills from a non-Claude tool no longer requires a Claude-specific copy step. `--with-opencode` is now just an extra `-a opencode` on the existing install instead of a second duplicated tree.
+
+2. **Lifecycle commands.** `npx skills list -g`, `update -g`, and `remove -g <name>` manage skills after install. Previously the only way to "update" was to re-run the whole installer and overwrite everything. `npx skills find <query>` also surfaces skills beyond this repo from the open ecosystem (Vercel's `agent-skills`, community authors, etc.).
+
+3. **One source of truth on disk.** The CLI symlinks skills from a package cache into each agent's directory, so a single `npx skills update -g` propagates everywhere a skill is wired up.
+
+4. **Installer doesn't grow with the skill list.** Three `curl` loops with hard-coded file lists (including every `resources/*.md` and `references/*.md`) collapsed to three `npx skills add` calls. Adding a new skill to `claude/.claude/skills/` no longer requires a matching installer edit — the CLI discovers it.
+
+**Trade-offs:**
+- Requires Node.js for `npx`. `--claude-only` and `--agents-only` still work without it.
+- The skills CLI doesn't expose ref pinning yet, so skills always install from the latest upstream commit. `--version` still pins `CLAUDE.md`, commands, and agents.
+- Skills used to ship at the same `v3.x` tag as everything else in this repo; now they roll independently. Use `npx skills list -g --json` if you want to snapshot what's installed.
+
+`CLAUDE.md`, slash commands, and agents are still `curl`ed directly from this repo — they aren't skills and aren't part of the skills.sh ecosystem.
+
+</details>
+
 **Optional: Enable GitHub MCP Integration**
 
 For enhanced GitHub workflows with native PR/issue integration:

--- a/install-claude.sh
+++ b/install-claude.sh
@@ -2,12 +2,17 @@
 #
 # Install CLAUDE.md development framework to ~/.claude/
 #
+# Skills are installed via the skills.sh CLI (npx skills), which supports
+# Claude Code, Cursor, Codex, Copilot, OpenCode, Gemini CLI, and 40+ other
+# agents. CLAUDE.md, slash commands, and agents are Claude-Code-specific
+# artifacts and are still downloaded directly from this repo.
+#
 # Usage:
 #   ./install-claude.sh                    # Install everything (CLAUDE.md + skills + commands + agents)
 #   ./install-claude.sh --claude-only      # Install only CLAUDE.md
 #   ./install-claude.sh --no-agents        # Install without agents
 #   ./install-claude.sh --skills-only      # Install only skills
-#   ./install-claude.sh --version v3.0.0   # Install specific version
+#   ./install-claude.sh --version v3.0.0   # Install specific version (for CLAUDE.md/commands/agents)
 #   ./install-claude.sh --with-opencode    # Also install OpenCode configuration
 #
 # One-liner installation:
@@ -33,9 +38,11 @@ INSTALL_OPENCODE=false
 INSTALL_EXTERNAL=true
 INSTALL_IMPECCABLE=true
 BASE_URL="https://raw.githubusercontent.com/citypaul/.dotfiles"
-WEB_QUALITY_SKILLS_URL="https://raw.githubusercontent.com/addyosmani/web-quality-skills"
-IMPECCABLE_SKILLS_URL="https://raw.githubusercontent.com/pbakaus/impeccable/main/.claude/skills"
-IMPECCABLE_BASE_URL="https://raw.githubusercontent.com/pbakaus/impeccable/main"
+
+# Skill sources on skills.sh (https://skills.sh)
+OWN_SKILLS_REPO="citypaul/.dotfiles"
+WEB_QUALITY_SKILLS_REPO="addyosmani/web-quality-skills"
+IMPECCABLE_SKILLS_REPO="pbakaus/impeccable"
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -93,30 +100,30 @@ while [[ $# -gt 0 ]]; do
       cat << EOF
 Install CLAUDE.md development framework to ~/.claude/
 
+Skills install via skills.sh (multi-agent); other artifacts (CLAUDE.md,
+commands, agents) download directly from this repo.
+
 Usage:
   $0 [OPTIONS]
 
 Options:
   --claude-only      Install only CLAUDE.md
   --no-agents        Install without agents
-  --skills-only      Install only skills
+  --skills-only      Install only skills (via skills.sh)
   --agents-only      Install only agents
-  --with-opencode    Also install OpenCode configuration (commands + agents)
-  --opencode-only    Install only OpenCode configuration (commands + agents)
+  --with-opencode    Also target the OpenCode agent for skills + install OpenCode config
+  --opencode-only    Install only OpenCode configuration (commands + agents + skills)
   --no-external      Skip all external community skills (web-quality-skills + impeccable)
   --no-impeccable    Skip impeccable design skills only
-  --version VERSION  Install specific version (default: main)
+  --version VERSION  Version for CLAUDE.md/commands/agents (default: main). Skills always latest.
   --help, -h         Show this help message
 
 Examples:
   # Install everything (recommended)
   $0
 
-  # Install specific version
-  $0 --version v3.0.0
-
-  # Install without agents
-  $0 --no-agents
+  # Install only skills for both Claude Code and OpenCode
+  $0 --skills-only --with-opencode
 
   # One-liner installation
   curl -fsSL https://raw.githubusercontent.com/citypaul/.dotfiles/main/install-claude.sh | bash
@@ -137,6 +144,15 @@ echo -e "${BLUE}║  CLAUDE.md Development Framework Installer         ║${NC}"
 printf "${BLUE}║  Version: %-40s║${NC}\n" "$VERSION"
 echo -e "${BLUE}╚════════════════════════════════════════════════════╝${NC}"
 echo ""
+
+# Check for npx if we'll need it
+if [[ "$INSTALL_SKILLS" == true ]]; then
+  if ! command -v npx >/dev/null 2>&1; then
+    echo -e "${RED}Error: npx is required to install skills via skills.sh${NC}"
+    echo -e "${YELLOW}Install Node.js (https://nodejs.org) or rerun with --claude-only / --agents-only${NC}"
+    exit 1
+  fi
+fi
 
 # Function to download a file
 download_file() {
@@ -166,31 +182,33 @@ backup_file() {
   fi
 }
 
-# Create directories
+# Install skills from a skills.sh source for the selected agents
+install_skills_from() {
+  local source="$1"
+  local label="$2"
+
+  echo -e "${YELLOW}→${NC} Installing $label from $source..."
+
+  # Build agent flags based on install flags
+  local agent_args=(-a claude-code)
+  if [[ "$INSTALL_OPENCODE" == true ]]; then
+    agent_args+=(-a opencode)
+  fi
+
+  # -g: install globally (~/.claude/skills, ~/.config/opencode/...)
+  # -s '*': install all skills from the source
+  # -y: skip prompts
+  if npx --yes skills add "$source" -g "${agent_args[@]}" -s '*' -y; then
+    echo -e "${GREEN}✓${NC} $label installed"
+  else
+    echo -e "${RED}✗${NC} Failed to install $label from $source"
+    return 1
+  fi
+}
+
+# Create directories for non-skills artifacts
 echo -e "${BLUE}Creating directories...${NC}"
-mkdir -p ~/.claude/agents ~/.claude/skills ~/.claude/commands
-mkdir -p ~/.claude/skills/tdd ~/.claude/skills/typescript-strict ~/.claude/skills/functional
-mkdir -p ~/.claude/skills/refactoring ~/.claude/skills/testing ~/.claude/skills/expectations ~/.claude/skills/planning
-mkdir -p ~/.claude/skills/front-end-testing ~/.claude/skills/react-testing ~/.claude/skills/mutation-testing ~/.claude/skills/test-design-reviewer
-mkdir -p ~/.claude/skills/ci-debugging ~/.claude/skills/hexagonal-architecture ~/.claude/skills/domain-driven-design ~/.claude/skills/twelve-factor ~/.claude/skills/api-design
-mkdir -p ~/.claude/skills/finding-seams ~/.claude/skills/characterisation-tests ~/.claude/skills/find-skills ~/.claude/skills/storyboard
-mkdir -p ~/.claude/skills/teach-me ~/.claude/skills/diagrams ~/.claude/skills/find-gaps
-mkdir -p ~/.claude/skills/hexagonal-architecture/resources ~/.claude/skills/domain-driven-design/resources ~/.claude/skills/api-design/resources ~/.claude/skills/cli-design/resources
-mkdir -p ~/.claude/skills/finding-seams/resources ~/.claude/skills/characterisation-tests/resources
-mkdir -p ~/.claude/skills/teach-me/resources ~/.claude/skills/diagrams/references
-if [[ "$INSTALL_EXTERNAL" == true ]]; then
-  mkdir -p ~/.claude/skills/accessibility ~/.claude/skills/best-practices ~/.claude/skills/core-web-vitals
-  mkdir -p ~/.claude/skills/performance ~/.claude/skills/seo ~/.claude/skills/web-quality-audit
-fi
-if [[ "$INSTALL_IMPECCABLE" == true ]]; then
-  mkdir -p ~/.claude/skills/impeccable/reference ~/.claude/skills/impeccable/scripts
-  mkdir -p ~/.claude/skills/adapt ~/.claude/skills/animate ~/.claude/skills/audit
-  mkdir -p ~/.claude/skills/bolder ~/.claude/skills/clarify ~/.claude/skills/colorize
-  mkdir -p ~/.claude/skills/critique/reference ~/.claude/skills/delight ~/.claude/skills/distill
-  mkdir -p ~/.claude/skills/harden ~/.claude/skills/layout ~/.claude/skills/optimize
-  mkdir -p ~/.claude/skills/overdrive ~/.claude/skills/polish ~/.claude/skills/quieter
-  mkdir -p ~/.claude/skills/shape ~/.claude/skills/typeset
-fi
+mkdir -p ~/.claude/agents ~/.claude/commands
 echo -e "${GREEN}✓${NC} Directories created"
 echo ""
 
@@ -205,254 +223,26 @@ if [[ "$INSTALL_CLAUDE" == true ]]; then
   echo ""
 fi
 
-# Install skills (v3.0: auto-discovered patterns)
+# Install skills via skills.sh CLI (multi-agent: Claude Code, OpenCode, ...)
 if [[ "$INSTALL_SKILLS" == true ]]; then
-  echo -e "${BLUE}Installing skills (auto-discovered patterns)...${NC}"
+  echo -e "${BLUE}Installing skills via skills.sh...${NC}"
+  echo -e "${YELLOW}→${NC} Multi-agent CLI — supports Claude Code, Cursor, Codex, Copilot, OpenCode, Gemini CLI, and 40+ others"
+  echo ""
 
-  skills=(
-    "tdd/SKILL.md"
-    "typescript-strict/SKILL.md"
-    "functional/SKILL.md"
-    "refactoring/SKILL.md"
-    "testing/SKILL.md"
-    "mutation-testing/SKILL.md"
-    "test-design-reviewer/SKILL.md"
-    "expectations/SKILL.md"
-    "planning/SKILL.md"
-    "front-end-testing/SKILL.md"
-    "react-testing/SKILL.md"
-    "ci-debugging/SKILL.md"
-    "hexagonal-architecture/SKILL.md"
-    "domain-driven-design/SKILL.md"
-    "twelve-factor/SKILL.md"
-    "api-design/SKILL.md"
-    "cli-design/SKILL.md"
-    "finding-seams/SKILL.md"
-    "characterisation-tests/SKILL.md"
-    "find-skills/SKILL.md"
-    "find-skills/LICENSE" # MIT attribution — vendored from vercel-labs/skills
-    "storyboard/SKILL.md"
-    "teach-me/SKILL.md"
-    "diagrams/SKILL.md"
-    "diagrams/LICENSE" # MIT attribution — vendored from markdown-viewer/skills
-    "diagrams/examples.md"
-    "find-gaps/SKILL.md"
-  )
+  install_skills_from "$OWN_SKILLS_REPO" "own skills (citypaul/.dotfiles)"
 
-  for skill in "${skills[@]}"; do
-    backup_file ~/.claude/skills/"$skill"
-    download_file \
-      "$BASE_URL/$VERSION/claude/.claude/skills/$skill" \
-      ~/.claude/skills/"$skill" \
-      "skills/$skill"
-  done
+  if [[ "$INSTALL_EXTERNAL" == true ]]; then
+    install_skills_from "$WEB_QUALITY_SKILLS_REPO" "web quality skills (addyosmani/web-quality-skills)"
+  fi
 
-  # Deep-dive resource files for skills that have them
-  resources=(
-    "hexagonal-architecture/resources/cqrs-lite.md"
-    "hexagonal-architecture/resources/cross-cutting-concerns.md"
-    "hexagonal-architecture/resources/incremental-adoption.md"
-    "hexagonal-architecture/resources/testing-hex-arch.md"
-    "hexagonal-architecture/resources/worked-example.md"
-    "domain-driven-design/resources/aggregate-design.md"
-    "domain-driven-design/resources/bounded-contexts.md"
-    "domain-driven-design/resources/domain-events.md"
-    "domain-driven-design/resources/domain-services.md"
-    "domain-driven-design/resources/error-modeling.md"
-    "domain-driven-design/resources/testing-by-layer.md"
-    "api-design/resources/api-evolution.md"
-    "api-design/resources/api-security.md"
-    "api-design/resources/http-fundamentals.md"
-    "api-design/resources/auth-security.md"
-    "cli-design/resources/output-architecture.md"
-    "cli-design/resources/testing-cli.md"
-    "cli-design/resources/stream-contracts.md"
-    "finding-seams/resources/seam-types.md"
-    "finding-seams/resources/creating-seams.md"
-    "finding-seams/resources/oop-patterns.md"
-    "characterisation-tests/resources/writing-process.md"
-    "characterisation-tests/resources/modern-tooling.md"
-    "teach-me/resources/assessment-patterns.md"
-    "teach-me/resources/course-generation.md"
-    "teach-me/resources/learning-science.md"
-    "teach-me/resources/session-management.md"
-    "diagrams/references/architecture.md"
-    "diagrams/references/canvas.md"
-    "diagrams/references/graphviz.md"
-    "diagrams/references/infocard.md"
-    "diagrams/references/infographic.md"
-    "diagrams/references/mermaid.md"
-    "diagrams/references/plantuml.md"
-    "diagrams/references/vega.md"
-  )
-
-  for resource in "${resources[@]}"; do
-    backup_file ~/.claude/skills/"$resource"
-    download_file \
-      "$BASE_URL/$VERSION/claude/.claude/skills/$resource" \
-      ~/.claude/skills/"$resource" \
-      "skills/$resource"
-  done
-
-  # References file
-  backup_file ~/.claude/skills/REFERENCES.md
-  download_file \
-    "$BASE_URL/$VERSION/claude/.claude/skills/REFERENCES.md" \
-    ~/.claude/skills/REFERENCES.md \
-    "skills/REFERENCES.md"
+  if [[ "$INSTALL_IMPECCABLE" == true ]]; then
+    install_skills_from "$IMPECCABLE_SKILLS_REPO" "impeccable design skills (pbakaus/impeccable)"
+  fi
 
   echo ""
 fi
 
-# Install external community skills (fetched from upstream repos)
-if [[ "$INSTALL_EXTERNAL" == true && "$INSTALL_SKILLS" == true ]]; then
-  echo -e "${BLUE}Installing external community skills...${NC}"
-  echo -e "${YELLOW}→${NC} Source: addyosmani/web-quality-skills (MIT License)"
-
-  external_skills=(
-    "accessibility/SKILL.md"
-    "best-practices/SKILL.md"
-    "core-web-vitals/SKILL.md"
-    "performance/SKILL.md"
-    "seo/SKILL.md"
-    "web-quality-audit/SKILL.md"
-  )
-
-  for skill in "${external_skills[@]}"; do
-    backup_file ~/.claude/skills/"$skill"
-    download_file \
-      "$WEB_QUALITY_SKILLS_URL/main/skills/$skill" \
-      ~/.claude/skills/"$skill" \
-      "skills/$skill (web-quality-skills)"
-  done
-
-  # Download the license file to preserve attribution as required by MIT
-  download_file \
-    "$WEB_QUALITY_SKILLS_URL/main/LICENSE" \
-    ~/.claude/skills/.web-quality-skills-LICENSE \
-    "web-quality-skills LICENSE"
-
-  echo ""
-fi
-
-# Install impeccable design skills (fetched from upstream repo)
-if [[ "$INSTALL_IMPECCABLE" == true && "$INSTALL_SKILLS" == true ]]; then
-  echo -e "${BLUE}Installing impeccable design skills...${NC}"
-  echo -e "${YELLOW}→${NC} Source: pbakaus/impeccable (Apache 2.0 License)"
-  echo ""
-  echo -e "  Impeccable is a frontend design vocabulary and quality system that"
-  echo -e "  guides AI coding tools toward distinctive, high-quality interfaces."
-  echo ""
-  echo -e "  ${YELLOW}Getting started:${NC}"
-  echo -e "    /impeccable teach   Set up design context for your project"
-  echo -e "    /impeccable craft   Shape, build, and iterate on a feature"
-  echo -e "    /impeccable extract Pull reusable components and tokens"
-  echo ""
-  echo -e "  ${YELLOW}Steering commands:${NC}"
-  echo -e "    /shape     Plan UX/UI before code        /critique  Full UX review with scoring"
-  echo -e "    /audit     Technical quality scoring      /polish    Final quality pass"
-  echo -e "    /typeset   Fix typography                 /colorize  Add strategic color"
-  echo -e "    /animate   Purposeful animations          /layout    Fix spacing and rhythm"
-  echo -e "    /harden    Production-ready hardening     /clarify   Improve UX copy"
-  echo -e "    /adapt     Cross-device adaptation        /bolder    Amplify safe designs"
-  echo -e "    /quieter   Tone down aggressive designs   /distill   Strip to essence"
-  echo -e "    /delight   Add moments of joy             /optimize  Performance improvements"
-  echo -e "    /overdrive Extraordinary effects"
-  echo ""
-  echo -e "  ${BLUE}Learn more: https://impeccable.style/skills/${NC}"
-  echo ""
-
-  # Core skill
-  backup_file ~/.claude/skills/impeccable/SKILL.md
-  download_file \
-    "$IMPECCABLE_SKILLS_URL/impeccable/SKILL.md" \
-    ~/.claude/skills/impeccable/SKILL.md \
-    "skills/impeccable/SKILL.md (impeccable core)"
-
-  # Reference files
-  impeccable_refs=(
-    "impeccable/reference/typography.md"
-    "impeccable/reference/color-and-contrast.md"
-    "impeccable/reference/spatial-design.md"
-    "impeccable/reference/motion-design.md"
-    "impeccable/reference/interaction-design.md"
-    "impeccable/reference/responsive-design.md"
-    "impeccable/reference/ux-writing.md"
-    "impeccable/reference/craft.md"
-    "impeccable/reference/extract.md"
-  )
-
-  for ref in "${impeccable_refs[@]}"; do
-    download_file \
-      "$IMPECCABLE_SKILLS_URL/$ref" \
-      ~/.claude/skills/"$ref" \
-      "skills/$ref (impeccable)"
-  done
-
-  # Cleanup script
-  download_file \
-    "$IMPECCABLE_SKILLS_URL/impeccable/scripts/cleanup-deprecated.mjs" \
-    ~/.claude/skills/impeccable/scripts/cleanup-deprecated.mjs \
-    "impeccable cleanup script"
-
-  # Steering commands
-  impeccable_commands=(
-    "adapt/SKILL.md"
-    "animate/SKILL.md"
-    "audit/SKILL.md"
-    "bolder/SKILL.md"
-    "clarify/SKILL.md"
-    "colorize/SKILL.md"
-    "critique/SKILL.md"
-    "delight/SKILL.md"
-    "distill/SKILL.md"
-    "harden/SKILL.md"
-    "layout/SKILL.md"
-    "optimize/SKILL.md"
-    "overdrive/SKILL.md"
-    "polish/SKILL.md"
-    "quieter/SKILL.md"
-    "shape/SKILL.md"
-    "typeset/SKILL.md"
-  )
-
-  for cmd in "${impeccable_commands[@]}"; do
-    backup_file ~/.claude/skills/"$cmd"
-    download_file \
-      "$IMPECCABLE_SKILLS_URL/$cmd" \
-      ~/.claude/skills/"$cmd" \
-      "skills/$cmd (impeccable)"
-  done
-
-  # Critique reference files
-  critique_refs=(
-    "critique/reference/cognitive-load.md"
-    "critique/reference/heuristics-scoring.md"
-    "critique/reference/personas.md"
-  )
-
-  for ref in "${critique_refs[@]}"; do
-    download_file \
-      "$IMPECCABLE_SKILLS_URL/$ref" \
-      ~/.claude/skills/"$ref" \
-      "skills/$ref (impeccable)"
-  done
-
-  # Download license and notice for attribution (required by Apache 2.0)
-  download_file \
-    "$IMPECCABLE_BASE_URL/LICENSE" \
-    ~/.claude/skills/.impeccable-LICENSE \
-    "impeccable LICENSE (Apache 2.0)"
-
-  download_file \
-    "$IMPECCABLE_BASE_URL/NOTICE.md" \
-    ~/.claude/skills/.impeccable-NOTICE \
-    "impeccable NOTICE"
-
-  echo ""
-fi
-
-# Install commands (v3.0: slash commands)
+# Install commands (slash commands)
 if [[ "$INSTALL_COMMANDS" == true ]]; then
   echo -e "${BLUE}Installing commands (slash commands)...${NC}"
 
@@ -559,13 +349,15 @@ if [[ "$INSTALL_CLAUDE" == true ]]; then
 fi
 
 if [[ "$INSTALL_SKILLS" == true ]]; then
-  echo -e "  ${GREEN}✓${NC} skills/ (19 auto-discovered patterns: tdd, testing, mutation-testing, test-design-reviewer, typescript-strict, functional, refactoring, expectations, planning, front-end-testing, react-testing, ci-debugging, hexagonal-architecture, domain-driven-design, twelve-factor, api-design, cli-design, finding-seams, characterisation-tests)"
+  echo -e "  ${GREEN}✓${NC} skills/ (own + external, installed via skills.sh)"
+  echo -e "     • citypaul/.dotfiles — auto-discovered patterns (tdd, testing, typescript-strict, ...)"
   if [[ "$INSTALL_EXTERNAL" == true ]]; then
-    echo -e "  ${GREEN}✓${NC} skills/ (6 web quality patterns: accessibility, best-practices, core-web-vitals, performance, seo, web-quality-audit)"
+    echo -e "     • addyosmani/web-quality-skills — accessibility, performance, SEO, ..."
   fi
   if [[ "$INSTALL_IMPECCABLE" == true ]]; then
-    echo -e "  ${GREEN}✓${NC} skills/ (18 impeccable design skills: impeccable core + 17 steering commands)"
+    echo -e "     • pbakaus/impeccable — design vocabulary + steering commands"
   fi
+  echo -e "     Run ${YELLOW}npx skills list -g${NC} to see everything installed."
 fi
 
 if [[ "$INSTALL_COMMANDS" == true ]]; then
@@ -582,15 +374,25 @@ if [[ "$INSTALL_OPENCODE" == true ]]; then
   echo -e "  ${GREEN}✓${NC} opencode.json (OpenCode rules configuration)"
   echo -e "  ${GREEN}✓${NC} command/ (slash commands from ~/.claude/commands/)"
   echo -e "  ${GREEN}✓${NC} agent/ (agents from ~/.claude/agents/)"
+  if [[ "$INSTALL_SKILLS" == true ]]; then
+    echo -e "  ${GREEN}✓${NC} skills also installed into OpenCode via skills.sh"
+  fi
 fi
 
 echo ""
-echo -e "${BLUE}Architecture (v3.0):${NC}"
+echo -e "${BLUE}Architecture:${NC}"
 echo ""
 echo -e "  ${YELLOW}CLAUDE.md${NC}  → Core principles (~100 lines, always loaded)"
-echo -e "  ${YELLOW}skills/${NC}    → Detailed patterns (loaded on-demand when relevant)"
+echo -e "  ${YELLOW}skills/${NC}    → Detailed patterns (loaded on-demand). Managed by ${YELLOW}npx skills${NC}"
 echo -e "  ${YELLOW}commands/${NC}  → Slash commands (manually invoked)"
 echo -e "  ${YELLOW}agents/${NC}    → Complex multi-step workflows"
+echo ""
+echo -e "${BLUE}Managing skills:${NC}"
+echo ""
+echo -e "  ${YELLOW}npx skills list -g${NC}              List installed skills"
+echo -e "  ${YELLOW}npx skills update -g${NC}            Update skills to latest"
+echo -e "  ${YELLOW}npx skills find <query>${NC}         Search skills.sh for more skills"
+echo -e "  ${YELLOW}npx skills remove -g <name>${NC}     Uninstall a skill"
 echo ""
 echo -e "${BLUE}Next steps:${NC}"
 echo ""
@@ -610,12 +412,12 @@ if [[ "$INSTALL_AGENTS" == true ]]; then
   echo ""
 fi
 
-if [[ "$INSTALL_OPENCODE" == false ]]; then
-  echo -e "${BLUE}Using OpenCode?${NC}"
+if [[ "$INSTALL_OPENCODE" == false && "$INSTALL_SKILLS" == true ]]; then
+  echo -e "${BLUE}Using OpenCode (or another agent)?${NC}"
   echo ""
-  echo -e "  All skills, commands, and agents also work with OpenCode."
-  echo -e "  Re-run with ${YELLOW}--with-opencode${NC} to set up everything in"
-  echo -e "  ~/.config/opencode/ so slash commands and agents show up."
+  echo -e "  Skills installed via skills.sh work with 40+ agents."
+  echo -e "  Re-run with ${YELLOW}--with-opencode${NC} to also target OpenCode, or run"
+  echo -e "  ${YELLOW}npx skills add $OWN_SKILLS_REPO -g -a <agent>${NC} to add another agent."
   echo ""
 fi
 
@@ -624,80 +426,38 @@ if [[ "$INSTALL_IMPECCABLE" == true && "$INSTALL_SKILLS" == true ]]; then
   echo -e "${BLUE}║  Impeccable Design Skills - Quick Start Guide      ║${NC}"
   echo -e "${BLUE}╚════════════════════════════════════════════════════╝${NC}"
   echo ""
-  echo -e "  Impeccable is a comprehensive frontend design system that replaces"
-  echo -e "  generic AI aesthetics with distinctive, high-quality interfaces."
-  echo -e "  It works through three modes and 17 steering commands."
+  echo -e "  Impeccable is a frontend design vocabulary that guides AI coding"
+  echo -e "  tools toward distinctive, high-quality interfaces."
   echo ""
-  echo -e "  ${YELLOW}Step 1: Set up design context (once per project)${NC}"
+  echo -e "  ${YELLOW}Getting started:${NC}"
+  echo -e "    ${GREEN}/impeccable teach${NC}   Set up design context for your project"
+  echo -e "    ${GREEN}/impeccable craft${NC}   Shape, build, and iterate on a feature"
+  echo -e "    ${GREEN}/impeccable extract${NC} Pull reusable components and tokens"
   echo ""
-  echo -e "    Run ${GREEN}/impeccable teach${NC} in any project. It will interview you"
-  echo -e "    about your target audience, use cases, and brand personality,"
-  echo -e "    then save the context to ${YELLOW}.impeccable.md${NC} in your project root."
-  echo -e "    Every design skill reads this file before doing work, so you"
-  echo -e "    never get generic output."
+  echo -e "  ${YELLOW}Steering commands:${NC}"
+  echo -e "    /shape /critique /audit /polish /typeset /colorize /animate"
+  echo -e "    /layout /harden /clarify /adapt /bolder /quieter /distill"
+  echo -e "    /delight /optimize /overdrive"
   echo ""
-  echo -e "  ${YELLOW}Step 2: Build features with the craft flow${NC}"
-  echo ""
-  echo -e "    Run ${GREEN}/impeccable craft [feature description]${NC} for the full flow:"
-  echo ""
-  echo -e "      1. ${YELLOW}/shape${NC}      Produces a design brief (UX planning, no code)"
-  echo -e "      2. Load refs   Pulls in typography, color, spatial, motion guides"
-  echo -e "      3. Build       Implements the feature following the brief"
-  echo -e "      4. Iterate     Visual review against brief + AI slop test"
-  echo -e "      5. Present     Shows the result and asks for feedback"
-  echo ""
-  echo -e "  ${YELLOW}Step 3: Use steering commands for targeted work${NC}"
-  echo ""
-  echo -e "    ${GREEN}/typeset${NC}    Fix typography, font selection, hierarchy"
-  echo -e "    ${GREEN}/colorize${NC}   Add strategic color using the OKLCH model"
-  echo -e "    ${GREEN}/layout${NC}     Fix spacing, rhythm, visual hierarchy"
-  echo -e "    ${GREEN}/animate${NC}    Add purposeful animations and micro-interactions"
-  echo -e "    ${GREEN}/clarify${NC}    Improve UX copy, error messages, labels"
-  echo -e "    ${GREEN}/adapt${NC}      Adapt for different screens, devices, platforms"
-  echo -e "    ${GREEN}/bolder${NC}     Amplify designs that feel too safe or generic"
-  echo -e "    ${GREEN}/quieter${NC}    Tone down designs that feel too aggressive"
-  echo -e "    ${GREEN}/distill${NC}    Strip a design down to its essence"
-  echo -e "    ${GREEN}/delight${NC}    Add moments of joy and personality"
-  echo -e "    ${GREEN}/overdrive${NC}  Extraordinary effects (shaders, WebGL, spring physics)"
-  echo -e "    ${GREEN}/optimize${NC}   Frontend performance improvements"
-  echo ""
-  echo -e "  ${YELLOW}Step 4: Quality gates before shipping${NC}"
-  echo ""
-  echo -e "    ${GREEN}/critique${NC}   Full UX review scored against Nielsen's 10 heuristics"
-  echo -e "    ${GREEN}/audit${NC}      Technical quality scoring across 5 dimensions"
-  echo -e "    ${GREEN}/polish${NC}     Final quality pass with comprehensive checklist"
-  echo -e "    ${GREEN}/harden${NC}     Production hardening (i18n, text overflow, edge cases)"
-  echo ""
-  echo -e "  ${YELLOW}Step 5: Extract reusable patterns${NC}"
-  echo ""
-  echo -e "    Run ${GREEN}/impeccable extract [target]${NC} to pull reusable components"
-  echo -e "    and design tokens into your design system."
-  echo ""
-  echo -e "  ${BLUE}Full documentation:${NC}"
-  echo -e "    ${YELLOW}https://impeccable.style/skills/${NC}"
-  echo -e "    ${YELLOW}https://github.com/citypaul/.dotfiles#-impeccable-design${NC}"
+  echo -e "  ${BLUE}Full documentation: https://impeccable.style/skills/${NC}"
   echo ""
 fi
 
 echo -e "${BLUE}Acknowledgments:${NC}"
 echo ""
-echo -e "  This project includes contributions and adapted work from:"
+echo -e "  Skills ecosystem: ${YELLOW}skills.sh${NC} (${BLUE}https://skills.sh${NC})"
 echo ""
-echo -e "  • ${YELLOW}Addy Osmani${NC} - Web quality skills (accessibility, performance, SEO,"
-echo -e "    core-web-vitals, best-practices, web-quality-audit)"
-echo -e "    ${BLUE}https://github.com/addyosmani/web-quality-skills${NC} (MIT License)"
+echo -e "  • ${YELLOW}Addy Osmani${NC} — web quality skills"
+echo -e "    ${BLUE}https://github.com/addyosmani/web-quality-skills${NC} (MIT)"
 echo ""
-echo -e "  • ${YELLOW}Kieran O'Hara${NC} - use-case-data-patterns agent"
+echo -e "  • ${YELLOW}Paul Bakaus${NC} — impeccable frontend design skills"
+echo -e "    ${BLUE}https://impeccable.style/skills/${NC} (Apache 2.0)"
+echo ""
+echo -e "  • ${YELLOW}Kieran O'Hara${NC} — use-case-data-patterns agent"
 echo -e "    ${BLUE}https://github.com/kieran-ohara/dotfiles${NC}"
 echo ""
-echo -e "  • ${YELLOW}Andrea Laforgia${NC} - test-design-reviewer skill"
+echo -e "  • ${YELLOW}Andrea Laforgia${NC} — test-design-reviewer skill"
 echo -e "    ${BLUE}https://github.com/andlaf-ak/claude-code-agents${NC}"
-echo ""
-echo -e "  • ${YELLOW}Paul Bakaus${NC} - Impeccable frontend design skills (impeccable core"
-echo -e "    + 17 steering commands: shape, critique, audit, polish, harden, typeset,"
-echo -e "    colorize, animate, layout, clarify, adapt, bolder, quieter, distill,"
-echo -e "    delight, optimize, overdrive)"
-echo -e "    ${BLUE}https://impeccable.style/skills/${NC} (Apache 2.0 License)"
 echo ""
 echo -e "${BLUE}For help or issues:${NC}"
 echo -e "  ${YELLOW}https://github.com/citypaul/.dotfiles${NC}"

--- a/install-claude.sh
+++ b/install-claude.sh
@@ -230,6 +230,45 @@ backup_file() {
   fi
 }
 
+# Migrate skill directories left behind by the pre-skills.sh curl-based
+# installer. Those were written as regular directories at ~/.claude/skills/<name>;
+# the skills CLI will then manage them in-place as Claude-Code-specific installs
+# instead of routing them through the universal ~/.agents/skills/ cache, which
+# is where Codex (and other "universal" agents) read from. Moving them aside
+# lets the CLI install each source into the universal path on this run, so the
+# Claude-side entries become symlinks and the same skills become visible to
+# Codex/OpenCode/etc.
+#
+# The files are moved, not deleted — everything ends up under
+# ~/.claude/skills.pre-skills-sh.<timestamp>/ and can be restored manually.
+migrate_legacy_skill_dirs() {
+  local skills_dir=~/.claude/skills
+  [[ -d "$skills_dir" ]] || return 0
+
+  local stale=()
+  local entry name
+  for entry in "$skills_dir"/*/; do
+    [[ -d "$entry" ]] || continue
+    name="$(basename "$entry")"
+    [[ -L "$skills_dir/$name" ]] && continue
+    stale+=("$name")
+  done
+
+  if [[ ${#stale[@]} -eq 0 ]]; then
+    return 0
+  fi
+
+  local backup="$skills_dir.pre-skills-sh.$(date +%Y%m%d_%H%M%S)"
+  echo -e "${YELLOW}→${NC} Found ${#stale[@]} pre-skills.sh skill director$([[ ${#stale[@]} -eq 1 ]] && echo "y" || echo "ies") at ~/.claude/skills/"
+  echo -e "${YELLOW}→${NC} Moving to $backup so the skills CLI can route them through the universal path"
+  mkdir -p "$backup"
+  for name in "${stale[@]}"; do
+    mv "$skills_dir/$name" "$backup/"
+    echo -e "   • $name"
+  done
+  echo ""
+}
+
 # Install skills from a skills.sh source for the selected agents
 install_skills_from() {
   local source="$1"
@@ -251,6 +290,32 @@ install_skills_from() {
   else
     echo -e "${RED}✗${NC} Failed to install $label from $source"
     return 1
+  fi
+}
+
+# Verify skills landed in the universal cache — the path Codex and other
+# "universal agents" read from. Regular (non-symlink) directories under
+# ~/.claude/skills/ after install mean something routed through the
+# Claude-Code-specific path and won't be visible to non-Claude agents.
+verify_skills_installed() {
+  local skills_dir=~/.claude/skills
+  [[ -d "$skills_dir" ]] || return 0
+
+  local stale=() entry name
+  for entry in "$skills_dir"/*/; do
+    [[ -d "$entry" ]] || continue
+    name="$(basename "$entry")"
+    [[ -L "$skills_dir/$name" ]] && continue
+    stale+=("$name")
+  done
+
+  if [[ ${#stale[@]} -gt 0 ]]; then
+    echo -e "${YELLOW}⚠${NC}  ${#stale[@]} skill(s) ended up as regular directories under ~/.claude/skills/"
+    echo -e "    These won't be visible to non-Claude agents (Codex, etc.):"
+    for name in "${stale[@]}"; do
+      echo -e "      • $name"
+    done
+    echo -e "    Re-run ${YELLOW}$0 --skills-only${NC} to migrate them, or remove via ${YELLOW}npx skills remove -g -s <name>${NC}."
   fi
 }
 
@@ -278,6 +343,8 @@ if [[ "$INSTALL_SKILLS" == true ]]; then
   echo -e "${YELLOW}→${NC} (Pass --agent <name> to target more — see skills.sh for the full list)"
   echo ""
 
+  migrate_legacy_skill_dirs
+
   install_skills_from "$OWN_SKILLS_REPO" "own skills (citypaul/.dotfiles)"
 
   if [[ "$INSTALL_EXTERNAL" == true ]]; then
@@ -288,6 +355,8 @@ if [[ "$INSTALL_SKILLS" == true ]]; then
     install_skills_from "$IMPECCABLE_SKILLS_REPO" "impeccable design skills (pbakaus/impeccable)"
   fi
 
+  echo ""
+  verify_skills_installed
   echo ""
 fi
 

--- a/install-claude.sh
+++ b/install-claude.sh
@@ -44,6 +44,11 @@ OWN_SKILLS_REPO="citypaul/.dotfiles"
 WEB_QUALITY_SKILLS_REPO="addyosmani/web-quality-skills"
 IMPECCABLE_SKILLS_REPO="pbakaus/impeccable"
 
+# Agents to target when installing skills via `npx skills add`.
+# Built up from --agent/--with-opencode flags; default is claude-code only.
+SKILL_AGENTS=(claude-code)
+INCLUDE_CLAUDE_CODE=true
+
 # Parse arguments
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -71,8 +76,21 @@ while [[ $# -gt 0 ]]; do
       INSTALL_AGENTS=true
       shift
       ;;
+    --agent)
+      if [[ -z "${2:-}" || "$2" == --* ]]; then
+        echo -e "${RED}Error: --agent requires a value (e.g. codex, cursor, copilot)${NC}"
+        exit 1
+      fi
+      SKILL_AGENTS+=("$2")
+      shift 2
+      ;;
+    --no-claude-code)
+      INCLUDE_CLAUDE_CODE=false
+      shift
+      ;;
     --with-opencode)
       INSTALL_OPENCODE=true
+      SKILL_AGENTS+=(opencode)
       shift
       ;;
     --opencode-only)
@@ -107,23 +125,31 @@ Usage:
   $0 [OPTIONS]
 
 Options:
-  --claude-only      Install only CLAUDE.md
-  --no-agents        Install without agents
-  --skills-only      Install only skills (via skills.sh)
-  --agents-only      Install only agents
-  --with-opencode    Also target the OpenCode agent for skills + install OpenCode config
-  --opencode-only    Install only OpenCode configuration (commands + agents + skills)
-  --no-external      Skip all external community skills (web-quality-skills + impeccable)
-  --no-impeccable    Skip impeccable design skills only
-  --version VERSION  Version for CLAUDE.md/commands/agents (default: main). Skills always latest.
-  --help, -h         Show this help message
+  --claude-only        Install only CLAUDE.md
+  --no-agents          Install without agents
+  --skills-only        Install only skills (via skills.sh)
+  --agents-only        Install only agents
+  --agent NAME         Also install skills for agent NAME (repeatable:
+                       --agent codex --agent cursor). Default target is
+                       claude-code. See skills.sh for the full agent list.
+  --no-claude-code     Skip the default claude-code target for skills
+                       (use with --agent to target other agents only)
+  --with-opencode      Shorthand for --agent opencode + install OpenCode config
+  --opencode-only      Install only OpenCode configuration (no skills/agents/commands)
+  --no-external        Skip all external community skills (web-quality-skills + impeccable)
+  --no-impeccable      Skip impeccable design skills only
+  --version VERSION    Version for CLAUDE.md/commands/agents (default: main). Skills always latest.
+  --help, -h           Show this help message
 
 Examples:
   # Install everything (recommended)
   $0
 
-  # Install only skills for both Claude Code and OpenCode
-  $0 --skills-only --with-opencode
+  # Install skills for Claude Code + Codex + Cursor
+  $0 --skills-only --agent codex --agent cursor
+
+  # Install only skills for Codex (no Claude Code)
+  $0 --skills-only --no-claude-code --agent codex
 
   # One-liner installation
   curl -fsSL https://raw.githubusercontent.com/citypaul/.dotfiles/main/install-claude.sh | bash
@@ -138,6 +164,28 @@ EOF
       ;;
   esac
 done
+
+# Honour --no-claude-code by stripping claude-code from the target list
+if [[ "$INCLUDE_CLAUDE_CODE" == false ]]; then
+  _filtered=()
+  for agent in "${SKILL_AGENTS[@]}"; do
+    [[ "$agent" == "claude-code" ]] && continue
+    _filtered+=("$agent")
+  done
+  SKILL_AGENTS=("${_filtered[@]}")
+fi
+
+# De-duplicate agent list while preserving order
+if [[ ${#SKILL_AGENTS[@]} -gt 0 ]]; then
+  SKILL_AGENTS=($(printf "%s\n" "${SKILL_AGENTS[@]}" | awk '!seen[$0]++'))
+fi
+
+# Validate: if we're installing skills, we need at least one agent to target
+if [[ "$INSTALL_SKILLS" == true && ${#SKILL_AGENTS[@]} -eq 0 ]]; then
+  echo -e "${RED}Error: no agents selected for skill install${NC}"
+  echo -e "${YELLOW}Pass --agent <name> or drop --no-claude-code${NC}"
+  exit 1
+fi
 
 echo -e "${BLUE}╔════════════════════════════════════════════════════╗${NC}"
 echo -e "${BLUE}║  CLAUDE.md Development Framework Installer         ║${NC}"
@@ -187,15 +235,15 @@ install_skills_from() {
   local source="$1"
   local label="$2"
 
-  echo -e "${YELLOW}→${NC} Installing $label from $source..."
+  echo -e "${YELLOW}→${NC} Installing $label from $source for: ${SKILL_AGENTS[*]}"
 
-  # Build agent flags based on install flags
-  local agent_args=(-a claude-code)
-  if [[ "$INSTALL_OPENCODE" == true ]]; then
-    agent_args+=(-a opencode)
-  fi
+  # Build -a flags from the SKILL_AGENTS array
+  local agent_args=()
+  for agent in "${SKILL_AGENTS[@]}"; do
+    agent_args+=(-a "$agent")
+  done
 
-  # -g: install globally (~/.claude/skills, ~/.config/opencode/...)
+  # -g: install globally (per-agent paths managed by the skills CLI)
   # -s '*': install all skills from the source
   # -y: skip prompts
   if npx --yes skills add "$source" -g "${agent_args[@]}" -s '*' -y; then
@@ -223,10 +271,11 @@ if [[ "$INSTALL_CLAUDE" == true ]]; then
   echo ""
 fi
 
-# Install skills via skills.sh CLI (multi-agent: Claude Code, OpenCode, ...)
+# Install skills via skills.sh CLI (multi-agent)
 if [[ "$INSTALL_SKILLS" == true ]]; then
   echo -e "${BLUE}Installing skills via skills.sh...${NC}"
-  echo -e "${YELLOW}→${NC} Multi-agent CLI — supports Claude Code, Cursor, Codex, Copilot, OpenCode, Gemini CLI, and 40+ others"
+  echo -e "${YELLOW}→${NC} Target agents: ${SKILL_AGENTS[*]}"
+  echo -e "${YELLOW}→${NC} (Pass --agent <name> to target more — see skills.sh for the full list)"
   echo ""
 
   install_skills_from "$OWN_SKILLS_REPO" "own skills (citypaul/.dotfiles)"
@@ -349,7 +398,7 @@ if [[ "$INSTALL_CLAUDE" == true ]]; then
 fi
 
 if [[ "$INSTALL_SKILLS" == true ]]; then
-  echo -e "  ${GREEN}✓${NC} skills/ (own + external, installed via skills.sh)"
+  echo -e "  ${GREEN}✓${NC} skills (installed via skills.sh for: ${SKILL_AGENTS[*]})"
   echo -e "     • citypaul/.dotfiles — auto-discovered patterns (tdd, testing, typescript-strict, ...)"
   if [[ "$INSTALL_EXTERNAL" == true ]]; then
     echo -e "     • addyosmani/web-quality-skills — accessibility, performance, SEO, ..."
@@ -357,7 +406,7 @@ if [[ "$INSTALL_SKILLS" == true ]]; then
   if [[ "$INSTALL_IMPECCABLE" == true ]]; then
     echo -e "     • pbakaus/impeccable — design vocabulary + steering commands"
   fi
-  echo -e "     Run ${YELLOW}npx skills list -g${NC} to see everything installed."
+  echo -e "     Run ${YELLOW}npx skills list -g${NC} to see paths for each agent."
 fi
 
 if [[ "$INSTALL_COMMANDS" == true ]]; then
@@ -412,12 +461,12 @@ if [[ "$INSTALL_AGENTS" == true ]]; then
   echo ""
 fi
 
-if [[ "$INSTALL_OPENCODE" == false && "$INSTALL_SKILLS" == true ]]; then
-  echo -e "${BLUE}Using OpenCode (or another agent)?${NC}"
+if [[ "$INSTALL_SKILLS" == true ]]; then
+  echo -e "${BLUE}Want to target more agents?${NC}"
   echo ""
-  echo -e "  Skills installed via skills.sh work with 40+ agents."
-  echo -e "  Re-run with ${YELLOW}--with-opencode${NC} to also target OpenCode, or run"
-  echo -e "  ${YELLOW}npx skills add $OWN_SKILLS_REPO -g -a <agent>${NC} to add another agent."
+  echo -e "  Skills via skills.sh work with 40+ agents (Codex, Cursor, Copilot, Gemini CLI, ...)."
+  echo -e "  Re-run with ${YELLOW}--agent <name>${NC} (repeatable) to add more:"
+  echo -e "     ${YELLOW}$0 --skills-only --agent codex --agent cursor${NC}"
   echo ""
 fi
 


### PR DESCRIPTION
## Summary

- Replaces the three direct-curl skill install blocks (own, web-quality, impeccable) in `install-claude.sh` with `npx skills add` calls against [skills.sh](https://skills.sh). The skills ecosystem is multi-agent — supports Claude Code, Cursor, Codex, Copilot, OpenCode, Gemini CLI, and 40+ other agents — so skills are no longer Claude-exclusive.
- `--with-opencode` now appends `-a opencode` to the skills install instead of just copying the Claude-Code install over; other agents can be added with `npx skills add <source> -g -a <agent>`.
- Script shrinks from ~700 → ~370 lines. `CLAUDE.md`, slash commands, and agents still download directly from this repo (not skills).

## Why

Skills installed via the CLI are portable across 40+ coding agents, symlink to a single source of truth under `node_modules`, and can be managed with `npx skills list/update/find/remove` instead of re-running the whole installer.

## Notes / trade-offs

- `--version` still pins `CLAUDE.md`, commands, and agents, but skills always install from the latest upstream (the skills CLI doesn't surface a ref-pinning option yet).
- `--skills-only` now requires Node.js so `npx` is available; the script preflights and errors clearly if it's missing.
- On an existing install that used the old curl mechanism, re-running this backs up + replaces ~48 skill directories with CLI-managed symlinks — expected, but worth flagging before first run.

## Test plan

- [ ] `./install-claude.sh --help` prints the updated flag list
- [ ] `./install-claude.sh --skills-only` installs all three skill sources globally for claude-code
- [ ] `./install-claude.sh --skills-only --with-opencode` installs for both claude-code and opencode targets
- [ ] `./install-claude.sh --claude-only` still works with no Node installed
- [ ] `npx skills list -g` shows all expected skills after install
- [ ] `./install-claude.sh --no-impeccable --skills-only` skips pbakaus/impeccable
- [ ] `./install-claude.sh --no-external --skills-only` skips both external sources

🤖 Generated with [Claude Code](https://claude.com/claude-code)