### PR TITLE
fix(planning): clarify that a slice maps to a PR, not a single commit

### DIFF
--- a/.changeset/clarify-slice-pr-not-commit.md
+++ b/.changeset/clarify-slice-pr-not-commit.md
@@ -1,0 +1,10 @@
+---
+"@paulhammond/dotfiles": patch
+---
+
+Clarify that a vertical slice maps to a PR, not a single commit
+
+The planning skill previously equated slice = commit, which contradicted the
+reality that TDD increments within a slice naturally produce multiple commits.
+Updated to clarify that a slice is the smallest independently mergeable PR,
+and that multiple TDD commits within a slice are expected.

--- a/claude/.claude/skills/planning/SKILL.md
+++ b/claude/.claude/skills/planning/SKILL.md
@@ -78,9 +78,11 @@ Each slice MUST:
 - Leave all tests passing
 - Be independently deployable
 - Have clear done criteria
-- Fit in a single commit
+- Fit in a single PR (the smallest independently mergeable unit)
 - Be describable in one sentence
 - Deliver or directly unblock observable behavior
+
+A slice is the unit of planning and review — one PR. Within a slice, TDD increments (RED-GREEN-MUTATE-KILL MUTANTS-REFACTOR) may produce multiple commits, but the slice itself is what gets reviewed and merged as a coherent unit.
 
 **If you can't describe a slice in one sentence, break it down further.**
 
@@ -88,7 +90,6 @@ Each slice MUST:
 
 **Too big if:**
 - Takes more than one session
-- Requires multiple commits to complete
 - Has multiple "and"s in description
 - You're unsure how to test it
 - Needs many unrelated fixtures, mocks, screens, or endpoints
@@ -264,8 +265,8 @@ When all slices are complete:
 ❌ **Do all plumbing first**
 - Prefer a walking skeleton that proves the real path, then widen it behavior by behavior
 
-❌ **Slices that span multiple commits**
-- Break down further until one slice = one commit
+❌ **Slices that span multiple PRs**
+- Break down further until one slice = one PR
 
 ❌ **Writing code before tests**
 - RED comes first, always


### PR DESCRIPTION
## Summary

- Clarifies that a vertical slice is the smallest independently mergeable **PR**, not a single commit
- TDD increments (RED-GREEN-MUTATE-KILL MUTANTS-REFACTOR) within a slice naturally produce multiple commits — this is expected, not a smell
- Removes contradictory language that equated slice = commit

## Changes

**`claude/.claude/skills/planning/SKILL.md`:**

1. "Fit in a single commit" → "Fit in a single PR (the smallest independently mergeable unit)"
2. Added clarifying paragraph distinguishing slice (planning/review unit = PR) from TDD increments (implementation granularity = commits)
3. Removed "Requires multiple commits to complete" from the "too big" heuristics
4. Anti-pattern changed from "Slices that span multiple commits" → "Slices that span multiple PRs"

## Context

The previous wording explicitly stated `one slice = one commit` in both the requirements and anti-patterns sections. This contradicted the TDD workflow where RED-GREEN-MUTATE-KILL MUTANTS-REFACTOR naturally produces multiple commits per slice. The fix distinguishes between the two granularities: slices are the planning unit (PRs), TDD increments are the implementation unit (commits).