### PR TITLE
Emphasize vertical-slice planning

### DIFF
--- a/.changeset/vertical-slice-planning.md
+++ b/.changeset/vertical-slice-planning.md
@@ -1,0 +1,9 @@
+---
+"@paulhammond/dotfiles": patch
+---
+
+Improve the planning skill to default to vertical slices.
+
+The planning guidance now asks agents to plan thin end-to-end behaviours through
+the real production path, while keeping existing TDD, mutation testing, and
+commit-approval quality gates intact.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Unlike typical style guides, CLAUDE.md provides:
 | **Refactoring** | Priority classification, semantic vs structural framework, DRY decision tree | [→ skills/refactoring](claude/.claude/skills/refactoring/SKILL.md) |
 | **Functional Programming** | Immutability violations catalog, pure functions, composition patterns | [→ skills/functional](claude/.claude/skills/functional/SKILL.md) |
 | **Expectations** | Learning capture guidance, documentation templates, quality criteria | [→ skills/expectations](claude/.claude/skills/expectations/SKILL.md) |
-| **Planning** | Small increments, plans directory, commit approval, prefer small PRs | [→ skills/planning](claude/.claude/skills/planning/SKILL.md) |
+| **Planning** | Vertical slices, known-good increments, commit approval, prefer small PRs | [→ skills/planning](claude/.claude/skills/planning/SKILL.md) |
 | **CI Debugging** | Systematic CI/CD failure diagnosis, hypothesis-first debugging, environment delta analysis | [→ skills/ci-debugging](claude/.claude/skills/ci-debugging/SKILL.md) |
 | **Hexagonal Architecture** | Ports and adapters, driving/driven asymmetry, CQRS-lite, composition roots, cross-cutting concerns, DI patterns, anti-patterns with code examples, full worked example, incremental adoption. 5 deep-dive resources | [→ skills/hexagonal-architecture](claude/.claude/skills/hexagonal-architecture/SKILL.md) |
 | **Domain-Driven Design** | Ubiquitous language, value objects, entities, aggregates, domain events (Decider pattern), domain services, specifications, bounded contexts with ACL, error modeling, "Where Does This Code Belong?" decision framework. 6 deep-dive resources | [→ skills/domain-driven-design](claude/.claude/skills/domain-driven-design/SKILL.md) |
@@ -130,7 +130,7 @@ Unlike typical style guides, CLAUDE.md provides:
 | Accidental mutations breaking things | [functional](claude/.claude/skills/functional/SKILL.md) | Complete immutability violations catalog |
 | Writing code before tests | [tdd](claude/.claude/skills/tdd/SKILL.md) | TDD quality gates + git verification |
 | Losing context on complex features | [expectations](claude/.claude/skills/expectations/SKILL.md) | Learning capture framework (7 criteria) |
-| Planning significant work | [planning](claude/.claude/skills/planning/SKILL.md) | Three-document model (PLAN/WIP/LEARNINGS), commit approval |
+| Planning significant work | [planning](claude/.claude/skills/planning/SKILL.md) | Vertical slices through the real production path, commit approval |
 | CI pipeline keeps failing | [ci-debugging](claude/.claude/skills/ci-debugging/SKILL.md) | Every failure is real until proven otherwise, hypothesis-first diagnosis |
 | Separating domain from infrastructure | [hexagonal-architecture](claude/.claude/skills/hexagonal-architecture/SKILL.md) | Ports define contracts, adapters implement them, domain stays pure |
 | Complex business rules need modeling | [domain-driven-design](claude/.claude/skills/domain-driven-design/SKILL.md) | Ubiquitous language, glossary enforcement, value objects, aggregates |
@@ -1019,10 +1019,10 @@ Claude Code: [Launches learn agent]
 
 ### 6. `progress-guardian` - Progress Guardian
 
-**Use proactively** when starting significant multi-step work, or **reactively** to track progress through plan steps.
+**Use proactively** when starting significant vertical-slice work, or **reactively** to track progress through plan slices.
 
 **What it manages:**
-- Tracks progress through steps in plan files (`plans/<name>.md`)
+- Tracks progress through vertical slices in plan files (`plans/<name>.md`)
 - Enforces small increments, TDD, and **commit approval**
 - Never modifies plans without explicit user approval
 - At end: orchestrates learning merge, then **deletes the plan file**
@@ -1037,7 +1037,7 @@ Claude Code: [Launches progress-guardian to update plan and ask for commit appro
 ```
 
 **Output:**
-- Plan file in `plans/` with approved steps and acceptance criteria
+- Plan file in `plans/` with approved slices and acceptance criteria
 - At end: learnings merged into CLAUDE.md/ADRs, plan file deleted
 
 **Key distinction:** Plan files are TEMPORARY (deleted when done). Learnings merged into permanent knowledge base first.
@@ -1227,9 +1227,9 @@ This is the full lifecycle for working on a feature, from project setup through 
 /plan  →  Creates a plan in plans/ on a branch with a PR — no code, just the plan
 ```
 
-**Why before code:** Planning in a separate step prevents the most common friction point — Claude jumping straight to implementation before the approach is agreed. The plan becomes a PR you can review and approve before any code is written. Each step in the plan specifies the failing test to write first.
+**Why before code:** Planning in a separate phase prevents the most common friction point — Claude jumping straight to implementation before the approach is agreed. The plan becomes a PR you can review and approve before any code is written. Each slice in the plan specifies the failing test to write first.
 
-#### Phase 3: Implement (repeat for each step in the plan)
+#### Phase 3: Implement (repeat for each slice in the plan)
 
 ```
 RED          →  Write a failing test (tdd-guardian verifies test-first)
@@ -1254,13 +1254,13 @@ Before creating any PR, run these checks in order:
 
 **Why mutation testing before the PR:** 100% code coverage doesn't mean your tests are good — it just means the code ran. Mutation testing verifies your tests would actually catch bugs. Running `refactor-scan` after ensures you're not shipping code you already know could be cleaner.
 
-#### Phase 5: Continue to the Next Step
+#### Phase 5: Continue to the Next Slice
 
 ```
-/continue  →  Pulls merged PR, creates new branch, updates plan, shows next step
+/continue  →  Pulls merged PR, creates new branch, updates plan, shows next slice
 ```
 
-**Why a command for this:** After a PR is merged, you need to pull main, create a new branch, and figure out where you left off. `/continue` does all of this and updates the plan document so you have immediate context for the next step. This eliminates the repetitive "pull, branch, update plan" sequence between PRs.
+**Why a command for this:** After a PR is merged, you need to pull main, create a new branch, and figure out where you left off. `/continue` does all of this and updates the plan document so you have immediate context for the next slice. This eliminates the repetitive "pull, branch, update plan" sequence between PRs.
 
 #### Phase 6: Capture Knowledge (throughout and at the end)
 
@@ -1297,7 +1297,7 @@ docs-guardian     →  Updates user-facing documentation
 
 ### How the Workflow Works (Regardless of Installation Method)
 
-Once installed, the full development lifecycle is: `/setup` → `/plan` → RED-GREEN-MUTATE-KILL MUTANTS-REFACTOR → `/pr` → `/continue` → repeat. See the [Recommended Flow](#recommended-flow) in the Slash Commands section for the detailed walkthrough with rationale for each step.
+Once installed, the full development lifecycle is: `/setup` → `/plan` → RED-GREEN-MUTATE-KILL MUTANTS-REFACTOR → `/pr` → `/continue` → repeat. See the [Recommended Flow](#recommended-flow) in the Slash Commands section for the detailed walkthrough with rationale for each phase.
 
 **Agent invocation examples:**
 

--- a/claude/.claude/agents/progress-guardian.md
+++ b/claude/.claude/agents/progress-guardian.md
@@ -1,7 +1,7 @@
 ---
 name: progress-guardian
 description: >
-  Tracks progress through significant work using plan files in plans/ directory. Use at start of features, to update progress, and at end to merge learnings.
+  Tracks progress through significant work using vertical-slice plan files in plans/ directory. Use at start of features, to update progress, and at end to merge learnings.
 tools: Read, Edit, Grep, Glob, Bash
 model: sonnet
 color: green
@@ -9,17 +9,17 @@ color: green
 
 # Progress Guardian
 
-Tracks your progress through significant work using plan files.
+Tracks your progress through significant work using vertical-slice plan files.
 
 ## Core Responsibility
 
-Manage plan files in the `plans/` directory:
+Manage vertical-slice plan files in the `plans/` directory:
 
 | File | Purpose | Updates |
 |------|---------|---------|
-| **plans/\<name\>.md** | What we're doing (approved steps) | Only with user approval |
+| **plans/\<name\>.md** | What we're doing (approved slices) | Only with user approval |
 
-Multiple plans can coexist. Each plan is a self-contained file with goal, acceptance criteria, and steps.
+Multiple plans can coexist. Each plan is a self-contained file with goal, acceptance criteria, and vertical slices.
 
 ## When to Invoke
 
@@ -64,15 +64,21 @@ User: "Feature is complete"
 - [ ] Criterion 1
 - [ ] Criterion 2
 
-## Steps
+## Slices
 
-### Step 1: [One sentence description]
+Each slice should be the thinnest useful end-to-end behaviour through the real production path.
 
+### Slice 1: [One sentence observable behaviour]
+
+- **Value**: Who gets what value?
+- **Path**: Entry point -> business path -> state/output -> observability
 - **Test**: What failing test will we write?
 - **Done when**: How do we know it's complete?
 
-### Step 2: [One sentence description]
+### Slice 2: [One sentence observable behaviour]
 
+- **Value**: Who gets what value?
+- **Path**: Entry point -> business path -> state/output -> observability
 - **Test**: What failing test will we write?
 - **Done when**: How do we know it's complete?
 
@@ -95,12 +101,12 @@ Before each PR:
 Never modify a plan without explicit user approval:
 
 ```markdown
-"The original plan had 5 steps, but we've discovered we need an additional
-step for rate limiting.
+"The original plan had 5 slices, but we've discovered we need an additional
+slice for rate limiting.
 
 Proposed change to plan:
-- Add Step 4: Implement rate limiting
-- Renumber subsequent steps
+- Add Slice 4: Reject excessive registration attempts
+- Renumber subsequent slices
 
 Do you approve this plan change?"
 ```
@@ -110,7 +116,7 @@ Do you approve this plan change?"
 After RED-GREEN-MUTATE-KILL MUTANTS-REFACTOR:
 
 ```markdown
-"Step 3 complete. All tests passing.
+"Slice 3 complete. All tests passing.
 
 Ready to commit: 'feat: add email validation'
 
@@ -121,12 +127,12 @@ Do you approve this commit?"
 
 ### 3. End-of-Feature Process
 
-When all steps are complete:
+When all slices are complete:
 
 1. **Verify completion**
    - All acceptance criteria met?
    - All tests passing?
-   - All steps complete?
+   - All slices complete?
 
 2. **Merge learnings**
    ```markdown
@@ -184,11 +190,10 @@ Add email format validation to user registration.
 - [ ] Valid emails accepted
 - [ ] Edge cases handled (empty, null, unicode)
 
-## Steps
-1. Write test for basic email format validation
-2. Implement validation using regex
-3. Write tests for edge cases
-4. Handle edge cases
+## Slices
+1. Slice 1: User sees invalid email rejected during registration
+2. Slice 2: User sees valid email accepted during registration
+3. Slice 3: User sees clear validation for empty and malformed emails
 
 Do you approve this plan?"
 
@@ -196,7 +201,7 @@ User: "Approved"
 
 progress-guardian: "Plan approved. Created plans/email-validation.md.
 
-Ready to begin Step 1: Write test for basic email format validation.
+Ready to begin Slice 1: User sees invalid email rejected during registration.
 
 What's the failing test?"
 
@@ -204,7 +209,7 @@ What's the failing test?"
 
 User: "Test passes now"
 
-progress-guardian: "Step 1 status: GREEN.
+progress-guardian: "Slice 1 status: GREEN.
 Any refactoring needed, or ready for commit approval?"
 
 User: "Ready to commit"
@@ -218,6 +223,6 @@ Do you approve this commit?"
 User: "Yes"
 
 progress-guardian: "Committed.
-Current: Step 2
-Ready for Step 2: Implement validation using regex."
+Current: Slice 2
+Ready for Slice 2: User sees valid email accepted during registration."
 ```

--- a/claude/.claude/commands/plan.md
+++ b/claude/.claude/commands/plan.md
@@ -12,7 +12,7 @@ Current branch:
 Active plans:
 !`ls plans/ 2>/dev/null || echo "No plans/ directory found"`
 
-Create a plan for the requested work:
+Create a vertical-slice plan for the requested work:
 
 1. If on main, create a new feature branch first
 2. Explore the codebase to understand the relevant areas
@@ -41,13 +41,17 @@ Tests at every level (unit, browser, integration) should verify behaviour.]
 - [ ] Criterion 1
 - [ ] Criterion 2
 
-## Steps
+## Slices
 
-Every step follows RED-GREEN-MUTATE-KILL MUTANTS-REFACTOR. No production code without a failing test.
-Read the project's CLAUDE.md and testing rules before writing steps.
+Every slice should be the thinnest useful end-to-end behaviour: actor, trigger, observable outcome, production path, and smallest deployable value.
+Every slice follows RED-GREEN-MUTATE-KILL MUTANTS-REFACTOR. No production code without a failing test.
+Read the project's CLAUDE.md and testing rules before writing slices.
 
-### Step 1: [One sentence description]
+### Slice 1: [One sentence observable behaviour]
 
+**Value**: Who gets what value?
+**Path**: Entry point -> business path -> state/output -> observability. Name any intentionally skipped states.
+**Acceptance criteria**: What observable behaviour proves this slice is done? Present to human and get confirmation before writing any code.
 **RED**: What failing test will we write? (Describes expected behaviour, not implementation.)
 **GREEN**: What minimum code makes the test pass?
 **MUTATE**: Run `mutation-testing` skill — produce a report.
@@ -55,7 +59,7 @@ Read the project's CLAUDE.md and testing rules before writing steps.
 **REFACTOR**: Assess improvements (only if they add value).
 **Done when**: How do we know it's complete?
 
-### Step 2: ...
+### Slice 2: ...
 
 ## Pre-PR Quality Gate
 
@@ -74,8 +78,9 @@ Before each PR:
 - **Do NOT write any production code, test code, or implementation files**
 - **Plan document only** — the only file you should create/modify is in `plans/`
 - Write the plan to a file, never present it inline in chat
-- **Prefer multiple small PRs** — break work into the smallest independently mergeable units. Each PR should be reviewable in isolation.
-- Each step in the plan must be small enough for a single commit
-- **TDD is mandatory** — every step must specify the failing test first (RED), then the minimum implementation (GREEN), then mutation testing to verify test effectiveness, then kill surviving mutants, then refactoring assessment. No exceptions.
+- **Prefer vertical slices** — break work into the smallest independently mergeable units that deliver observable value through the real production path.
+- **Avoid layer-cake plans** — database-only, API-only, UI-only, and "do all plumbing first" work is allowed only when it names the next vertical slice it unlocks and has independent verification.
+- Each slice in the plan must be small enough for a single commit
+- **TDD is mandatory** — every slice must specify the failing test first (RED), then the minimum implementation (GREEN), then mutation testing to verify test effectiveness, then kill surviving mutants, then refactoring assessment. No exceptions.
 - **Test behaviour, not implementation** — acceptance criteria and test descriptions must describe observable outcomes (what the user sees, what the API returns), never internal details (what function was called, what query was run)
-- **Read project testing rules** — before writing steps, read the project's CLAUDE.md and any testing guidelines to ensure tests follow the project's conventions (factories, MSW vs mocks, real DB vs stubs, etc.)
+- **Read project testing rules** — before writing slices, read the project's CLAUDE.md and any testing guidelines to ensure tests follow the project's conventions (factories, MSW vs mocks, real DB vs stubs, etc.)

--- a/claude/.claude/skills/planning/SKILL.md
+++ b/claude/.claude/skills/planning/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: planning
-description: Planning work in small, known-good increments. Use when starting significant work or breaking down complex tasks.
+description: Planning work as vertical slices in small, known-good increments. Use when starting significant work, slicing features, planning PRs, or breaking down complex tasks.
 ---
 
-# Planning in Small Increments
+# Planning in Vertical Slices
 
-**All work must be done in small, known-good increments.** Each increment leaves the codebase in a working state where all tests pass.
+**Plan by vertical slices wherever possible.** Each slice delivers the smallest end-to-end behavior a real actor can observe, while leaving the codebase in a known-good state where all tests pass.
+
+Horizontal work is allowed only when it explicitly unblocks the next vertical slice and is independently verifiable.
 
 Use the `/plan` command to create plans. Use the `/continue` command to resume work after a merged PR.
 
@@ -29,40 +31,85 @@ Multiple plans can coexist — each is independent and won't conflict across bra
 
 There will be exceptions — some changes are inherently coupled and splitting them would create broken intermediate states. Use judgement. But the default should always be to ask "can this be split?"
 
-## What Makes a "Known-Good Increment"
+## What Makes a Vertical Slice
 
-Each step MUST:
+A vertical slice is not "small because it touches one layer." It is small because it delivers one observable behavior through the real production path.
+
+Each slice MUST name:
+- **Actor**: who receives the value (user, admin, API client, scheduled job, support operator)
+- **Trigger**: what starts the behavior (click, request, event, command, timer)
+- **Observable outcome**: what proves the behavior happened
+- **Production path**: the real surfaces, use case, domain logic, persistence, and external adapters involved
+- **Smallest deployable value**: the narrowest useful version that can ship safely
+
+Good slices are often thin but complete:
+- A form submits one valid field through the real API and persists it
+- A background job handles one event type and emits the expected audit result
+- A CLI command supports one input shape and returns stable stdout/stderr
+- A read-only screen shows one real state using production data loading
+
+## Choosing Slices
+
+Before writing plan slices:
+
+1. **Name the outcome** — describe the user- or system-visible result in one sentence.
+2. **Map the path** — list the real entry point, business path, state change, output, and observability.
+3. **Pick the walking skeleton** — choose the thinnest end-to-end version that proves the path works.
+4. **Add one behavior or state at a time** — validation, permissions, error states, empty states, retries, analytics, and polish become later slices.
+5. **Check reversibility** — each slice should be easy to revert or disable without undoing unrelated work.
+
+Ask "what is the smallest real behavior we can ship?" before asking "what files need to change?"
+
+## Horizontal Work Exceptions
+
+Avoid plans that do all database, API, UI, or infrastructure work up front. Horizontal work may be its own slice only when all of these are true:
+
+- It names the next vertical slice it unlocks
+- It leaves the codebase deployable
+- It has observable verification (test, command output, migration dry-run, or runtime check)
+- It is smaller than doing it inside the vertical slice
+- It does not introduce unused abstractions or speculative flexibility
+
+Valid horizontal exceptions include dependency upgrades, migrations, test harness setup, infrastructure wiring, mechanical refactors, and safety fixes. Keep them rare and explicit.
+
+## What Makes a Known-Good Slice
+
+Each slice MUST:
 - Leave all tests passing
 - Be independently deployable
 - Have clear done criteria
 - Fit in a single commit
 - Be describable in one sentence
+- Deliver or directly unblock observable behavior
 
-**If you can't describe a step in one sentence, break it down further.**
+**If you can't describe a slice in one sentence, break it down further.**
 
-## Step Size Heuristics
+## Slice Size Heuristics
 
 **Too big if:**
 - Takes more than one session
 - Requires multiple commits to complete
 - Has multiple "and"s in description
 - You're unsure how to test it
+- Needs many unrelated fixtures, mocks, screens, or endpoints
+- Builds a layer without proving an outcome
 
 **Right size if:**
-- One clear test case
-- One logical change
+- One clear behavior
+- One primary test case plus focused edge cases
 - Can explain to someone quickly
 - Obvious when done
-- Single responsibility
+- Touches only the path needed for the behavior
+- Leaves a useful checkpoint even if later slices never happen
 
 ## TDD Integration
 
-**Every step follows RED-GREEN-MUTATE-KILL MUTANTS-REFACTOR.** See `tdd` skill for the workflow, `testing` skill for factory patterns.
+**Every slice follows RED-GREEN-MUTATE-KILL MUTANTS-REFACTOR.** See `tdd` skill for the workflow, `testing` skill for factory patterns.
 
 ```
-FOR EACH STEP:
+FOR EACH SLICE:
     │
-    ├─► CONFIRM: Present acceptance criteria for this step
+    ├─► CONFIRM: Present acceptance criteria for this slice
     │   - Human must approve criteria before any code is written
     │   - Criteria must be specific and observable
     │   - Do NOT proceed until human confirms
@@ -102,7 +149,7 @@ FOR EACH STEP:
 
 **NEVER commit without user approval.**
 
-After completing a step (RED-GREEN-MUTATE-KILL MUTANTS-REFACTOR):
+After completing a slice (RED-GREEN-MUTATE-KILL MUTANTS-REFACTOR):
 
 1. Verify all tests pass
 2. Verify static analysis passes
@@ -141,14 +188,16 @@ Test at the lowest level that gives confidence: prefer unit tests (vitest) for l
 - [ ] Criterion 2
 - [ ] Criterion 3
 
-## Steps
+## Slices
 
-Every step follows RED-GREEN-MUTATE-KILL MUTANTS-REFACTOR. No production code without a failing test.
-Read the project's CLAUDE.md and testing rules before writing steps.
+Every slice follows RED-GREEN-MUTATE-KILL MUTANTS-REFACTOR. No production code without a failing test.
+Read the project's CLAUDE.md and testing rules before writing slices.
 
-### Step 1: [One sentence description]
+### Slice 1: [One sentence observable behaviour]
 
-**Acceptance criteria**: [What observable behaviour proves this step is done? Be specific — "user sees X", "API returns Y", "test covers Z". Vague criteria like "it works" are not acceptable. **Present to human and get confirmation before writing any code.**]
+**Value**: [Who gets what value?]
+**Path**: [Entry point -> business path -> state/output -> observability. Name any intentionally skipped states.]
+**Acceptance criteria**: [What observable behaviour proves this slice is done? Be specific — "user sees X", "API returns Y", "test covers Z". Vague criteria like "it works" are not acceptable. **Present to human and get confirmation before writing any code.**]
 **RED**: What failing test will we write? (Describes expected behaviour, not implementation. Include likely mutator gaps from the `mutation-testing` skill's `resources/mutator-rules.md` resource.)
 **GREEN**: What minimum code makes the test pass?
 **MUTATE**: Run `mutation-testing` skill — produce a report.
@@ -156,8 +205,10 @@ Read the project's CLAUDE.md and testing rules before writing steps.
 **REFACTOR**: Assess improvements (only if they add value).
 **Done when**: All acceptance criteria met, mutation report reviewed, human approves commit.
 
-### Step 2: [One sentence description]
+### Slice 2: [One sentence observable behaviour]
 
+**Value**: ...
+**Path**: ...
 **Acceptance criteria**: ...
 **RED**: ...
 **GREEN**: ...
@@ -183,14 +234,14 @@ Before each PR:
 If the plan needs to change:
 
 1. Explain what changed and why
-2. Propose updated steps
+2. Propose updated slices
 3. **Wait for approval** before proceeding
 
 Plans are not immutable, but changes must be explicit and approved.
 
 ## End of Feature
 
-When all steps are complete:
+When all slices are complete:
 
 1. **Verify completion** — all acceptance criteria met, all tests passing
 2. **Merge learnings** — if significant insights were gained, use the `learn` agent for CLAUDE.md updates or `adr` agent for architectural decisions
@@ -201,8 +252,20 @@ When all steps are complete:
 ❌ **Committing without approval**
 - Always wait for explicit "yes" before committing
 
-❌ **Steps that span multiple commits**
-- Break down further until one step = one commit
+❌ **Layer-cake plans**
+- "Build database, then API, then UI" delays learning and hides broken integration
+
+❌ **Foundation work with no named slice**
+- If setup is needed, name the vertical slice it unlocks and how the setup is verified
+
+❌ **Database-only, API-only, or UI-only slices by default**
+- These are usually implementation tasks, not independently valuable behavior
+
+❌ **Do all plumbing first**
+- Prefer a walking skeleton that proves the real path, then widen it behavior by behavior
+
+❌ **Slices that span multiple commits**
+- Break down further until one slice = one commit
 
 ❌ **Writing code before tests**
 - RED comes first, always
@@ -220,7 +283,7 @@ START FEATURE
 │
 ├─► Create plan in plans/ (get approval)
 │
-│   FOR EACH STEP:
+│   FOR EACH SLICE:
 │   │
 │   ├─► CONFIRM: Present acceptance criteria, **wait for human approval**
 │   ├─► RED: Failing test


### PR DESCRIPTION
## Summary
- make the planning skill default to vertical slices through the real production path
- update /plan and progress-guardian templates to use slices instead of generic steps
- refresh README discovery/workflow text and add a patch changeset

## Tests
- pnpm test
- YAML frontmatter parse for touched skill/command/agent/changeset
- git diff --check