### PR TITLE
Add production parity skill builder

### DIFF
--- a/.changeset/bright-parity-skills.md
+++ b/.changeset/bright-parity-skills.md
@@ -1,0 +1,5 @@
+---
+"@paulhammond/dotfiles": minor
+---
+
+Add production-parity-skill-builder skill for creating app-specific skills that detect and fix drift between production and non-production environments. Idea credited to GitHub user @dm.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ It became unexpectedly popular when I shared the [CLAUDE.md file](claude/.claude
 
 This repository now serves two purposes:
 
-1. **[CLAUDE.md](claude/.claude/CLAUDE.md)** + **[Skills](claude/.claude/skills/)** + **[Ten specialized agents](claude/.claude/agents/)** + **[Five slash commands](claude/.claude/commands/)** - Development guidelines, 24 auto-discovered skill patterns + 18 impeccable design skills from [pbakaus/impeccable](https://github.com/pbakaus/impeccable) + 6 web quality skills from [addyosmani/web-quality-skills](https://github.com/addyosmani/web-quality-skills) + the `grill-me` planning interview skill from [mattpocock/skills](https://skills.sh/mattpocock/skills/grill-me) + the `seo-audit` marketing skill from [coreyhaines31/marketingskills](https://skills.sh/coreyhaines31/marketingskills/seo-audit), and automated quality guidance (what most visitors want)
+1. **[CLAUDE.md](claude/.claude/CLAUDE.md)** + **[Skills](claude/.claude/skills/)** + **[Ten specialized agents](claude/.claude/agents/)** + **[Five slash commands](claude/.claude/commands/)** - Development guidelines, 25 auto-discovered skill patterns + 18 impeccable design skills from [pbakaus/impeccable](https://github.com/pbakaus/impeccable) + 6 web quality skills from [addyosmani/web-quality-skills](https://github.com/addyosmani/web-quality-skills) + the `grill-me` planning interview skill from [mattpocock/skills](https://skills.sh/mattpocock/skills/grill-me) + the `seo-audit` marketing skill from [coreyhaines31/marketingskills](https://skills.sh/coreyhaines31/marketingskills/seo-audit), and automated quality guidance (what most visitors want)
 2. **Personal dotfiles** - My shell configs, git aliases, and tool configurations (what this repo was originally for)
 
 **Most people are here for CLAUDE.md and the agents.** This README focuses primarily on those, with [dotfiles coverage at the end](#-personal-dotfiles-the-original-purpose).
@@ -85,6 +85,7 @@ Unlike typical style guides, CLAUDE.md provides:
 | **Expectations** | Learning capture guidance, documentation templates, quality criteria | [→ skills/expectations](claude/.claude/skills/expectations/SKILL.md) |
 | **Planning** | Small increments, plans directory, commit approval, prefer small PRs | [→ skills/planning](claude/.claude/skills/planning/SKILL.md) |
 | **CI Debugging** | Systematic CI/CD failure diagnosis, hypothesis-first debugging, environment delta analysis | [→ skills/ci-debugging](claude/.claude/skills/ci-debugging/SKILL.md) |
+| **Production Parity Skill Builder** | Creates app-specific skills that inspect docs, code, tests, CI, deployment, infrastructure, config, auth, and environment setup to catch drift between production and non-production environments | [→ skills/production-parity-skill-builder](claude/.claude/skills/production-parity-skill-builder/SKILL.md) |
 | **Hexagonal Architecture** | Ports and adapters, driving/driven asymmetry, CQRS-lite, composition roots, cross-cutting concerns, DI patterns, anti-patterns with code examples, full worked example, incremental adoption. 5 deep-dive resources | [→ skills/hexagonal-architecture](claude/.claude/skills/hexagonal-architecture/SKILL.md) |
 | **Domain-Driven Design** | Ubiquitous language, value objects, entities, aggregates, domain events (Decider pattern), domain services, specifications, bounded contexts with ACL, error modeling, "Where Does This Code Belong?" decision framework. 6 deep-dive resources | [→ skills/domain-driven-design](claude/.claude/skills/domain-driven-design/SKILL.md) |
 | **Twelve-Factor App** | Config via env vars, stateless processes, graceful shutdown, structured logging, backing services | [→ skills/twelve-factor](claude/.claude/skills/twelve-factor/SKILL.md) |
@@ -132,6 +133,7 @@ Unlike typical style guides, CLAUDE.md provides:
 | Losing context on complex features | [expectations](claude/.claude/skills/expectations/SKILL.md) | Learning capture framework (7 criteria) |
 | Planning significant work | [planning](claude/.claude/skills/planning/SKILL.md) | Three-document model (PLAN/WIP/LEARNINGS), commit approval |
 | CI pipeline keeps failing | [ci-debugging](claude/.claude/skills/ci-debugging/SKILL.md) | Every failure is real until proven otherwise, hypothesis-first diagnosis |
+| Local, CI, PR, or staging differs from production | [production-parity-skill-builder](claude/.claude/skills/production-parity-skill-builder/SKILL.md) | Generate an app-specific parity skill that inspects source, infra, config, and auth before asking targeted questions |
 | Separating domain from infrastructure | [hexagonal-architecture](claude/.claude/skills/hexagonal-architecture/SKILL.md) | Ports define contracts, adapters implement them, domain stays pure |
 | Complex business rules need modeling | [domain-driven-design](claude/.claude/skills/domain-driven-design/SKILL.md) | Ubiquitous language, glossary enforcement, value objects, aggregates |
 | Config scattered in code, not env vars | [twelve-factor](claude/.claude/skills/twelve-factor/SKILL.md) | Validate config at startup with Zod, inject via options objects |
@@ -171,6 +173,7 @@ Skills are **auto-discovered** by Claude when relevant:
 - After MUTATE + KILL MUTANTS? → `refactoring` skill assesses opportunities
 - Reviewing test effectiveness? → `mutation-testing` skill identifies weak tests
 - Designing API endpoints? → `api-design` skill provides contract-first patterns
+- Investigating local/prod drift? → `production-parity-skill-builder` creates an app-specific parity skill from docs, source, tests, config, auth, and infra
 - Code with hard-to-test dependencies? → `finding-seams` skill identifies substitution points
 - Changing code with no tests? → `characterisation-tests` skill documents existing behavior
 - Building a UI? → `impeccable` skill loads design methodology and anti-slop patterns
@@ -1374,7 +1377,7 @@ Both patterns resolve to the same content on disk, so the first `--agent codex` 
 **What gets installed:**
 - ✅ `~/.claude/CLAUDE.md` (~100 lines - lean core principles)
 - ✅ `~/.claude/skills/` — installed via [skills.sh](https://skills.sh) (`npx skills add`):
-  - [citypaul/.dotfiles](https://skills.sh/citypaul/.dotfiles) — 24 auto-discovered patterns (tdd, testing, mutation-testing, typescript-strict, functional, refactoring, planning, front-end-testing, react-testing, and more)
+  - [citypaul/.dotfiles](https://skills.sh/citypaul/.dotfiles) — 25 auto-discovered patterns (tdd, testing, mutation-testing, typescript-strict, functional, refactoring, planning, front-end-testing, react-testing, and more)
   - [pbakaus/impeccable](https://skills.sh/pbakaus/impeccable) — frontend design vocabulary + 17 steering commands
   - [addyosmani/web-quality-skills](https://skills.sh/addyosmani/web-quality-skills) — accessibility, performance, SEO, core-web-vitals, best-practices, web-quality-audit
   - [mattpocock/skills/grill-me](https://skills.sh/mattpocock/skills/grill-me) — one-question-at-a-time plan and design interrogation
@@ -1625,7 +1628,7 @@ This gives you the complete guidelines (1,818 lines) in a single standalone file
 
 ### Version Note: v1.0.0 vs v2.0.0 vs v3.0.0
 
-**Current version (v3.0.0):** Skills-based architecture with lean CLAUDE.md (~100 lines) + 21 auto-discovered skills + 5 slash commands + planning workflow
+**Current version (v3.0.0):** Skills-based architecture with lean CLAUDE.md (~100 lines) + 25 auto-discovered skills + 5 slash commands + planning workflow
 
 **Previous version (v2.0.0):** Modular structure with main file (156 lines) + 6 detailed docs loaded via @imports (~3000+ lines total)
 
@@ -1648,7 +1651,7 @@ The installer pulls `CLAUDE.md`, slash commands, and Claude-Code agents from the
 ## 📚 Documentation
 
 - **[CLAUDE.md](claude/.claude/CLAUDE.md)** - Core development principles (~100 lines)
-- **[Skills](claude/.claude/skills/)** - Auto-discovered patterns. 24 from this repo, 6 from [addyosmani/web-quality-skills](https://github.com/addyosmani/web-quality-skills), 17 from [pbakaus/impeccable](https://github.com/pbakaus/impeccable), and `seo-audit` from [coreyhaines31/marketingskills](https://skills.sh/coreyhaines31/marketingskills/seo-audit) — all installed via [skills.sh](https://skills.sh) for multi-agent portability.
+- **[Skills](claude/.claude/skills/)** - Auto-discovered patterns. 25 from this repo, 6 from [addyosmani/web-quality-skills](https://github.com/addyosmani/web-quality-skills), 17 from [pbakaus/impeccable](https://github.com/pbakaus/impeccable), and `seo-audit` from [coreyhaines31/marketingskills](https://skills.sh/coreyhaines31/marketingskills/seo-audit) — all installed via [skills.sh](https://skills.sh) for multi-agent portability.
 - **[Commands](claude/.claude/commands/)** - Slash commands (/setup, /pr, /plan, /continue, /generate-pr-review)
 - **[Agents README](claude/.claude/agents/README.md)** - Detailed agent documentation with examples
 - **[Agent Definitions](claude/.claude/agents/)** - Individual agent configuration files (10 agents: tdd-guardian, ts-enforcer, refactor-scan, docs-guardian, learn, progress-guardian, adr, pr-reviewer, use-case-data-patterns, twelve-factor-audit)
@@ -1825,7 +1828,7 @@ cd ~/.dotfiles
 ```
 
 This will install:
-- ✅ CLAUDE.md + 27 skills (20 built-in + 6 web quality + 1 marketing) + 10 agents (development guidelines)
+- ✅ CLAUDE.md + skills (25 from this repo plus external skill bundles) + 10 agents (development guidelines)
 - ✅ Commands (/setup, /pr, /plan, /continue, /generate-pr-review slash commands)
 - ✅ Claude Code settings.json (plugins, hooks, statusline)
 - ✅ Git aliases and configuration
@@ -1912,6 +1915,8 @@ Special thanks to contributors who have shared their work:
 - **[Kieran O'Hara](https://github.com/kieran-ohara)** - The `use-case-data-patterns` agent is adapted from [Kieran's dotfiles](https://github.com/kieran-ohara/dotfiles/blob/main/config/claude/agents/analyse-use-case-to-data-patterns.md). Thank you for creating and sharing this excellent agent specification.
 
 - **[Andrea Laforgia](https://github.com/andlaf-ak)** - The `test-design-reviewer` skill is adapted from [Andrea's claude-code-agents repository](https://github.com/andlaf-ak/claude-code-agents/blob/main/test-design-reviewer.md). Thank you for creating and sharing this comprehensive test design review framework based on Dave Farley's testing principles.
+
+- **[@dm](https://github.com/dm)** - Idea credit for the `production-parity-skill-builder` skill, inspired by the need to keep local, CI, PR, preview, and staging environments aligned with production-only restrictions such as identity-provider group membership.
 
 - **[Paul Bakaus](https://github.com/pbakaus)** - The impeccable design skills (core skill + 17 steering commands: shape, critique, audit, polish, harden, typeset, colorize, animate, layout, clarify, adapt, bolder, quieter, distill, delight, optimize, overdrive) are sourced from [impeccable.style](https://impeccable.style/skills/). These skills are fetched directly from the upstream repository at install time. Licensed under the [Apache 2.0 License](https://github.com/pbakaus/impeccable/blob/main/LICENSE). Impeccable builds on Anthropic's original frontend-design skill. See the [NOTICE](https://github.com/pbakaus/impeccable/blob/main/NOTICE.md) for full attribution chain.
 

--- a/claude/.claude/skills/production-parity-skill-builder/SKILL.md
+++ b/claude/.claude/skills/production-parity-skill-builder/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: production-parity-skill-builder
+description: Create an application-specific production parity skill by inspecting an app's docs, source, tests, CI, deployment, infrastructure, config, auth, and environment setup, then asking targeted harness questions only for source-unanswerable decisions. Use when local, CI, PR, preview, staging, or other non-production environments may drift from production behavior; when production-only auth, config, identity-provider groups, feature flags, infrastructure, backing services, or policy differences caused bugs; or when a team wants a reusable skill that detects, documents, tests, and helps fix parity drift for one specific application.
+---
+
+# Production Parity Skill Builder
+
+Build a skill for one application. The generated skill's job is to keep local and non-production environments behaviorally aligned with production, while making every intentional difference explicit and tested.
+
+Idea credit: GitHub user [@dm](https://github.com/dm).
+
+Production is the reference contract. Local, CI, PR, preview, and staging may use lighter infrastructure, but they must either emulate production behavior or document the divergence with compensating tests. A production authentik group restriction that is absent locally is a parity bug, not a harmless convenience.
+
+## Workflow
+
+### 1. Inspect Before Asking
+
+First build evidence from the repository. Do not ask the user to explain what can be discovered from files.
+
+Inspect, as applicable:
+
+- docs: `README*`, `docs/`, ADRs, runbooks, onboarding, local setup, deployment notes
+- app code: config loading, auth/authz, tenancy, feature flags, service clients, scheduled jobs, webhooks
+- tests: unit, integration, E2E, smoke, contract, auth fixtures, seed data, factories
+- local setup: Dockerfile, compose files, devcontainers, scripts, seeders, Makefiles, package scripts
+- CI and previews: GitHub Actions, GitLab CI, Buildkite, preview deployment config, test matrices
+- infra: Terraform, Pulumi, CDK, Helm, Kustomize, Kubernetes manifests, Cloudflare/Vercel/Netlify/Fly/Render config
+- production descriptors: env schemas, secret names, IdP/OIDC/SAML settings, ingress, network policy, runtime versions, database extensions, queues, object storage, cron, external provider config
+
+Use `rg --files` and targeted `rg` searches. Search for environment names and parity-sensitive terms:
+
+```text
+prod|production|staging|preview|pr|local|dev|ci|docker|compose|k8s|helm|terraform|pulumi|auth|oidc|saml|jwt|group|role|claim|permission|feature flag|secret|env|webhook|cron|queue|seed|fixture|migration
+```
+
+### 2. Build The Parity Map
+
+Create a working parity map before writing the generated skill. For each surface, record:
+
+- production truth source: file, manifest, doc, dashboard export, or user answer
+- non-production representation: local, CI, PR/preview, staging
+- drift risk: what user-visible or security behavior changes if this differs
+- current guard: test, schema check, smoke test, contract test, policy check, or none
+- fix pattern: emulate, seed, contract-test, validate config, parse infra, or document explicit divergence
+- owner or escalation path when the repo cannot answer it
+
+Load `resources/parity-surface-catalog.md` when choosing surfaces and checks. Use the catalog as a checklist, not as a claim that every app needs every surface.
+
+### 3. Ask Targeted Questions
+
+Use the harness's available ask-question facility when it exists: `AskUserQuestion`, `request_user_input`, `ask_question`, or the equivalent in the active agent harness. If no structured question tool is available, ask a concise plain-text question.
+
+Ask only after inspection. Ask only questions that change the generated skill or required fixes.
+
+Question rules:
+
+- Ask one decision at a time unless two options are tightly coupled.
+- Prefer structured options when the answer space is enumerable.
+- Include the evidence that triggered the question.
+- Recommend the safest option first, but name the tradeoff.
+- Capture each answer into the generated skill; do not leave decisions only in chat.
+
+Load `resources/question-patterns.md` for reusable question shapes.
+
+Example:
+
+```markdown
+Production appears to require authentik group `app-users` for login, but local and PR setup seed no equivalent restriction.
+How should non-production enforce this?
+
+1. Mirror production with seeded IdP group membership. Recommended: catches auth drift while keeping local deterministic.
+2. Use a lightweight OIDC/authentik emulator with the same required claim. Good when running real authentik locally is too heavy.
+3. Keep local unrestricted, but add contract/E2E tests that fail unless prod-only group enforcement is represented. Faster local login, higher residual drift risk.
+```
+
+### 4. Generate The App-Specific Skill
+
+Write a new skill for the specific app, normally named `<app-name>-production-parity` unless the user or repo naming convention suggests otherwise.
+
+The generated skill must include:
+
+- frontmatter whose description triggers on parity, drift, local/prod mismatch, auth/config/infra differences, and environment setup for that app
+- an "App Parity Contract" that names production as the reference and lists intentional non-prod divergences
+- "Production Truth Sources" with exact file paths, manifests, docs, commands, or user-confirmed sources
+- "Inspection Workflow" with repo-specific commands and files to read
+- "Parity Surfaces" tailored to the app, not a generic checklist dump
+- "Drift Checks" with concrete tests, scripts, schemas, or manual checks the agent should run
+- "Fix Patterns" that explain how to close drift in this app's architecture
+- "Question Protocol" instructing the agent to use the active harness's ask-question facility for source-unanswerable decisions
+- "Output Contract" for every future run: inspected files, risks found, fixes made, tests run, remaining explicit divergences
+
+Start from `resources/generated-skill-template.md`, but remove irrelevant sections and replace placeholders with app-specific evidence.
+
+### 5. Add Safeguards Where The Repo Supports Them
+
+If the user asked for fixes, or if the generated skill would be weak without a guard, add narrowly scoped checks in the target app:
+
+- config parity: schema validation for required env vars and production-only restrictions
+- auth parity: tests for required IdP groups, roles, claims, redirect URIs, cookies, and session policies
+- fixture parity: seeded users, tenants, feature flags, roles, plans, quotas, and data lifecycle states
+- infra parity: parse or diff deployment manifests against local/preview manifests for security-relevant settings
+- provider parity: contract tests or recorded fixtures for external APIs, webhooks, email, storage, queues, and payment providers
+- runtime parity: pinned versions for language runtime, database, extensions, image tags, and build commands
+- smoke parity: a preview/staging smoke test that proves the app starts with production-equivalent restrictions before merge
+
+When a difference is intentional, require a named reason and compensating guard. "Local is easier" is not enough.
+
+### 6. Validate The Generated Skill
+
+Before finishing:
+
+1. Re-read the generated skill as if invoked on a fresh thread.
+2. Confirm every app-specific claim cites a repo source or a captured user answer.
+3. Confirm no generic checklist item remains unless it applies to the app.
+4. Run the skill validation command available in the harness or repository if one exists.
+5. If validation cannot be run, say exactly why.
+
+## Output
+
+Return:
+
+- generated skill path
+- files and directories inspected
+- highest-risk parity gaps found during creation
+- questions asked and captured decisions
+- tests or validation run
+- recommended next fixes if drift was found but not fixed
+
+Do not present a generic parity report as the final product. The primary deliverable is the reusable app-specific skill.

--- a/claude/.claude/skills/production-parity-skill-builder/resources/generated-skill-template.md
+++ b/claude/.claude/skills/production-parity-skill-builder/resources/generated-skill-template.md
@@ -1,0 +1,93 @@
+# Generated Skill Template
+
+Replace placeholders with app-specific evidence. Remove sections that do not apply.
+
+````markdown
+---
+name: <app-name>-production-parity
+description: Detect, document, test, and fix drift between production and local, CI, PR, preview, staging, or other non-production environments for <app-name>. Use when working on <app-name> auth, config, deployment, infrastructure, tests, local setup, fixtures, feature flags, backing services, or any issue where behavior may differ from production.
+---
+
+# <App Name> Production Parity
+
+Production is the reference contract for <app-name>. Non-production environments may be lighter, but every difference must be explicit, justified, and covered by a guard.
+
+## App Parity Contract
+
+- Production environments: <prod names/URLs/manifest paths>
+- Non-production environments: <local/CI/PR/preview/staging names>
+- Intentional divergences: <link/list, each with reason and compensating guard>
+- Blocking rule: unknown production behavior is a parity risk until sourced or answered
+
+## Production Truth Sources
+
+List exact sources:
+
+- <file/path>: <what it proves>
+- <deployment manifest or IaC path>: <what it proves>
+- <doc/runbook>: <what it proves>
+- User-confirmed decision on <date>: <decision>
+
+## Inspection Workflow
+
+1. Read <docs/setup/deployment files>.
+2. Inspect <config/auth/infra/test files>.
+3. Build or update the parity map for changed surfaces.
+4. Ask harness questions only for source-unanswerable decisions.
+5. Add or update guards before declaring drift closed.
+
+## Parity Surfaces
+
+### <Surface Name>
+
+- Production behavior: <evidence-backed behavior>
+- Local behavior: <evidence-backed behavior>
+- CI/PR/preview behavior: <evidence-backed behavior>
+- Drift risks: <security/user/data/release impact>
+- Guards: <tests/scripts/manual checks>
+- Fix pattern: <how to close drift in this app>
+
+Repeat for each app-relevant surface.
+
+## Drift Checks
+
+Run the checks that apply to the changed surface:
+
+```bash
+<command>
+```
+
+Expected result:
+
+- <what passing proves>
+- <what failure usually means>
+
+## Fix Patterns
+
+Use these app-specific patterns:
+
+- <auth group/claim parity pattern>
+- <config schema pattern>
+- <local seed/fixture pattern>
+- <infra manifest check pattern>
+- <preview smoke test pattern>
+
+## Question Protocol
+
+Use the active harness's structured ask-question facility when available (`AskUserQuestion`, `request_user_input`, `ask_question`, or equivalent). If unavailable, ask one concise plain-text question.
+
+Ask only when inspection cannot answer a decision that changes parity behavior. Capture every answer into this skill or the source artifact it names.
+
+## Output Contract
+
+Every run must report:
+
+- files inspected
+- parity surfaces touched
+- drift found
+- fixes made
+- checks run and results
+- explicit divergences left in place
+- unanswered questions with owner or next step
+```
+````

--- a/claude/.claude/skills/production-parity-skill-builder/resources/parity-surface-catalog.md
+++ b/claude/.claude/skills/production-parity-skill-builder/resources/parity-surface-catalog.md
@@ -1,0 +1,185 @@
+# Parity Surface Catalog
+
+Use this catalog to build a parity map for one app. Select only surfaces that apply.
+
+## Identity, Authn, And Authz
+
+Inspect:
+
+- OIDC/SAML provider config, callback URLs, logout URLs, issuer/audience, token lifetimes
+- required IdP groups, roles, claims, scopes, tenant membership, admin flags
+- middleware, route guards, API authorization policies, RBAC/ABAC rules
+- session cookies, SameSite/Secure flags, CSRF, CORS, trusted origins
+- local/CI auth bypasses, fake users, seeded users, test factories
+
+Common drift:
+
+- production requires a group or claim that local login bypasses
+- preview apps use a different redirect URI or cookie domain
+- local fixtures grant admin rights by default
+- E2E tests authenticate by mutating session state and skip the real gate
+
+Useful guards:
+
+- contract test that asserts required claims/groups are enforced
+- seeded IdP fixtures that mirror production roles
+- config schema requiring the same auth mode unless an explicit test-only override is set
+- E2E test that covers denied access for a user missing the production-required group
+
+## Config, Secrets, And Feature Flags
+
+Inspect:
+
+- env schemas, `.env.example`, deployment env vars, secret names, config maps
+- feature flag providers, defaults, bootstrap data, flag targeting rules
+- production-only config branches and environment-name conditionals
+
+Common drift:
+
+- missing local env var falls back to permissive behavior
+- production flag default differs from test default
+- config branches key on `NODE_ENV` instead of capability/config values
+
+Useful guards:
+
+- startup validation that fails on missing required config
+- generated config matrix comparing prod, CI, preview, and local keys
+- tests for both enabled and disabled flag states when production can see both
+- explicit list of allowed non-prod overrides
+
+## Runtime, Build, And Dependency Shape
+
+Inspect:
+
+- runtime versions, package manager, lockfiles, base images, build commands
+- native dependencies, browser versions, database image tags, extension versions
+- production bundler/minifier/server mode versus local dev server
+
+Common drift:
+
+- local uses a dev server path that production never serves
+- CI tests run one Node/Python/Ruby version while production image uses another
+- local database image lacks extensions or collation settings used in production
+
+Useful guards:
+
+- pinned runtime/tool versions shared by local, CI, and production build
+- CI job that builds and boots the production artifact
+- migration or startup check for database extensions and settings
+
+## Data, Database, And Tenancy
+
+Inspect:
+
+- schemas, migrations, seed scripts, fixtures, RLS policies, indexes, constraints
+- tenant/account isolation, plan/entitlement data, lifecycle states
+- backup/restore, anonymized prod snapshots, generated data realism
+
+Common drift:
+
+- local seed data omits restricted roles, empty states, quotas, or lifecycle edge cases
+- tests use factories that bypass constraints or RLS
+- migrations are tested against an empty database only
+
+Useful guards:
+
+- seeds for every production-critical role/state
+- migration tests against realistic prior schema/data
+- tests proving tenant boundaries and permission denial
+- constraints and RLS exercised through public app behavior
+
+## Backing Services And Async Work
+
+Inspect:
+
+- queues, workers, cron, schedulers, webhooks, cache, email, object storage
+- retry/dead-letter policy, idempotency, rate limits, ordering guarantees
+- local emulators and fake providers
+
+Common drift:
+
+- local executes jobs inline while production is eventually consistent
+- fake provider always succeeds
+- preview lacks webhook signature verification
+
+Useful guards:
+
+- contract tests for provider payloads and signatures
+- worker integration tests with retry/dead-letter behavior
+- local emulator configured with production-like policies where possible
+- explicit divergence for intentionally synchronous local execution
+
+## Network, Edge, And Security Policy
+
+Inspect:
+
+- ingress, CDN, WAF, Cloudflare/Vercel/Netlify/Fly/Render config, TLS
+- CSP, HSTS, CORS, allowed origins, IP allowlists, service mesh, network policies
+- cookies/domains, proxy headers, trusted hosts
+
+Common drift:
+
+- local permits all origins but production denies cross-origin requests
+- preview lacks security headers or trusted proxy behavior
+- tests call services directly and skip the edge path
+
+Useful guards:
+
+- smoke test through the same public route shape used by production
+- header/CORS assertions in integration or E2E tests
+- manifest checks for security policy deltas
+
+## Observability And Operations
+
+Inspect:
+
+- health checks, readiness/liveness probes, logs, metrics, traces, alert names
+- dashboards, runbooks, SLOs, error budgets, incident docs
+- release, rollback, migration, and feature flag rollout procedures
+
+Common drift:
+
+- local success does not prove production readiness checks pass
+- preview deploys without the background worker or health probe
+- errors are swallowed locally but alerted in production
+
+Useful guards:
+
+- smoke test for readiness/health endpoints under production-equivalent config
+- test or lint for required structured log fields and metrics
+- runbook links in the app-specific skill for known parity failures
+
+## Third-Party And Provider Contracts
+
+Inspect:
+
+- payment, email, analytics, CRM, identity, storage, search, AI, maps, and other API clients
+- sandbox versus production provider settings
+- webhook schemas, signature verification, idempotency keys, retry behavior
+
+Common drift:
+
+- provider sandbox has weaker validation than production
+- mocked clients do not model provider errors, rate limits, or idempotency
+- webhook tests omit signature verification or replay protection
+
+Useful guards:
+
+- provider contract tests or recorded fixtures
+- negative-path tests for common production provider errors
+- smoke tests against sandbox with production-equivalent config
+
+## Explicit Divergence Register
+
+Every intentional difference needs:
+
+- surface
+- production behavior
+- non-production behavior
+- reason
+- risk
+- compensating guard
+- owner
+- review trigger
+
+If any field is missing, the divergence is not explicit enough.

--- a/claude/.claude/skills/production-parity-skill-builder/resources/question-patterns.md
+++ b/claude/.claude/skills/production-parity-skill-builder/resources/question-patterns.md
@@ -1,0 +1,79 @@
+# Question Patterns
+
+Ask only after repository inspection. Each question should close a specific gap in the generated app-specific skill.
+
+## Auth Restriction
+
+Use when production requires a group, role, claim, scope, tenant membership, or IdP policy that non-production does not clearly mirror.
+
+```markdown
+I found production evidence for `[restriction]` in `[source]`, but `[local/CI/preview source]` does not show an equivalent.
+How should non-production represent this rule?
+
+1. Mirror production with seeded users/groups/claims. Recommended: catches auth drift in normal tests.
+2. Use a lightweight emulator or fake provider that emits the same required claim. Good if the real IdP is too heavy locally.
+3. Keep the local bypass, but add contract/E2E tests that prove the production restriction. Fastest local path, highest residual drift risk.
+```
+
+## Missing Production Truth
+
+Use when code references production behavior but the source of truth is outside the repo.
+
+```markdown
+The repo references `[surface]`, but I cannot find the production source of truth for `[specific setting]`.
+Where should the generated parity skill treat as authoritative?
+
+1. `[candidate file/service/doc]`. Recommended if this is maintained with deploys.
+2. A named external source such as `[dashboard/provider/admin console]`, with a manual verification step.
+3. Treat it as unknown and add a blocking follow-up before the parity skill is considered complete.
+```
+
+## Intentional Divergence
+
+Use when non-production clearly differs and may be deliberate.
+
+```markdown
+`[environment]` differs from production for `[surface]`: production `[behavior]`, non-production `[behavior]`.
+Should this remain an intentional divergence?
+
+1. No, close the drift by mirroring production. Recommended when the behavior affects auth, data safety, billing, or user-visible access.
+2. Yes, keep it and add `[specific compensating guard]`.
+3. Unsure, record it as a blocking parity risk with owner `[owner/team if known]`.
+```
+
+## Test Boundary
+
+Use when there are multiple plausible places to enforce a parity guard.
+
+```markdown
+The highest-risk drift is `[risk]`. Which guard should the generated skill prefer?
+
+1. Fast deterministic test at `[unit/integration/config]` boundary. Recommended if it can observe the production rule.
+2. E2E or smoke test through `[real route/deployed preview]`. Better confidence, slower feedback.
+3. Static manifest/config check. Good for infra settings, weaker for runtime behavior.
+```
+
+## Heavy Local Dependency
+
+Use when mirroring production exactly would require expensive local infrastructure.
+
+```markdown
+Production uses `[service]`, but running it locally may be heavy.
+What parity strategy should the generated skill encode?
+
+1. Run the real service in local/CI with minimal seeded config. Highest parity, more setup cost.
+2. Use an emulator/fake with contract tests against production-like fixtures. Balanced for most teams.
+3. Mock it in tests, but require preview/staging smoke tests against the real integration. Fast local work, later feedback.
+```
+
+## Question Capture Format
+
+After the user answers, capture:
+
+- question asked
+- chosen answer
+- evidence that made the question necessary
+- generated-skill section updated
+- resulting guard or explicit divergence
+
+If the answer is ambiguous, ask one follow-up that makes it testable.


### PR DESCRIPTION
## Summary
- Add production-parity-skill-builder with an inspect-first workflow for creating app-specific production parity skills
- Add parity surface, question pattern, and generated skill template resources
- Update README skill counts/index and credit GitHub user @dm for the idea
- Add a minor changeset

## Tests
- pnpm test
- Ruby YAML frontmatter validation for all checked-in skills