### PR TITLE
Improve mutation testing skill

### DIFF
--- a/.changeset/large-masks-fix.md
+++ b/.changeset/large-masks-fix.md
@@ -1,0 +1,5 @@
+---
+"@paulhammond/dotfiles": minor
+---
+
+Improve mutation testing guidance with a Stryker-first workflow, an on-demand mutator-rules resource, full-project and diff-against-main commands, survivor triage, and mutation-aware TDD/testing guidance on when to fix issues directly versus asking for human judgment.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Unlike typical style guides, CLAUDE.md provides:
 | Section | What It Provides | Detailed Patterns |
 |---------|-----------------|-------------------|
 | **Testing Principles** | Behavior-driven testing, 100% coverage strategy, factory patterns | [→ skills/testing](claude/.claude/skills/testing/SKILL.md) |
-| **Mutation Testing** | Test effectiveness verification, mutation operators, weak test detection | [→ skills/mutation-testing](claude/.claude/skills/mutation-testing/SKILL.md) |
+| **Mutation Testing** | Stryker setup, full/diff mutation runs, survivor triage, mutator-rule resource | [→ skills/mutation-testing](claude/.claude/skills/mutation-testing/SKILL.md) |
 | **Test Design Review** | Dave Farley's 8 properties evaluation, Farley Score calculation, test quality assessment | [→ skills/test-design-reviewer](claude/.claude/skills/test-design-reviewer/SKILL.md) |
 | **Front-End Testing** | Vitest Browser Mode (preferred) + DOM Testing Library patterns, real browser testing with Playwright | [→ skills/front-end-testing](claude/.claude/skills/front-end-testing/SKILL.md) |
 | **React Testing** | Vitest Browser Mode with vitest-browser-react (preferred) + React Testing Library patterns | [→ skills/react-testing](claude/.claude/skills/react-testing/SKILL.md) |
@@ -219,12 +219,11 @@ it("should reject payments with negative amounts", () => {
 **Problem it solves:** 100% code coverage but bugs still slip through; tests that don't actually verify behavior; weak assertions that pass regardless of code correctness
 
 **What's inside:**
-- Comprehensive mutation operator reference (arithmetic, conditional, logical, boolean, method expressions)
-- Weak vs strong test examples for each operator type
-- Systematic 4-step branch analysis process
-- Equivalent mutant identification and handling
-- Test strengthening patterns
-- Integration with TDD workflow
+- Stryker-first workflow for full-project, incremental, and diff-against-main mutation runs
+- Setup guidance for projects that do not already have a mutation testing harness
+- Survivor triage: fix obvious gaps immediately, ask for human judgment on subtle domain questions
+- On-demand mutator-rule resource with operator reference and weak vs strong test examples
+- Equivalent mutant identification, CI guidance, and TDD-based test strengthening patterns
 
 **The core insight:**
 

--- a/claude/.claude/skills/mutation-testing/SKILL.md
+++ b/claude/.claude/skills/mutation-testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mutation-testing
-description: Mutation testing patterns for verifying test effectiveness. Use when analyzing branch code to find weak or missing tests.
+description: Set up and run mutation testing with Stryker, including full-project and diff-against-main runs, then use surviving mutants to strengthen weak or missing tests.
 ---
 
 # Mutation Testing
@@ -10,6 +10,14 @@ For writing good tests (factories, behavior-driven patterns), load the `testing`
 Mutation testing answers the question: **"Are my tests actually catching bugs?"**
 
 Code coverage tells you what code your tests execute. Mutation testing tells you if your tests would **detect changes** to that code. A test suite with 100% coverage can still miss 40% of potential bugs.
+
+**Default posture:** use an automated mutation harness first. For JavaScript and TypeScript projects, recommend Stryker as the starting point if it is not already set up. Use manual/mental mutations only as a fallback, a teaching aid, or a focused follow-up for subtle survivors.
+
+**Deep-dive resources** are in the `resources/` directory. Load them on demand:
+
+| Resource | Load when... |
+|----------|-------------|
+| `mutator-rules.md` | Planning tests, scanning changed code for likely gaps, manually applying mutations, or interpreting surviving/equivalent mutants |
 
 ---
 
@@ -35,512 +43,163 @@ Use mutation testing analysis when:
 - Finding missing edge case tests
 - Validating that refactoring didn't weaken test suite
 
-**Integration with TDD:**
+**Integration with planning and TDD:**
 
 ```
-RED-GREEN-MUTATE-REFACTOR Cycle
-┌─────────────────────────────────────────────────┐
-│ 1. RED:      Write failing test                 │
-│ 2. GREEN:    Minimum code to pass               │
-│ 3. MUTATE:   Verify tests catch real bugs  ◄──  │  ← You are here
-│ 4. REFACTOR: Improve structure with confidence  │
-└─────────────────────────────────────────────────┘
+FOR EACH STEP:
+    ├─► CONFIRM: Human approves observable acceptance criteria
+    ├─► RED: Write failing test, using mutator rules to spot likely gaps
+    ├─► GREEN: Make it pass
+    ├─► Run mutation testing
+    ├─► KILL MUTANTS: Strengthen tests for worthwhile survivors
+    ├─► REFACTOR: If valuable
+    └─► STOP: Present work, mutation report, and wait for commit approval
+
+PRE-PR QUALITY GATE:
+    └─► Re-run mutation testing for the branch/repo scope
 ```
 
-**Why MUTATE before REFACTOR:** Mutation testing validates test strength *before* you restructure code. Refactoring with unverified tests means restructuring code whose safety net you haven't checked.
+Mutation testing is not a replacement for RED-GREEN-REFACTOR. It verifies the tests created during those increments are strong enough to catch real behavioral regressions before refactoring and before PR.
 
 ---
 
-## Execution Process
+## Harness-First Mutation Workflow
 
-When verifying test effectiveness, **actually mutate the code and run the tests.** Do not just reason about whether tests would catch mutations — prove it.
+When analyzing code on a branch, prove test effectiveness with Stryker whenever practical. Do not stop at reasoning about whether a test would catch a mutation; run the harness, then use the report to drive focused test improvements.
 
-### Step 1: Identify Changed Code
+### Step 1: Inspect Setup and Scope
 
 ```bash
-# Get files changed on the branch
-git diff main...HEAD --name-only | grep -E '\.(ts|js|tsx|jsx)$' | grep -v '\.test\.'
-
-# Get detailed diff for analysis
-git diff main...HEAD -- src/
+rg --files | rg '(^|/)(package.json|stryker\.config\.(mjs|cjs|js|json)|stryker\.conf\.(js|json))$'
+git diff main...HEAD --name-only
 ```
 
-### Step 2: Apply Mutations and Run Tests
+- Identify the package manager, test runner, affected package(s), and existing Stryker config.
+- If the repo uses a base branch other than `main`, substitute that branch in all diff commands.
+- In monorepos, start in the smallest affected package, then widen to the repo-level command when the targeted run is healthy.
+- If no Stryker setup exists in a JS/TS project, recommend adding it before doing manual mutation analysis.
 
-For each changed function/method, work through the mutation operators (see Mutation Operators section below). For each applicable mutation:
+### Step 2: Set Up Stryker When Missing
 
-1. **Mutate**: Change the production code (e.g., flip `*` to `/`, negate a condition)
-2. **Run**: Execute the test suite
-3. **Evaluate**: Did a test fail?
-   - **Yes** → mutant killed (good). Revert the mutation.
-   - **No** → mutant survived (bad). Revert the mutation, then add or strengthen a test.
-4. **Revert**: Always restore the original code before the next mutation
-
-**Always revert each mutation before applying the next.** Never leave mutated code in place.
-
-You do not need to apply every possible mutation to every line. Focus on:
-- Changed code on the branch
-- Operators most likely to have surviving mutants (see Quick Reference)
-- Conditions with boundary values
-- Boolean logic with multiple operands
-
-### Step 3: Produce a Report
-
-After working through the mutations, produce a summary:
-
-```markdown
-## Mutation Testing Report
-
-### Killed (tests caught the mutation)
-- `calculateTotal`: `*` → `/` — killed by "calculates total for multiple items"
-- `isEligible`: `>=` → `>` — killed by "returns true at exact boundary"
-
-### Survived (tests DID NOT catch the mutation)
-- `applyDiscount`: `>` → `>=` — no test for boundary value at exactly 100
-  → **Action**: Add boundary test for discount threshold
-
-### Summary
-- Mutations applied: 8
-- Killed: 6
-- Survived: 2
-- Mutation score: 75%
-```
-
-### Step 4: Kill Surviving Mutants
-
-Not every surviving mutant warrants a new test. Some mutations produce equivalent behavior, and some boundary cases are low-risk enough that the test would add noise without meaningful protection.
-
-**Fix immediately** when:
-- The mutation represents a realistic bug (wrong operator, inverted condition)
-- The surviving mutant is in critical business logic (money, permissions, eligibility)
-- The fix is a simple boundary test or stronger assertion
-
-**Ask the human** when:
-- You're unsure whether the mutation represents a real risk
-- The test to kill it would be complex or hard to name clearly
-- The mutation is in a code path that's also covered by integration/E2E tests
-- The surviving mutant feels like an equivalent mutant but you're not certain
-
-Present the mutation, explain why the current tests don't catch it, and let the human decide whether it's worth a new test.
-
-When fixing, follow TDD — write the failing test first, verify it fails against the mutated code, then verify it passes against the original code.
-
----
-
-## Mutation Operators
-
-### Arithmetic Operator Mutations
-
-| Original | Mutated | Test Should Verify |
-|----------|---------|-------------------|
-| `a + b` | `a - b` | Addition behavior |
-| `a - b` | `a + b` | Subtraction behavior |
-| `a * b` | `a / b` | Multiplication behavior |
-| `a / b` | `a * b` | Division behavior |
-| `a % b` | `a * b` | Modulo behavior |
-
-**Example Analysis:**
-
-```typescript
-// Production code
-const calculateTotal = (price: number, quantity: number): number => {
-  return price * quantity;
-};
-
-// Mutant: price / quantity
-// Question: Would tests fail if * became /?
-
-// ❌ WEAK TEST - Would NOT catch mutant
-it('calculates total', () => {
-  expect(calculateTotal(10, 1)).toBe(10); // 10 * 1 = 10, 10 / 1 = 10 (SAME!)
-});
-
-// ✅ STRONG TEST - Would catch mutant
-it('calculates total', () => {
-  expect(calculateTotal(10, 3)).toBe(30); // 10 * 3 = 30, 10 / 3 = 3.33 (DIFFERENT!)
-});
-```
-
-### Conditional Expression Mutations
-
-| Original | Mutated | Test Should Verify |
-|----------|---------|-------------------|
-| `a < b` | `a <= b` | Boundary value at equality |
-| `a < b` | `a >= b` | Both sides of condition |
-| `a <= b` | `a < b` | Boundary value at equality |
-| `a <= b` | `a > b` | Both sides of condition |
-| `a > b` | `a >= b` | Boundary value at equality |
-| `a > b` | `a <= b` | Both sides of condition |
-| `a >= b` | `a > b` | Boundary value at equality |
-| `a >= b` | `a < b` | Both sides of condition |
-
-**Example Analysis:**
-
-```typescript
-// Production code
-const isAdult = (age: number): boolean => {
-  return age >= 18;
-};
-
-// Mutant: age > 18
-// Question: Would tests fail if >= became >?
-
-// ❌ WEAK TEST - Would NOT catch boundary mutant
-it('returns true for adults', () => {
-  expect(isAdult(25)).toBe(true);  // 25 >= 18 = true, 25 > 18 = true (SAME!)
-});
-
-// ✅ STRONG TEST - Would catch boundary mutant
-it('returns true for exactly 18', () => {
-  expect(isAdult(18)).toBe(true);  // 18 >= 18 = true, 18 > 18 = false (DIFFERENT!)
-});
-```
-
-### Equality Operator Mutations
-
-| Original | Mutated | Test Should Verify |
-|----------|---------|-------------------|
-| `a === b` | `a !== b` | Both equal and not equal cases |
-| `a !== b` | `a === b` | Both equal and not equal cases |
-| `a == b` | `a != b` | Both equal and not equal cases |
-| `a != b` | `a == b` | Both equal and not equal cases |
-
-### Logical Operator Mutations
-
-| Original | Mutated | Test Should Verify |
-|----------|---------|-------------------|
-| `a && b` | `a \|\| b` | Case where one is true, other is false |
-| `a \|\| b` | `a && b` | Case where one is true, other is false |
-| `a ?? b` | `a && b` | Nullish coalescing behavior |
-
-**Example Analysis:**
-
-```typescript
-// Production code
-const canAccess = (isAdmin: boolean, isOwner: boolean): boolean => {
-  return isAdmin || isOwner;
-};
-
-// Mutant: isAdmin && isOwner
-// Question: Would tests fail if || became &&?
-
-// ❌ WEAK TEST - Would NOT catch mutant
-it('returns true when both conditions met', () => {
-  expect(canAccess(true, true)).toBe(true);  // true || true = true && true (SAME!)
-});
-
-// ✅ STRONG TEST - Would catch mutant
-it('returns true when only admin', () => {
-  expect(canAccess(true, false)).toBe(true);  // true || false = true, true && false = false (DIFFERENT!)
-});
-```
-
-### Boolean Literal Mutations
-
-| Original | Mutated | Test Should Verify |
-|----------|---------|-------------------|
-| `true` | `false` | Both true and false outcomes |
-| `false` | `true` | Both true and false outcomes |
-| `!(a)` | `a` | Negation is necessary |
-
-### Block Statement Mutations
-
-| Original | Mutated | Test Should Verify |
-|----------|---------|-------------------|
-| `{ code }` | `{ }` | Side effects of the block |
-
-**Example Analysis:**
-
-```typescript
-// Production code
-const processOrder = (order: Order): void => {
-  validateOrder(order);
-  saveOrder(order);
-  sendConfirmation(order);
-};
-
-// Mutant: Empty function body
-// Question: Would tests fail if all statements removed?
-
-// ❌ WEAK TEST - Would NOT catch mutant
-it('processes order without error', () => {
-  expect(() => processOrder(order)).not.toThrow();  // Empty function also doesn't throw!
-});
-
-// ✅ STRONG TEST - Would catch mutant
-it('saves order to database', () => {
-  processOrder(order);
-  expect(mockDatabase.save).toHaveBeenCalledWith(order);
-});
-```
-
-### String Literal Mutations
-
-| Original | Mutated | Test Should Verify |
-|----------|---------|-------------------|
-| `"text"` | `""` | Non-empty string behavior |
-| `""` | `"Stryker was here!"` | Empty string behavior |
-
-### Array Declaration Mutations
-
-| Original | Mutated | Test Should Verify |
-|----------|---------|-------------------|
-| `[1, 2, 3]` | `[]` | Non-empty array behavior |
-| `new Array(1, 2)` | `new Array()` | Array contents matter |
-
-### Unary Operator Mutations
-
-| Original | Mutated | Test Should Verify |
-|----------|---------|-------------------|
-| `+a` | `-a` | Sign matters |
-| `-a` | `+a` | Sign matters |
-| `++a` | `--a` | Increment vs decrement |
-| `a++` | `a--` | Increment vs decrement |
-
-### Method Expression Mutations (TypeScript/JavaScript)
-
-| Original | Mutated | Test Should Verify |
-|----------|---------|-------------------|
-| `startsWith()` | `endsWith()` | Correct string position |
-| `endsWith()` | `startsWith()` | Correct string position |
-| `toUpperCase()` | `toLowerCase()` | Case transformation |
-| `toLowerCase()` | `toUpperCase()` | Case transformation |
-| `some()` | `every()` | Partial vs full match |
-| `every()` | `some()` | Full vs partial match |
-| `filter()` | (removed) | Filtering is necessary |
-| `reverse()` | (removed) | Order matters |
-| `sort()` | (removed) | Ordering is necessary |
-| `min()` | `max()` | Correct extremum |
-| `max()` | `min()` | Correct extremum |
-| `trim()` | `trimStart()` | Correct trim behavior |
-
-### Optional Chaining Mutations
-
-| Original | Mutated | Test Should Verify |
-|----------|---------|-------------------|
-| `foo?.bar` | `foo.bar` | Null/undefined handling |
-| `foo?.[i]` | `foo[i]` | Null/undefined handling |
-| `foo?.()` | `foo()` | Null/undefined handling |
-
----
-
-## Mutant States and Metrics
-
-### Mutant States
-
-| State | Meaning | Action |
-|-------|---------|--------|
-| **Killed** | Test failed when mutant applied | Good - tests are effective |
-| **Survived** | Tests passed with mutant active | Bad - add/strengthen test |
-| **No Coverage** | No test exercises this code | Add behavior test |
-| **Timeout** | Tests timed out (infinite loop) | Counted as detected |
-| **Equivalent** | Mutant produces same behavior | No action - not a real bug |
-
-### Metrics
-
-- **Mutation Score**: `killed / valid * 100` - The higher, the better
-- **Detected**: `killed + timeout`
-- **Undetected**: `survived + no coverage`
-
-### Target Mutation Score
-
-| Score | Quality |
-|-------|---------|
-| < 60% | Weak test suite - significant gaps |
-| 60-80% | Moderate - many improvements possible |
-| 80-90% | Good - but still gaps to address |
-| > 90% | Strong - but watch for equivalent mutants |
-
----
-
-## Equivalent Mutants
-
-Equivalent mutants produce the same behavior as the original code. They cannot be killed because there is no observable difference.
-
-### Common Equivalent Mutant Patterns
-
-**Pattern 1: Operations with identity elements**
-
-```typescript
-// Mutant in conditional where both branches have same effect
-if (whatever) {
-  number += 0;  // Can mutate to -= 0, *= 1, /= 1 - all equivalent!
-} else {
-  number += 0;
-}
-```
-
-**Pattern 2: Boundary conditions that don't affect outcome**
-
-```typescript
-// When max equals min, condition doesn't matter
-const max = Math.max(a, b);
-const min = Math.min(a, b);
-if (a >= b) {  // Mutating to <= or < has no effect when a === b
-  result = 10 ** (max - min);  // 10 ** 0 = 1 regardless
-}
-```
-
-**Pattern 3: Dead code paths**
-
-```typescript
-// If this path is never reached, mutations don't matter
-if (impossibleCondition) {
-  doSomething();  // Mutating this won't affect behavior
-}
-```
-
-### How to Handle Equivalent Mutants
-
-1. **Identify**: Analyze if mutation truly changes observable behavior
-2. **Document**: Note why mutant is equivalent
-3. **Accept**: 100% mutation score may not be achievable
-4. **Consider refactoring**: Sometimes equivalent mutants indicate unclear code
-
----
-
-## Branch Analysis Checklist
-
-When analyzing code changes on a branch:
-
-### For Each Function/Method Changed:
-
-- [ ] **Arithmetic operators**: Would changing +, -, *, / be detected?
-- [ ] **Conditionals**: Are boundary values tested (>=, <=)?
-- [ ] **Boolean logic**: Are all branches of &&, || tested?
-- [ ] **Return statements**: Would changing return value be detected?
-- [ ] **Method calls**: Would removing or swapping methods be detected?
-- [ ] **String literals**: Would empty strings be detected?
-- [ ] **Array operations**: Would empty arrays be detected?
-
-### Red Flags (Likely Surviving Mutants):
-
-- [ ] Tests only verify "no error thrown"
-- [ ] Tests only check one side of a condition
-- [ ] Tests use identity values (0, 1, empty string)
-- [ ] Tests only verify function was called, not with what
-- [ ] Tests don't verify return values
-- [ ] Boundary values not tested
-
-### Questions to Ask:
-
-1. "If I changed this operator, would a test fail?"
-2. "If I negated this condition, would a test fail?"
-3. "If I removed this line, would a test fail?"
-4. "If I returned early here, would a test fail?"
-
----
-
-## Strengthening Weak Tests
-
-### Pattern: Add Boundary Value Tests
-
-```typescript
-// Original weak test
-it('validates age', () => {
-  expect(isAdult(25)).toBe(true);
-  expect(isAdult(10)).toBe(false);
-});
-
-// Strengthened with boundary values
-it('validates age at boundary', () => {
-  expect(isAdult(17)).toBe(false);  // Just below
-  expect(isAdult(18)).toBe(true);   // Exactly at boundary
-  expect(isAdult(19)).toBe(true);   // Just above
-});
-```
-
-### Pattern: Test Both Branches of Conditions
-
-```typescript
-// Original weak test - only tests one branch
-it('returns access result', () => {
-  expect(canAccess(true, true)).toBe(true);
-});
-
-// Strengthened - tests all meaningful combinations
-it('grants access when admin', () => {
-  expect(canAccess(true, false)).toBe(true);
-});
-
-it('grants access when owner', () => {
-  expect(canAccess(false, true)).toBe(true);
-});
-
-it('denies access when neither', () => {
-  expect(canAccess(false, false)).toBe(false);
-});
-```
-
-### Pattern: Avoid Identity Values
-
-```typescript
-// Weak - uses identity values
-it('calculates', () => {
-  expect(multiply(10, 1)).toBe(10);  // x * 1 = x / 1
-  expect(add(5, 0)).toBe(5);         // x + 0 = x - 0
-});
-
-// Strong - uses values that reveal operator differences
-it('calculates', () => {
-  expect(multiply(10, 3)).toBe(30);  // 10 * 3 != 10 / 3
-  expect(add(5, 3)).toBe(8);         // 5 + 3 != 5 - 3
-});
-```
-
-### Pattern: Verify Side Effects
-
-```typescript
-// Weak - no verification of side effects
-it('processes order', () => {
-  processOrder(order);
-  // No assertions!
-});
-
-// Strong - verifies observable outcomes
-it('processes order', () => {
-  processOrder(order);
-  expect(orderRepository.save).toHaveBeenCalledWith(order);
-  expect(emailService.send).toHaveBeenCalledWith(
-    expect.objectContaining({ to: order.customerEmail })
-  );
-});
-```
-
----
-
-## Integration with Stryker (Optional)
-
-For automated mutation testing, use Stryker:
-
-### Installation
+Use the official initializer as the starting point:
 
 ```bash
-npm init stryker
+npm init stryker@latest
 ```
 
-### Configuration (stryker.conf.json)
+Then inspect and adapt the generated `stryker.config.*`:
+
+- Prefer the project test runner plugin when available (`vitest`, `jest`, `mocha`, etc.). Use the generic command runner only when no tighter integration is practical.
+- Mutate first-party production source only. Exclude tests, fixtures, snapshots, generated files, declaration files, build outputs, migrations, and low-signal barrels.
+- For TypeScript, consider `@stryker-mutator/typescript-checker` so type-invalid mutants are reported as compile errors instead of wasting test time.
+- Keep setup changes reviewable: add dependencies, config, scripts, and `.gitignore` entries for Stryker temp/report output only when the project needs them.
+
+### Step 3: Recommend Useful Commands
+
+Suggest project scripts for full-project, cached, and branch-diff mutation runs:
 
 ```json
 {
-  "testRunner": "jest",
-  "coverageAnalysis": "perTest",
-  "reporters": ["html", "clear-text", "progress"],
-  "mutate": ["src/**/*.ts", "!src/**/*.test.ts"]
+  "scripts": {
+    "mutation": "stryker run",
+    "mutation:incremental": "stryker run --incremental",
+    "mutation:diff": "node scripts/stryker-diff.mjs main"
+  }
 }
 ```
 
-### Running
+The `mutation:diff` helper should:
+
+- Read the base branch argument, defaulting to `main`.
+- Collect changed files with `git diff --name-only --diff-filter=ACMRTUXB <base>...HEAD`.
+- Keep changed production files matching the project's source extensions.
+- Exclude test/spec files, fixtures, snapshots, generated files, declaration files, and build output.
+- Run `stryker run --incremental --force --mutate <comma-separated-files>`.
+- Exit clearly when there are no changed production files to mutate.
+
+Prefer a small Node helper over dense shell inside `package.json`; quoting `*`, `!`, and command substitution is fragile across shells. For quick local use, this POSIX one-liner is acceptable:
 
 ```bash
-npx stryker run
+CHANGED=$(git diff --name-only --diff-filter=ACMRTUXB main...HEAD -- '*.ts' '*.tsx' '*.js' '*.jsx' | grep -Ev '(^|/)(__tests__|test|tests|fixtures|generated)/|\.(test|spec|d)\.' | paste -sd, -)
+test -n "$CHANGED" && npx stryker run --incremental --force --mutate "$CHANGED"
 ```
 
-### Incremental Mode (for branches)
+Use exact line ranges for tiny follow-up checks when the report points to a specific survivor:
 
 ```bash
-npx stryker run --incremental
+npx stryker run --incremental --force --mutate src/example.ts:42-57
 ```
+
+### Step 4: Run and Triage
+
+Start with `mutation:diff` for branch feedback. Run `mutation` across the full project when introducing Stryker, changing shared test infrastructure, preparing CI gates, or validating a broad test-strengthening pass.
+
+Categorize Stryker findings:
+
+| Category | Description | Action Required |
+|----------|-------------|-----------------|
+| Killed | Test failed when mutant was applied | None - tests are effective |
+| Survived | Tests passed with mutant active | Add/strengthen test, unless equivalent |
+| No Coverage | No test exercises this code | Add behavior test |
+| Equivalent | Mutant produces same behavior | None - not a real bug |
+
+Fix obvious issues immediately:
+
+- Missing boundary tests
+- Weak or absent assertions
+- One-sided branch coverage
+- Missing side-effect verification
+- High-value business rules such as money, permissions, eligibility, safety, or data loss
+
+Use the harness's ask-question facility for subtle survivors that require human judgment. Ask one concise question with concrete choices, explain the mutation, and describe the tradeoff. Use this when behavior is intentionally unspecified, the correct domain rule is unclear, the test would be expensive or brittle, or the mutant may be equivalent but you are not certain.
+
+### Step 5: Kill Survivors With TDD
+
+For each survivor worth killing:
+
+1. Keep or recreate the mutant.
+2. Write the smallest behavior test that fails against the mutant for the right reason.
+3. Restore the original production code.
+4. Verify the new test passes.
+5. Re-run Stryker scoped to the mutated file or line range, then re-run the diff command.
+
+Avoid overfitting tests to implementation details. Strong mutation tests assert observable behavior: return values, persisted state, emitted events, permissions, messages, or meaningful collaborator calls.
+
+## Stryker Configuration Guidance
+
+Stryker should be the normal entry point for JS/TS mutation testing.
+
+### Starting Configuration
+
+Prefer `stryker.config.mjs` or the format generated by the initializer. A typical starting point:
+
+```javascript
+export default {
+  testRunner: "vitest",
+  coverageAnalysis: "perTest",
+  reporters: ["html", "clear-text", "progress"],
+  mutate: [
+    "src/**/*.{ts,tsx,js,jsx}",
+    "!src/**/*.test.{ts,tsx,js,jsx}",
+    "!src/**/*.spec.{ts,tsx,js,jsx}",
+    "!src/**/*.d.ts"
+  ]
+}
+```
+
+Adapt `testRunner`, `mutate`, `testFiles`, build commands, and checker plugins to match the project. Do not cargo-cult this exact config into a repo with a different layout.
+
+### CI and Quality Gates
+
+- Start with report-only or diff-only mutation checks if the existing suite has many survivors.
+- Add failing thresholds only after establishing a realistic baseline.
+- Persist HTML and clear-text reports as CI artifacts.
+- Use incremental mode for fast local feedback, but periodically force a full run to avoid stale assumptions.
+- Treat mutation score as a signal, not a vanity metric. Prioritize surviving/no-coverage mutants in changed and high-risk code.
+
+### Manual Mutation Fallback
+
+If Stryker is unavailable or cannot target the code under review, load `resources/mutator-rules.md` and manually apply the relevant operators. Always revert each mutation before the next one. Manual mutation should still follow the same loop: mutate, run tests, classify, fix obvious gaps, ask about judgment calls, and report the result.
 
 ---
 
@@ -560,27 +219,5 @@ npx stryker run --incremental
 **Remember:**
 - Coverage measures execution, mutation testing measures detection
 - A test that doesn't make assertions can't kill mutants
-- Boundary values are critical for conditional mutations
-- Avoid identity values that make operators interchangeable
-
----
-
-## Quick Reference
-
-### Operators Most Likely to Have Surviving Mutants
-
-1. `>=` vs `>` (boundary not tested)
-2. `&&` vs `||` (only tested when both true/false)
-3. `+` vs `-` (only tested with 0)
-4. `*` vs `/` (only tested with 1)
-5. `some()` vs `every()` (only tested with all matching)
-
-### Test Values That Kill Mutants
-
-| Avoid | Use Instead |
-|-------|-------------|
-| 0 (for +/-) | Non-zero values |
-| 1 (for */) | Values > 1 |
-| Empty arrays | Arrays with multiple items |
-| Identical values for comparisons | Distinct values |
-| All true/false for logical ops | Mixed true/false |
+- Boundary values, mixed boolean cases, non-identity values, and observable side effects kill many common mutants
+- For the full mutator checklist and examples, load `resources/mutator-rules.md`

--- a/claude/.claude/skills/mutation-testing/resources/mutator-rules.md
+++ b/claude/.claude/skills/mutation-testing/resources/mutator-rules.md
@@ -1,0 +1,245 @@
+# Mutator Rules Reference
+
+Load this resource when planning tests, scanning changed code for likely test gaps, manually applying mutations, or interpreting surviving mutants from Stryker.
+
+## Quick Scan
+
+For each changed behavior, ask:
+
+- **Arithmetic operators**: Would changing `+`, `-`, `*`, `/`, or `%` be detected?
+- **Conditionals**: Are boundary values tested for `<`, `<=`, `>`, `>=`?
+- **Equality**: Are both equal and not-equal cases observable?
+- **Boolean logic**: Is there a mixed `true`/`false` case that distinguishes `&&` from `||`?
+- **Return statements**: Would changing or deleting the returned value fail?
+- **Method calls**: Would removing, swapping, or changing the method fail?
+- **String literals**: Would an empty or changed string fail?
+- **Array operations**: Would an empty array or removed filtering/sorting fail?
+- **Optional chaining**: Are `null` and `undefined` cases covered when safety is promised?
+- **Side effects**: Would deleting the body or skipping a collaborator call fail?
+
+Fix obvious gaps immediately. If the expected behavior is a domain/product judgment, ask the human using the harness's ask-question facility.
+
+## Mutation Operators
+
+### Arithmetic Operators
+
+| Original | Mutated | Test should verify |
+|----------|---------|-------------------|
+| `a + b` | `a - b` | Addition behavior |
+| `a - b` | `a + b` | Subtraction behavior |
+| `a * b` | `a / b` | Multiplication behavior |
+| `a / b` | `a * b` | Division behavior |
+| `a % b` | `a * b` | Modulo behavior |
+
+Avoid identity values that hide the difference: `0` for `+/-`, `1` for `*/`.
+
+### Conditional Expressions
+
+| Original | Mutated | Test should verify |
+|----------|---------|-------------------|
+| `a < b` | `a <= b` | Equality boundary |
+| `a < b` | `a >= b` | Both sides of condition |
+| `a <= b` | `a < b` | Equality boundary |
+| `a <= b` | `a > b` | Both sides of condition |
+| `a > b` | `a >= b` | Equality boundary |
+| `a > b` | `a <= b` | Both sides of condition |
+| `a >= b` | `a > b` | Equality boundary |
+| `a >= b` | `a < b` | Both sides of condition |
+
+Boundary tests should usually cover just below, exactly at, and just above the threshold.
+
+### Equality Operators
+
+| Original | Mutated | Test should verify |
+|----------|---------|-------------------|
+| `a === b` | `a !== b` | Equal and not-equal cases |
+| `a !== b` | `a === b` | Equal and not-equal cases |
+| `a == b` | `a != b` | Equal and not-equal cases |
+| `a != b` | `a == b` | Equal and not-equal cases |
+
+### Logical Operators
+
+| Original | Mutated | Test should verify |
+|----------|---------|-------------------|
+| `a && b` | `a \|\| b` | One operand true, the other false |
+| `a \|\| b` | `a && b` | One operand true, the other false |
+| `a ?? b` | `a && b` | Nullish-only fallback behavior |
+
+Avoid only testing all-true or all-false combinations.
+
+### Boolean Literals and Negation
+
+| Original | Mutated | Test should verify |
+|----------|---------|-------------------|
+| `true` | `false` | Both true and false outcomes |
+| `false` | `true` | Both true and false outcomes |
+| `!(a)` | `a` | Negation is necessary |
+
+### Block Statements and Side Effects
+
+| Original | Mutated | Test should verify |
+|----------|---------|-------------------|
+| `{ code }` | `{ }` | Observable side effects of the block |
+
+Tests that only assert "does not throw" often miss empty-body mutants. Verify returned values, persisted state, emitted events, messages, permissions, or meaningful collaborator calls.
+
+### String Literals
+
+| Original | Mutated | Test should verify |
+|----------|---------|-------------------|
+| `"text"` | `""` | Non-empty string behavior |
+| `""` | `"Stryker was here!"` | Empty string behavior |
+
+### Array Declarations
+
+| Original | Mutated | Test should verify |
+|----------|---------|-------------------|
+| `[1, 2, 3]` | `[]` | Non-empty array behavior |
+| `new Array(1, 2)` | `new Array()` | Array contents matter |
+
+### Unary and Update Operators
+
+| Original | Mutated | Test should verify |
+|----------|---------|-------------------|
+| `+a` | `-a` | Sign matters |
+| `-a` | `+a` | Sign matters |
+| `++a` | `--a` | Increment vs decrement |
+| `a++` | `a--` | Increment vs decrement |
+
+### Method Expressions
+
+| Original | Mutated | Test should verify |
+|----------|---------|-------------------|
+| `startsWith()` | `endsWith()` | Correct string position |
+| `endsWith()` | `startsWith()` | Correct string position |
+| `toUpperCase()` | `toLowerCase()` | Case transformation |
+| `toLowerCase()` | `toUpperCase()` | Case transformation |
+| `some()` | `every()` | Partial vs full match |
+| `every()` | `some()` | Full vs partial match |
+| `filter()` | removed | Filtering is necessary |
+| `reverse()` | removed | Order matters |
+| `sort()` | removed | Ordering is necessary |
+| `min()` | `max()` | Correct extremum |
+| `max()` | `min()` | Correct extremum |
+| `trim()` | `trimStart()` | Correct trim behavior |
+
+### Optional Chaining
+
+| Original | Mutated | Test should verify |
+|----------|---------|-------------------|
+| `foo?.bar` | `foo.bar` | Null/undefined handling |
+| `foo?.[i]` | `foo[i]` | Null/undefined handling |
+| `foo?.()` | `foo()` | Null/undefined handling |
+
+## Red Flags
+
+- Tests only verify "no error thrown"
+- Tests only check one side of a condition
+- Tests use identity values (`0`, `1`, empty string, empty array)
+- Tests only verify a function was called, not the observable result
+- Tests do not verify return values
+- Tests use all-true or all-false values for logical expressions
+- Boundary values are not tested
+- Side effects are not asserted
+
+## Equivalent Mutants
+
+Equivalent mutants produce the same observable behavior as the original code. They cannot be killed by a useful test.
+
+Common patterns:
+
+- Identity operations: `+= 0`, `-= 0`, `*= 1`, `/= 1`
+- Boundary mutations where equal values make both branches equivalent
+- Dead or impossible code paths
+- Branches with the same observable outcome
+
+Handle equivalent mutants by documenting why behavior cannot differ. If many equivalent mutants appear, consider whether the production code can be simplified.
+
+## Strengthening Patterns
+
+### Boundary Values
+
+Weak:
+
+```typescript
+it('validates age', () => {
+  expect(isAdult(25)).toBe(true);
+  expect(isAdult(10)).toBe(false);
+});
+```
+
+Strong:
+
+```typescript
+it('validates age at boundary', () => {
+  expect(isAdult(17)).toBe(false);
+  expect(isAdult(18)).toBe(true);
+  expect(isAdult(19)).toBe(true);
+});
+```
+
+### Boolean Combinations
+
+Weak:
+
+```typescript
+it('returns access result', () => {
+  expect(canAccess(true, true)).toBe(true);
+});
+```
+
+Strong:
+
+```typescript
+it('grants access when admin', () => {
+  expect(canAccess(true, false)).toBe(true);
+});
+
+it('grants access when owner', () => {
+  expect(canAccess(false, true)).toBe(true);
+});
+
+it('denies access when neither', () => {
+  expect(canAccess(false, false)).toBe(false);
+});
+```
+
+### Non-Identity Values
+
+Weak:
+
+```typescript
+it('calculates', () => {
+  expect(multiply(10, 1)).toBe(10);
+  expect(add(5, 0)).toBe(5);
+});
+```
+
+Strong:
+
+```typescript
+it('calculates', () => {
+  expect(multiply(10, 3)).toBe(30);
+  expect(add(5, 3)).toBe(8);
+});
+```
+
+### Observable Side Effects
+
+Weak:
+
+```typescript
+it('processes order', () => {
+  processOrder(order);
+});
+```
+
+Strong:
+
+```typescript
+it('processes order', () => {
+  const result = processOrder(order);
+  expect(result.status).toBe('confirmed');
+  expect(orderRepository.savedOrders()).toContainEqual(order);
+});
+```

--- a/claude/.claude/skills/planning/SKILL.md
+++ b/claude/.claude/skills/planning/SKILL.md
@@ -70,6 +70,7 @@ FOR EACH STEP:
     ├─► RED: Write failing test FIRST
     │   - Test describes expected behavior
     │   - Test fails for the right reason
+    │   - Test plan accounts for likely mutants from the `mutation-testing` skill's `resources/mutator-rules.md` resource
     │
     ├─► GREEN: Write MINIMUM code to pass
     │   - No extra features
@@ -148,7 +149,7 @@ Read the project's CLAUDE.md and testing rules before writing steps.
 ### Step 1: [One sentence description]
 
 **Acceptance criteria**: [What observable behaviour proves this step is done? Be specific — "user sees X", "API returns Y", "test covers Z". Vague criteria like "it works" are not acceptable. **Present to human and get confirmation before writing any code.**]
-**RED**: What failing test will we write? (Describes expected behaviour, not implementation.)
+**RED**: What failing test will we write? (Describes expected behaviour, not implementation. Include likely mutator gaps from the `mutation-testing` skill's `resources/mutator-rules.md` resource.)
 **GREEN**: What minimum code makes the test pass?
 **MUTATE**: Run `mutation-testing` skill — produce a report.
 **KILL MUTANTS**: Address surviving mutants (ask human when value is ambiguous).

--- a/claude/.claude/skills/tdd/SKILL.md
+++ b/claude/.claude/skills/tdd/SKILL.md
@@ -7,7 +7,7 @@ description: Test-Driven Development workflow. Use for ALL code changes - featur
 
 TDD is the fundamental practice. Every line of production code must be written in response to a failing test.
 
-**For how to write good tests**, load the `testing` skill. This skill focuses on the TDD workflow/process.
+**For how to write good tests**, load the `testing` skill. This skill focuses on the TDD workflow/process. For mutation-aware test planning, load the `mutation-testing` skill and use its `resources/mutator-rules.md` resource as the source of truth.
 
 ---
 
@@ -17,6 +17,8 @@ TDD is the fundamental practice. Every line of production code must be written i
 - NO production code until you have a failing test
 - Test describes desired behavior, not implementation
 - Test should fail for the right reason
+- Before finalizing the test, scan the intended behavior against the mutator rules: boundaries, boolean combinations, equality, arithmetic identities, array/string operations, optional chaining, and side effects
+- Add obvious missing cases immediately; use the harness's ask-question facility when the expected behavior is a product/domain judgment
 
 ### GREEN: Minimum Code to Pass
 - Write ONLY enough code to make the test pass
@@ -25,11 +27,12 @@ TDD is the fundamental practice. Every line of production code must be written i
 ### MUTATE: Verify Test Effectiveness
 - Run `mutation-testing` skill against the changed code
 - Produce a mutation testing report (killed/survived/score)
-- This validates whether your tests would catch real bugs
+- This validates whether the RED-phase mutator scan caught the important gaps
 
 ### KILL MUTANTS: Address Surviving Mutants
 - Add or strengthen tests to kill surviving mutants
-- Ask the human when a surviving mutant's value is ambiguous
+- Fix obvious gaps directly
+- Ask the human with the harness's ask-question facility when a surviving mutant's value is ambiguous
 - All tests pass after fixes
 
 ### REFACTOR: Assess Improvements

--- a/claude/.claude/skills/testing/SKILL.md
+++ b/claude/.claude/skills/testing/SKILL.md
@@ -5,13 +5,35 @@ description: Testing patterns for behavior-driven tests. Use when writing tests,
 
 # Testing Patterns
 
-For verifying test effectiveness through mutation analysis, load the `mutation-testing` skill. For evaluating test quality against Dave Farley's properties, load the `test-design-reviewer` skill.
+For verifying test effectiveness through mutation analysis, load the `mutation-testing` skill. Use its mutator rules while planning and writing tests, not only after tests exist. For evaluating test quality against Dave Farley's properties, load the `test-design-reviewer` skill.
 
 ## Core Principle
 
 **Test behavior, not implementation.** 100% coverage through business behavior, not implementation details.
 
 **Example:** Validation code in `payment-validator.ts` gets 100% coverage by testing `processPayment()` behavior, NOT by directly testing validator functions.
+
+---
+
+## Mutation-Aware Test Planning
+
+When planning or writing tests, automatically scan the intended behavior and changed production code against the mutator rules from the `mutation-testing` skill's `resources/mutator-rules.md` resource. A good test should fail if a realistic mutant changes the behavior.
+
+Load that resource when the code under test includes conditionals, arithmetic, equality, boolean logic, array/string operations, optional chaining, or meaningful side effects. Use it to identify likely surviving mutants before the Stryker run.
+
+When the scan finds an obvious gap, add or strengthen a behavior test immediately. When the gap depends on product or domain judgment, use the harness's ask-question facility before choosing a test. Ask one concise question with concrete choices, explain the potential mutant, and state the tradeoff.
+
+Example ask-question prompt:
+
+```markdown
+The discount rule uses `subtotal >= 100`, but current tests only cover `150`.
+Should the exact `100` boundary receive the discount?
+- Yes: add a boundary test for `100`
+- No: change/confirm the rule as `subtotal > 100`
+- Unspecified: document the behavior as intentionally not guaranteed
+```
+
+Do not ask when the gap is plainly a missing assertion, missing boundary, missing branch, or missing side-effect check. Fix those directly.
 
 ---
 


### PR DESCRIPTION
## Summary
- Make the mutation-testing skill Stryker-first, with full-project, incremental, and diff-against-main guidance
- Extract mutator rules into an on-demand resource and reference it from testing, TDD, and planning skills
- Add guidance to fix obvious mutation gaps directly and ask the human about subtle judgment-call gaps
- Add a minor changeset

## Verification
- git diff --check