### PR TITLE
fix: support macOS bash in installer

### DIFF
--- a/.changeset/quiet-bash-dedupes.md
+++ b/.changeset/quiet-bash-dedupes.md
@@ -1,0 +1,5 @@
+---
+"@paulhammond/dotfiles": patch
+---
+
+Fix the Claude installer on macOS Bash by avoiding the Bash 4-only `mapfile` builtin when de-duplicating skill agent targets.

--- a/install-claude.sh
+++ b/install-claude.sh
@@ -187,7 +187,19 @@ fi
 
 # De-duplicate agent list while preserving order
 if [[ ${#SKILL_AGENTS[@]} -gt 0 ]]; then
-  mapfile -t SKILL_AGENTS < <(printf "%s\n" "${SKILL_AGENTS[@]}" | awk '!seen[$0]++')
+  _deduped=()
+  for agent in "${SKILL_AGENTS[@]}"; do
+    _seen=false
+    for existing in "${_deduped[@]}"; do
+      if [[ "$existing" == "$agent" ]]; then
+        _seen=true
+        break
+      fi
+    done
+    [[ "$_seen" == true ]] && continue
+    _deduped+=("$agent")
+  done
+  SKILL_AGENTS=("${_deduped[@]}")
 fi
 
 # Validate: if we're installing skills, we need at least one agent to target


### PR DESCRIPTION
## Summary
- replace the Bash 4-only mapfile usage in install-claude.sh with a Bash 3.2-compatible de-duplication loop
- add a patch changeset for the installer portability fix

## Tests
- /bin/bash -n install-claude.sh
- pnpm test
- mocked Bash 3.2 skills-only run with duplicate --agent codex values