### PR TITLE
Clarify requirements-to-code skill pipeline

### DIFF
--- a/.changeset/strict-slices-enforce.md
+++ b/.changeset/strict-slices-enforce.md
@@ -1,0 +1,5 @@
+---
+"@paulhammond/dotfiles": patch
+---
+
+Enforce loading the full `tdd`, `testing`, `mutation-testing`, and `refactoring` skill cycle before implementing planned slices.

--- a/.changeset/strict-slices-enforce.md
+++ b/.changeset/strict-slices-enforce.md
@@ -2,4 +2,4 @@
 "@paulhammond/dotfiles": patch
 ---
 
-Clarify the requirements-to-code skill pipeline and enforce loading the full `tdd`, `testing`, `mutation-testing`, and `refactoring` skill cycle before implementing planned slices.
+Clarify the requirements-to-code skill pipeline so consumers know when to use `grill-me`, `story-splitting`, `find-gaps`, `planning`, and the TDD execution skills. Also enforce loading the full `tdd`, `testing`, `mutation-testing`, and `refactoring` skill cycle before implementing planned slices.

--- a/.changeset/strict-slices-enforce.md
+++ b/.changeset/strict-slices-enforce.md
@@ -2,4 +2,4 @@
 "@paulhammond/dotfiles": patch
 ---
 
-Enforce loading the full `tdd`, `testing`, `mutation-testing`, and `refactoring` skill cycle before implementing planned slices.
+Clarify the requirements-to-code skill pipeline and enforce loading the full `tdd`, `testing`, `mutation-testing`, and `refactoring` skill cycle before implementing planned slices.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,5 @@
 # Changelog
 
-## Unreleased
-
-### Patch Changes
-
-- Clarify the requirements-to-code skill pipeline so consumers can choose between `grill-me`, `story-splitting`, `find-gaps`, `planning`, and the TDD execution skills.
-- Enforce loading `tdd`, `testing`, `mutation-testing`, and `refactoring` before implementing planned slices.
-
 ## 3.30.0
 
 ### Minor Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Patch Changes
+
+- Clarify the requirements-to-code skill pipeline so consumers can choose between `grill-me`, `story-splitting`, `find-gaps`, `planning`, and the TDD execution skills.
+- Enforce loading `tdd`, `testing`, `mutation-testing`, and `refactoring` before implementing planned slices.
+
 ## 3.30.0
 
 ### Minor Changes

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ For product work, the skills fit together like this:
 2. **`planning`** — turn the selected child story or narrow capability into PR-sized implementation slices in `plans/`.
 3. **`storyboard`** — when UX spans multiple surfaces, create the visual review artifact that reveals missing mocks and flow gaps.
 4. **`find-gaps`** — tighten plans, acceptance criteria, and mocks; if it finds horizontal/component slices, go back to `story-splitting`.
-5. **`tdd` + `testing` + `mutation-testing` + `refactoring`** — execute each approved slice in a known-good state.
+5. **`tdd` + `testing` + `mutation-testing` + `refactoring`** — load all four before code changes for every approved slice, then execute RED-GREEN-MUTATE-KILL MUTANTS-REFACTOR in a known-good state.
 
 Use `grill-me` at any point when the decision tree itself needs pressure-testing before the artifact is ready to split, plan, or implement.
 
@@ -1251,24 +1251,26 @@ This is the full lifecycle for working on a feature, from project setup through 
 #### Phase 3: Implement (repeat for each slice in the plan)
 
 ```
+LOAD         →  Load tdd + testing + mutation-testing + refactoring before code changes
 RED          →  Write a failing test (tdd-guardian verifies test-first)
 GREEN        →  Write minimum code to pass (ts-enforcer checks type safety)
 MUTATE       →  Run mutation testing, produce report (mutation-testing skill)
 KILL MUTANTS →  Address surviving mutants (ask human when ambiguous)
-REFACTOR     →  Assess improvements (refactor-scan identifies opportunities)
+REFACTOR     →  Assess improvements (refactoring skill + refactor-scan)
 COMMIT       →  Wait for approval, then commit
 ```
 
-**Why this order:** Mutation testing comes *before* refactoring so you restructure code with verified test strength, not assumed test strength. The cycle is enforced by agents, not willpower. `tdd-guardian` catches tests written after code, `ts-enforcer` catches type safety violations, mutation testing verifies tests catch real bugs, and `refactor-scan` only runs after MUTATE — you refactor with confidence that your tests are strong. Each cycle produces one small, reviewable commit.
+**Why this order:** The implementation skills are loaded first so the agent has the full workflow, test-writing patterns, mutation rules, and refactoring rubric in context before touching code. Mutation testing comes *before* refactoring so you restructure code with verified test strength, not assumed test strength. The cycle is enforced by skills and agents, not willpower. `tdd-guardian` catches tests written after code, `ts-enforcer` catches type safety violations, mutation testing verifies tests catch real bugs, and `refactor-scan` only runs after MUTATE — you refactor with confidence that your tests are strong. Each cycle produces one small, reviewable commit.
 
 #### Phase 4: Pre-PR Quality Gate
 
 Before creating any PR, run these checks in order:
 
 ```
-1. mutation-testing  →  Verify tests actually detect changes (kill surviving mutants)
-2. refactor-scan     →  Assess refactoring opportunities (only if adds value)
-3. /pr               →  Runs typecheck + lint + test + build, then creates PR
+1. skill routing     →  Verify tdd + testing + mutation-testing + refactoring were loaded
+2. mutation-testing  →  Verify tests actually detect changes (kill surviving mutants)
+3. refactoring       →  Assess refactoring opportunities (only if adds value)
+4. /pr               →  Runs typecheck + lint + test + build, then creates PR
 ```
 
 **Why mutation testing before the PR:** 100% code coverage doesn't mean your tests are good — it just means the code ran. Mutation testing verifies your tests would actually catch bugs. Running `refactor-scan` after ensures you're not shipping code you already know could be cleaner.

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ Unlike typical style guides, CLAUDE.md provides:
 | **Refactoring** | Priority classification, semantic vs structural framework, DRY decision tree | [→ skills/refactoring](claude/.claude/skills/refactoring/SKILL.md) |
 | **Functional Programming** | Immutability violations catalog, pure functions, composition patterns | [→ skills/functional](claude/.claude/skills/functional/SKILL.md) |
 | **Expectations** | Learning capture guidance, documentation templates, quality criteria | [→ skills/expectations](claude/.claude/skills/expectations/SKILL.md) |
-| **Planning** | Vertical slices, known-good increments, commit approval, prefer small PRs | [→ skills/planning](claude/.claude/skills/planning/SKILL.md) |
-| **Story Splitting** | Split large stories, epics, features, and backlog items into small end-to-end user-value slices; based on Tim Ottinger's story-splitting resource list and linked articles | [→ skills/story-splitting](claude/.claude/skills/story-splitting/SKILL.md) |
+| **Planning** | Turn a selected child story or narrow capability into PR-sized implementation slices with acceptance criteria and the required TDD skill cycle | [→ skills/planning](claude/.claude/skills/planning/SKILL.md) |
+| **Story Splitting** | Turn broad stories, epics, features, and backlog items into independently valuable child stories; based on Tim Ottinger's story-splitting resource list and linked articles | [→ skills/story-splitting](claude/.claude/skills/story-splitting/SKILL.md) |
 | **CI Debugging** | Systematic CI/CD failure diagnosis, hypothesis-first debugging, environment delta analysis | [→ skills/ci-debugging](claude/.claude/skills/ci-debugging/SKILL.md) |
 | **Production Parity Skill Builder** | Creates app-specific skills that inspect docs, code, tests, CI, deployment, infrastructure, config, auth, and environment setup to catch drift between production and non-production environments | [→ skills/production-parity-skill-builder](claude/.claude/skills/production-parity-skill-builder/SKILL.md) |
 | **Hexagonal Architecture** | Ports and adapters, driving/driven asymmetry, CQRS-lite, composition roots, cross-cutting concerns, DI patterns, anti-patterns with code examples, full worked example, incremental adoption. 5 deep-dive resources | [→ skills/hexagonal-architecture](claude/.claude/skills/hexagonal-architecture/SKILL.md) |
@@ -99,8 +99,8 @@ Unlike typical style guides, CLAUDE.md provides:
 | **Teach Me** | Evidence-based private tutor for any topic. Discovery interview, structured learning plans, Socratic questioning, Bloom's Taxonomy progression, spaced repetition, confidence calibration, course generation. 4 deep-dive resources. Invoked via `/teach-me [topic]` | [→ skills/teach-me](claude/.claude/skills/teach-me/SKILL.md) |
 | **Diagrams** | Create diagrams in Markdown using Mermaid, Graphviz, Vega-Lite, PlantUML, JSON Canvas, infographics, info cards, architecture diagrams. Decision guide picks the right tool; 8 per-tool references. Vendored from [markdown-viewer/skills](https://github.com/markdown-viewer/skills) under MIT | [→ skills/diagrams](claude/.claude/skills/diagrams/SKILL.md) |
 | **Find Skills** | Discovers and installs skills from the open agent skills ecosystem (`npx skills`, [skills.sh](https://skills.sh/)). Activates on "how do I do X" / "find a skill for X". Verifies install count, source reputation, and GitHub stars before recommending. Vendored from [vercel-labs/skills](https://github.com/vercel-labs/skills) under MIT | [→ skills/find-skills](claude/.claude/skills/find-skills/SKILL.md) |
-| **Find Gaps** | Conversational pre-implementation review for plans, acceptance criteria, and design mocks. Surveys the artifact with a per-type checklist, then walks you through gaps **one question at a time**, turning each answer into a new AC (Given/When/Then), plan paragraph, or mock-state spec written back to the source of truth. Output is the tightened artifact, not a gap report. Pairs with `storyboard` for multi-mock audits | [→ skills/find-gaps](claude/.claude/skills/find-gaps/SKILL.md) |
-| **Grill Me** | Relentless one-question-at-a-time plan and design interviews. Stress-tests decisions branch-by-branch, explores the codebase when it can answer questions directly, and recommends an answer for each unresolved question | [→ skills.sh/mattpocock/skills/grill-me](https://skills.sh/mattpocock/skills/grill-me) |
+| **Find Gaps** | Conversational pre-implementation review for written stories, plans, acceptance criteria, specs, and design mocks. Surveys the artifact with a per-type checklist, then walks you through gaps **one question at a time**, turning each answer into a new AC (Given/When/Then), plan paragraph, or mock-state spec written back to the source of truth. Output is the tightened artifact, not a gap report. Pairs with `storyboard` for multi-mock audits | [→ skills/find-gaps](claude/.claude/skills/find-gaps/SKILL.md) |
+| **Grill Me** | Relentless one-question-at-a-time decision-tree interviews before story splitting, planning, or implementation. Stress-tests decisions branch-by-branch, explores the codebase when it can answer questions directly, and recommends an answer for each unresolved question | [→ skills.sh/mattpocock/skills/grill-me](https://skills.sh/mattpocock/skills/grill-me) |
 | **Web Quality Audit** | Comprehensive Lighthouse-based quality review across all categories | [→ web-quality-skills](https://github.com/addyosmani/web-quality-skills) |
 | **Performance** | Loading speed, runtime efficiency, resource optimization | [→ web-quality-skills](https://github.com/addyosmani/web-quality-skills) |
 | **Core Web Vitals** | LCP, INP, CLS specific optimizations | [→ web-quality-skills](https://github.com/addyosmani/web-quality-skills) |
@@ -132,8 +132,10 @@ Unlike typical style guides, CLAUDE.md provides:
 | Accidental mutations breaking things | [functional](claude/.claude/skills/functional/SKILL.md) | Complete immutability violations catalog |
 | Writing code before tests | [tdd](claude/.claude/skills/tdd/SKILL.md) | TDD quality gates + git verification |
 | Losing context on complex features | [expectations](claude/.claude/skills/expectations/SKILL.md) | Learning capture framework (7 criteria) |
-| Planning significant work | [planning](claude/.claude/skills/planning/SKILL.md) | Vertical slices through the real production path, commit approval |
-| Splitting a big story or epic | [story-splitting](claude/.claude/skills/story-splitting/SKILL.md) | Preserve end-to-end customer value while shrinking variation, risk, and scope |
+| Requirement is still fuzzy or decision-heavy | [grill-me](https://skills.sh/mattpocock/skills/grill-me) | Pressure-test the decision tree one question at a time before writing stories or plans |
+| Turning a broad requirement into stories | [story-splitting](claude/.claude/skills/story-splitting/SKILL.md) | Produce independently valuable child stories with scope, deferrals, and acceptance examples |
+| Planning significant implementation work | [planning](claude/.claude/skills/planning/SKILL.md) | Turn one selected child story into PR-sized implementation slices with commit approval |
+| Tightening a story, plan, AC set, or mock | [find-gaps](claude/.claude/skills/find-gaps/SKILL.md) | Find missing decisions and write confirmed answers back into the artifact |
 | Backlog items keep turning into frontend/backend tickets | [story-splitting](claude/.claude/skills/story-splitting/SKILL.md) | Reject component stories; split by capability, path, interface, data, rules, quality, or learning |
 | CI pipeline keeps failing | [ci-debugging](claude/.claude/skills/ci-debugging/SKILL.md) | Every failure is real until proven otherwise, hypothesis-first diagnosis |
 | Local, CI, PR, or staging differs from production | [production-parity-skill-builder](claude/.claude/skills/production-parity-skill-builder/SKILL.md) | Generate an app-specific parity skill that inspects source, infra, config, and auth before asking targeted questions |
@@ -185,15 +187,19 @@ Skills are **auto-discovered** by Claude when relevant:
 
 ### Scope-to-Implementation Flow
 
-For product work, the skills fit together like this:
+For product work, the skills form a requirements-to-code pipeline. Each skill owns a different question and produces a different artifact:
 
-1. **`story-splitting`** — turn a broad story, epic, feature, or backlog item into independently valuable child stories.
-2. **`planning`** — turn the selected child story or narrow capability into PR-sized implementation slices in `plans/`.
-3. **`storyboard`** — when UX spans multiple surfaces, create the visual review artifact that reveals missing mocks and flow gaps.
-4. **`find-gaps`** — tighten plans, acceptance criteria, and mocks; if it finds horizontal/component slices, go back to `story-splitting`.
-5. **`tdd` + `testing` + `mutation-testing` + `refactoring`** — load all four before code changes for every approved slice, then execute RED-GREEN-MUTATE-KILL MUTANTS-REFACTOR in a known-good state.
+| Stage | Question | Skill | Output |
+|-------|----------|-------|--------|
+| 1. Decide | Do we understand the product/design decision tree? | `grill-me` | Resolved decisions, recommended answers, and remaining open questions |
+| 2. Split | What independently valuable child stories exist? | `story-splitting` | Child stories with value, scope, deferrals, acceptance examples, and release constraints |
+| 3. Tighten | What is missing, ambiguous, unverifiable, or unsafe? | `find-gaps` | Confirmed artifact updates: AC, plan paragraphs, mock-state specs, or a return to `story-splitting` |
+| 4. Plan | How do we implement the selected child story safely? | `planning` | PR-sized implementation slices in `plans/` |
+| 5. Build | How do we change code without outrunning tests? | `tdd` + `testing` + `mutation-testing` + `refactoring` | RED-GREEN-MUTATE-KILL MUTANTS-REFACTOR in a known-good state |
 
-Use `grill-me` at any point when the decision tree itself needs pressure-testing before the artifact is ready to split, plan, or implement.
+Use the earliest stage that matches the uncertainty. Skip `grill-me` when the decision is already clear. Skip `story-splitting` for tiny or already-narrow work. Use `find-gaps` only once there is an artifact to inspect. Use `planning` only after one child story or narrow capability has been selected for implementation.
+
+`storyboard` fits between Split and Tighten when UX spans multiple surfaces: it creates the visual artifact; `find-gaps` then reviews missing states and flow gaps.
 
 **No manual invocation needed** - Claude detects when skills apply. Impeccable steering commands (`/shape`, `/critique`, `/polish`, etc.) can also be invoked directly, and you can explicitly ask to be "grilled" on a plan when you want a deeper interview.
 

--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -94,8 +94,10 @@ For detailed patterns and examples, load the `functional` skill.
 For detailed TDD workflow, load the `tdd` skill.
 For implementation of any planned slice, load `tdd`, `testing`, `mutation-testing`, and `refactoring` before code changes begin.
 For refactoring methodology, load the `refactoring` skill.
-For broad stories, epics, features, or backlog items, load the `story-splitting` skill before planning.
-For significant implementation work, load the `planning` skill to turn selected slices into PR-sized plans in `plans/`.
+For fuzzy product/design decisions, load `grill-me` to pressure-test the decision tree before writing stories or plans.
+For broad stories, epics, features, or backlog items, load `story-splitting` to create child stories before planning.
+For tightening an existing story, plan, acceptance criteria set, or mock spec, load `find-gaps` to write confirmed answers back into the artifact.
+For significant implementation work, load `planning` to turn one selected child story or narrow capability into PR-sized plans in `plans/`.
 For CI failure diagnosis, load the `ci-debugging` skill.
 For hexagonal architecture projects, load the `hexagonal-architecture` skill.
 For Domain-Driven Design projects, load the `domain-driven-design` skill.
@@ -106,8 +108,8 @@ For documenting existing behavior before changes, load the `characterisation-tes
 For multi-surface design audits before code (embed every mock in a scope on one reviewable page with flow diagram + gap cards + per-mock audit checklists), load the `storyboard` skill.
 For structured learning of any topic (interactive tutoring, courses, quizzes), use `/teach-me [topic]`.
 For discovering and installing agent skills from the open ecosystem (`npx skills`), load the `find-skills` skill.
-For adversarial review of plans, acceptance criteria, or design mocks — one question at a time, turning each answer into a new AC / plan paragraph / mock-state spec written back to the source of truth — load the `find-gaps` skill.
-For relentless plan or design interrogation before implementation — one question at a time, with recommended answers and codebase exploration where useful — load the `grill-me` skill.
+For adversarial review of plans, acceptance criteria, stories, or design mocks — one question at a time, turning each answer into a new AC / plan paragraph / mock-state spec written back to the source of truth — load the `find-gaps` skill.
+For relentless decision-tree interrogation before story splitting, planning, or implementation — one question at a time, with recommended answers and codebase exploration where useful — load the `grill-me` skill.
 
 **Project onboarding:** Run `/setup` in any new project to detect its tech stack and generate project-level CLAUDE.md, hooks, commands, and PR review agent in one shot. This replaces the need for `/init`.
 

--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -92,6 +92,7 @@ For detailed patterns and examples, load the `functional` skill.
 - **Wait for commit approval** before every commit
 - Each increment leaves codebase in working state
 For detailed TDD workflow, load the `tdd` skill.
+For implementation of any planned slice, load `tdd`, `testing`, `mutation-testing`, and `refactoring` before code changes begin.
 For refactoring methodology, load the `refactoring` skill.
 For broad stories, epics, features, or backlog items, load the `story-splitting` skill before planning.
 For significant implementation work, load the `planning` skill to turn selected slices into PR-sized plans in `plans/`.

--- a/claude/.claude/agents/README.md
+++ b/claude/.claude/agents/README.md
@@ -250,9 +250,12 @@ progress-guardian (orchestrates)
    - Get approval for the plan before writing any code
 
 3. **For each step in plan**
-   - RED: Write failing test (TDD non-negotiable)
+   - LOAD: `tdd`, `testing`, `mutation-testing`, and `refactoring` before code changes
+   - RED: Write failing behavior test (TDD non-negotiable)
    - GREEN: Minimal code to pass
-   - REFACTOR: Invoke `refactor-scan` to assess improvements
+   - MUTATE: Run `mutation-testing` skill and produce a report
+   - KILL MUTANTS: Address surviving mutants or justify equivalent mutants
+   - REFACTOR: Run `refactoring` skill and invoke `refactor-scan` to assess improvements
    - **WAIT FOR COMMIT APPROVAL**
 
 4. **When plan needs changing**
@@ -267,8 +270,9 @@ progress-guardian (orchestrates)
    - **Ask for commit approval**
 
 7. **Pre-PR quality gate**
+   - Verify `tdd`, `testing`, `mutation-testing`, and `refactoring` were loaded for implemented slices
    - Run `mutation-testing` skill: Verify tests detect changes, kill surviving mutants
-   - Invoke `refactor-scan`: Assess improvements (only if adds value)
+   - Run `refactoring` skill and invoke `refactor-scan`: Assess improvements (only if adds value)
    - Invoke `pr-reviewer`: Self-review changes
    - Fix any issues found
    - Run `/pr` to create PR with quality gates (typecheck + lint + test + build)

--- a/claude/.claude/agents/progress-guardian.md
+++ b/claude/.claude/agents/progress-guardian.md
@@ -67,19 +67,30 @@ User: "Feature is complete"
 ## Slices
 
 Each slice should be the thinnest useful end-to-end behaviour through the real production path.
+Every slice must load `tdd`, `testing`, `mutation-testing`, and `refactoring` before implementation, then follow RED-GREEN-MUTATE-KILL MUTANTS-REFACTOR.
 
 ### Slice 1: [One sentence observable behaviour]
 
 - **Value**: Who gets what value?
 - **Path**: Entry point -> business path -> state/output -> observability
-- **Test**: What failing test will we write?
+- **Required implementation skills**: `tdd`, `testing`, `mutation-testing`, `refactoring`
+- **RED**: What failing behavior test will we write?
+- **GREEN**: What minimum code makes it pass?
+- **MUTATE**: Run `mutation-testing` skill and produce a report
+- **KILL MUTANTS**: Address surviving mutants or justify equivalent mutants
+- **REFACTOR**: Run `refactoring` skill and apply only valuable improvements
 - **Done when**: How do we know it's complete?
 
 ### Slice 2: [One sentence observable behaviour]
 
 - **Value**: Who gets what value?
 - **Path**: Entry point -> business path -> state/output -> observability
-- **Test**: What failing test will we write?
+- **Required implementation skills**: `tdd`, `testing`, `mutation-testing`, `refactoring`
+- **RED**: What failing behavior test will we write?
+- **GREEN**: What minimum code makes it pass?
+- **MUTATE**: Run `mutation-testing` skill and produce a report
+- **KILL MUTANTS**: Address surviving mutants or justify equivalent mutants
+- **REFACTOR**: Run `refactoring` skill and apply only valuable improvements
 - **Done when**: How do we know it's complete?
 
 ## Pre-PR Quality Gate

--- a/claude/.claude/agents/tdd-guardian.md
+++ b/claude/.claude/agents/tdd-guardian.md
@@ -1,7 +1,7 @@
 ---
 name: tdd-guardian
 description: >
-  Use this agent proactively to guide Test-Driven Development throughout the coding process and reactively to verify TDD compliance. Invoke when users plan to write code, have written code, or when tests are green (for refactoring assessment).
+  Use this agent proactively to guide Test-Driven Development throughout the coding process and reactively to verify TDD compliance. Invoke when users plan to write code, have written code, tests are green, mutation testing is due, or refactoring assessment is due.
 tools: Read, Grep, Glob, Bash
 model: sonnet
 color: red
@@ -33,19 +33,23 @@ You are the TDD Guardian, an elite Test-Driven Development coach and enforcer. Y
 **Process:**
 1. **Identify the simplest behavior** to test first
 2. **Help write the failing test** that describes business behavior
-3. **Ensure test is behavior-focused**, not implementation-focused
-4. **Stop them** if they try to write production code before the test
-5. **Guide minimal implementation** - only enough to pass
-6. **Prompt refactoring assessment** when tests are green
+3. **Ensure the `testing` skill is loaded** for behavior-driven test patterns
+4. **Ensure test is behavior-focused**, not implementation-focused
+5. **Stop them** if they try to write production code before the test
+6. **Guide minimal implementation** - only enough to pass
+7. **Require mutation testing** by loading the `mutation-testing` skill before refactoring
+8. **Require refactoring assessment** by loading the `refactoring` skill after mutants are killed
 
 **Response Pattern:**
 ```
 "Let's start with TDD. What's the simplest behavior we can test first?
 
 We'll:
-1. Write a failing test for that specific behavior
-2. Implement just enough code to make it pass
-3. Assess if refactoring would add value
+1. Load `testing` for behavior-driven test patterns
+2. Write a failing test for that specific behavior
+3. Implement just enough code to make it pass
+4. Load `mutation-testing`, run it, and kill valuable survivors
+5. Load `refactoring` and assess whether restructuring adds value
 
 What behavior should we test?"
 ```

--- a/claude/.claude/agents/tdd-guardian.md
+++ b/claude/.claude/agents/tdd-guardian.md
@@ -31,25 +31,25 @@ You are the TDD Guardian, an elite Test-Driven Development coach and enforcer. Y
 **Your job:** Guide them through TDD BEFORE they write production code.
 
 **Process:**
-1. **Identify the simplest behavior** to test first
-2. **Help write the failing test** that describes business behavior
-3. **Ensure the `testing` skill is loaded** for behavior-driven test patterns
+1. **Ensure the full implementation cycle is loaded** before code changes: `tdd`, `testing`, `mutation-testing`, and `refactoring`
+2. **Identify the simplest behavior** to test first
+3. **Help write the failing test** that describes business behavior
 4. **Ensure test is behavior-focused**, not implementation-focused
 5. **Stop them** if they try to write production code before the test
 6. **Guide minimal implementation** - only enough to pass
-7. **Require mutation testing** by loading the `mutation-testing` skill before refactoring
-8. **Require refactoring assessment** by loading the `refactoring` skill after mutants are killed
+7. **Run mutation testing** before refactoring and produce a report
+8. **Run refactoring assessment** after valuable mutants are killed
 
 **Response Pattern:**
 ```
 "Let's start with TDD. What's the simplest behavior we can test first?
 
 We'll:
-1. Load `testing` for behavior-driven test patterns
+1. Load `tdd`, `testing`, `mutation-testing`, and `refactoring`
 2. Write a failing test for that specific behavior
 3. Implement just enough code to make it pass
-4. Load `mutation-testing`, run it, and kill valuable survivors
-5. Load `refactoring` and assess whether restructuring adds value
+4. Run mutation testing and kill valuable survivors
+5. Assess whether restructuring adds value
 
 What behavior should we test?"
 ```

--- a/claude/.claude/commands/plan.md
+++ b/claude/.claude/commands/plan.md
@@ -46,12 +46,13 @@ Tests at every level (unit, browser, integration) should verify behaviour.]
 
 Every slice should be the thinnest useful end-to-end behaviour: actor, trigger, observable outcome, production path, and smallest deployable value.
 Every slice follows RED-GREEN-MUTATE-KILL MUTANTS-REFACTOR. No production code without a failing test.
-Read the project's CLAUDE.md and testing rules before writing slices.
+Every slice must explicitly load `tdd`, `testing`, `mutation-testing`, and `refactoring` before implementation. Read the project's CLAUDE.md and testing rules before writing slices.
 
 ### Slice 1: [One sentence observable behaviour]
 
 **Value**: Who gets what value?
 **Path**: Entry point -> business path -> state/output -> observability. Name any intentionally skipped states.
+**Required implementation skills**: Before code changes, load `tdd`, `testing`, `mutation-testing`, and `refactoring` (plus UI/domain/architecture skills when relevant).
 **Acceptance criteria**: What observable behaviour proves this slice is done? Present to human and get confirmation before writing any code.
 **RED**: What failing test will we write? (Describes expected behaviour, not implementation.)
 **GREEN**: What minimum code makes the test pass?
@@ -82,6 +83,7 @@ Before each PR:
 - **Prefer vertical slices** — break work into the smallest independently mergeable units that deliver observable value through the real production path.
 - **Avoid layer-cake plans** — database-only, API-only, UI-only, and "do all plumbing first" work is allowed only when it names the next vertical slice it unlocks and has independent verification.
 - Each slice in the plan must be small enough for a single PR. A slice may contain multiple TDD commits, but it must be reviewable and mergeable as one coherent unit.
+- **Skill routing is mandatory** — every slice must list `tdd`, `testing`, `mutation-testing`, and `refactoring` as required implementation skills before code changes begin.
 - **TDD is mandatory** — every slice must specify the failing test first (RED), then the minimum implementation (GREEN), then mutation testing to verify test effectiveness, then kill surviving mutants, then refactoring assessment. No exceptions.
 - **Test behaviour, not implementation** — acceptance criteria and test descriptions must describe observable outcomes (what the user sees, what the API returns), never internal details (what function was called, what query was run)
 - **Read project testing rules** — before writing slices, read the project's CLAUDE.md and any testing guidelines to ensure tests follow the project's conventions (factories, MSW vs mocks, real DB vs stubs, etc.)

--- a/claude/.claude/commands/plan.md
+++ b/claude/.claude/commands/plan.md
@@ -16,9 +16,11 @@ Create a vertical-slice plan for the requested work:
 
 1. If on main, create a new feature branch first
 2. Explore the codebase to understand the relevant areas
-3. If the request is still a large story, epic, broad feature idea, or backlog item, use the `story-splitting` skill first to identify independently valuable child stories
-4. Write the plan to `plans/<feature-name>.md` (create the directory if needed)
-5. Create a PR with the plan for review
+3. If the request has unresolved product or design decisions, use `grill-me` before writing stories or plans
+4. If the request is still a large story, epic, broad feature idea, or backlog item, use the `story-splitting` skill first to identify independently valuable child stories
+5. If the selected story, acceptance criteria, or mocks are ambiguous, use `find-gaps` to tighten the artifact before finalizing the plan
+6. Write the plan to `plans/<feature-name>.md` (create the directory if needed)
+7. Create a PR with the plan for review
 
 ## Plan File Structure
 

--- a/claude/.claude/commands/pr.md
+++ b/claude/.claude/commands/pr.md
@@ -13,10 +13,12 @@ Changes summary:
 
 Before creating the PR, verify each of these has been completed:
 
-1. **Mutation testing** — The `mutation-testing` skill has been run. All surviving mutants are killed or justified as equivalent mutants.
-2. **Refactoring assessment** — The `refactoring` skill has been run. Any valuable refactoring has been committed separately.
-3. **Typecheck and lint pass** — The project's typecheck and lint commands pass with zero errors.
-4. **DDD glossary check** (if project uses DDD) — All new/changed types, functions, and test names conform to the project's DDD glossary.
+1. **Implementation skill routing** — For each implemented slice, `tdd`, `testing`, `mutation-testing`, and `refactoring` were loaded before code changes began.
+2. **TDD evidence** — RED happened before GREEN; every production change was demanded by a failing behavior test.
+3. **Mutation testing** — The `mutation-testing` skill has been run. All surviving mutants are killed or justified as equivalent mutants.
+4. **Refactoring assessment** — The `refactoring` skill has been run. Any valuable refactoring has been committed separately.
+5. **Typecheck and lint pass** — The project's typecheck and lint commands pass with zero errors.
+6. **DDD glossary check** (if project uses DDD) — All new/changed types, functions, and test names conform to the project's DDD glossary.
 
 If any step has not been completed, run it now before creating the PR.
 

--- a/claude/.claude/skills/REFERENCES.md
+++ b/claude/.claude/skills/REFERENCES.md
@@ -305,8 +305,8 @@ Authoritative sources used to develop the DDD and hexagonal architecture skills.
 - **RED-GREEN-REFACTOR cycle** (original formulation) → TDD skill: core workflow foundation
 - **Tests as documentation of behavior** → Testing skill: test naming guidance
 
-### Eran Boudjnah — RED-GREEN-MUTATE-REFACTOR reordering
-- **Mutation testing before refactoring** → TDD skill: cycle ordering. Insight: verify test strength *before* restructuring code, so you refactor with genuine confidence. Pointed out on LinkedIn that the original RED-GREEN-REFACTOR-MUTATE order means refactoring with unverified test effectiveness.
+### Eran Boudjnah — RED-GREEN-MUTATE-REFACTOR reordering, extended with KILL MUTANTS
+- **Mutation testing before refactoring** → TDD skill: RED-GREEN-MUTATE-KILL MUTANTS-REFACTOR ordering. Insight: verify test strength and address valuable survivors *before* restructuring code, so you refactor with genuine confidence. Pointed out on LinkedIn that the original RED-GREEN-REFACTOR-MUTATE order means refactoring with unverified test effectiveness.
 
 ### Gary Bernhardt — ["Boundaries"](https://www.destroyallsoftware.com/talks/boundaries) (2012)
 - **Functional core, imperative shell** — pure domain logic surrounded by impure adapters → Hex arch skill: the fundamental structural principle

--- a/claude/.claude/skills/find-gaps/SKILL.md
+++ b/claude/.claude/skills/find-gaps/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: find-gaps
-description: Adversarially review plans, acceptance criteria, and design mocks to surface missing states, unhandled edge cases, unstated assumptions, unverifiable criteria, and plan slices that are still too broad or horizontal — then work interactively with the user, one question at a time, to turn each gap into a new acceptance criterion, plan update, mock-state spec, or recommendation to use story-splitting. Use when reviewing a spec/plan/mocks before coding, when the user says "what's missing?" / "find gaps" / "poke holes" / "help me tighten this", or when a hand-off artifact needs to reach a testable state.
+description: Adversarially review written stories, plans, acceptance criteria, specs, and design mocks to surface missing states, unhandled edge cases, unstated assumptions, unverifiable criteria, and slices that are still too broad or horizontal — then work interactively with the user, one question at a time, to turn each gap into a new acceptance criterion, plan update, mock-state spec, or recommendation to use story-splitting. Use when an existing artifact needs tightening before planning or coding.
 ---
 
 # Find Gaps
@@ -20,8 +20,21 @@ Use this skill when the user:
 - Is doing a pre-mortem
 
 Pair with `storyboard` when reviewing multiple mocks together — storyboard gives the single-page view, this skill finds what's *missing* across them.
-Pair with `story-splitting` when a plan, spec, or backlog item is too large, horizontal, component-split, or not yet expressed as independently valuable child stories.
+Pair with `story-splitting` when a story, plan, spec, or backlog item is too large, horizontal, component-split, or not yet expressed as independently valuable child stories.
 Pair with `characterisation-tests` when the "gap" is behavior of existing code that nobody wrote down.
+
+## Boundary With Nearby Skills
+
+`find-gaps` needs an artifact to inspect. It does not discover the whole decision tree from scratch and it does not split broad work into child stories.
+
+| Need | Use | Why |
+|------|-----|-----|
+| Pressure-test unresolved product or design decisions | `grill-me` | It interviews the decision tree and recommends answers |
+| Break broad work into independently valuable child stories | `story-splitting` | It creates product/backlog stories, not implementation tasks |
+| Tighten a written story, plan, AC set, or mock spec | `find-gaps` | It finds missing states, edge cases, roles, constraints, and unverifiable wording, then writes confirmed decisions back |
+| Sequence a selected child story into PR-sized work | `planning` | It owns implementation slices and the TDD execution plan |
+
+If the artifact is not yet written down, first use `grill-me` or `story-splitting`. If this review discovers the artifact is actually multiple stories tangled together, stop and route back to `story-splitting`. If the artifact is clear enough to implement, route forward to `planning`.
 
 ## Core Principles
 

--- a/claude/.claude/skills/mutation-testing/SKILL.md
+++ b/claude/.claude/skills/mutation-testing/SKILL.md
@@ -59,7 +59,7 @@ PRE-PR QUALITY GATE:
     └─► Re-run mutation testing for the branch/repo scope
 ```
 
-Mutation testing is not a replacement for RED-GREEN-REFACTOR. It verifies the tests created during those increments are strong enough to catch real behavioral regressions before refactoring and before PR.
+Mutation testing is not a replacement for RED-GREEN-MUTATE-KILL MUTANTS-REFACTOR. It verifies the tests created during those increments are strong enough to catch real behavioral regressions before refactoring and before PR.
 
 ---
 

--- a/claude/.claude/skills/planning/SKILL.md
+++ b/claude/.claude/skills/planning/SKILL.md
@@ -19,6 +19,15 @@ Use `story-splitting` before this skill when the request is still an epic, large
 
 If a plan starts producing database-only, API-only, UI-only, or "do all plumbing first" slices, pause and return to `story-splitting` unless the horizontal work explicitly unlocks the next vertical slice and has independent verification.
 
+Use `grill-me` before planning when the selected story still contains unresolved product or design decisions. Use `find-gaps` before or after drafting the plan when acceptance criteria, failure modes, roles, states, or release constraints are missing or unverifiable.
+
+| Input state | Use | Output |
+|-------------|-----|--------|
+| Fuzzy decision tree | `grill-me` | Resolved decisions or named open questions |
+| Broad requirement with multiple outcomes | `story-splitting` | Child stories |
+| Existing story/plan/AC/mocks with holes | `find-gaps` | Confirmed artifact updates |
+| Selected child story ready for delivery sequencing | `planning` | PR-sized implementation slices |
+
 ## Plans Directory
 
 Plans live in `plans/` at the project root. Each plan is a self-contained file named descriptively (e.g., `plans/gift-tracking.md`, `plans/email-validation.md`).

--- a/claude/.claude/skills/planning/SKILL.md
+++ b/claude/.claude/skills/planning/SKILL.md
@@ -114,10 +114,16 @@ A slice is the unit of planning and review — one PR. Within a slice, TDD incre
 
 ## TDD Integration
 
-**Every slice follows RED-GREEN-MUTATE-KILL MUTANTS-REFACTOR.** See `tdd` skill for the workflow, `testing` skill for factory patterns.
+**Every slice follows RED-GREEN-MUTATE-KILL MUTANTS-REFACTOR.** Before any implementation work for a slice, load `tdd`, `testing`, `mutation-testing`, and `refactoring`. This section is a routing contract, not a replacement for those skills.
 
 ```
 FOR EACH SLICE:
+    │
+    ├─► LOAD: Required implementation skills
+    │   - `tdd` for RED-GREEN-MUTATE-KILL MUTANTS-REFACTOR workflow
+    │   - `testing` for behavior-driven tests and factories
+    │   - `mutation-testing` for mutator-aware planning and verification
+    │   - `refactoring` for the final refactor assessment
     │
     ├─► CONFIRM: Present acceptance criteria for this slice
     │   - Human must approve criteria before any code is written
@@ -207,6 +213,7 @@ Read the project's CLAUDE.md and testing rules before writing slices.
 
 **Value**: [Who gets what value?]
 **Path**: [Entry point -> business path -> state/output -> observability. Name any intentionally skipped states.]
+**Required implementation skills**: Before code changes, load `tdd`, `testing`, `mutation-testing`, and `refactoring` (plus UI/domain/architecture skills when relevant).
 **Acceptance criteria**: [What observable behaviour proves this slice is done? Be specific — "user sees X", "API returns Y", "test covers Z". Vague criteria like "it works" are not acceptable. **Present to human and get confirmation before writing any code.**]
 **RED**: What failing test will we write? (Describes expected behaviour, not implementation. Include likely mutator gaps from the `mutation-testing` skill's `resources/mutator-rules.md` resource.)
 **GREEN**: What minimum code makes the test pass?
@@ -219,6 +226,7 @@ Read the project's CLAUDE.md and testing rules before writing slices.
 
 **Value**: ...
 **Path**: ...
+**Required implementation skills**: ...
 **Acceptance criteria**: ...
 **RED**: ...
 **GREEN**: ...
@@ -295,6 +303,7 @@ START FEATURE
 │
 │   FOR EACH SLICE:
 │   │
+│   ├─► LOAD: `tdd` + `testing` + `mutation-testing` + `refactoring`
 │   ├─► CONFIRM: Present acceptance criteria, **wait for human approval**
 │   ├─► RED: Failing test
 │   ├─► GREEN: Make it pass

--- a/claude/.claude/skills/story-splitting/SKILL.md
+++ b/claude/.claude/skills/story-splitting/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: story-splitting
-description: Split large stories, epics, features, initiatives, or backlog items into small end-to-end user-value slices without turning them into technical component tasks. Use when refining a backlog, slicing stories, decomposing epics, planning an MVP or walking skeleton, looking for vertical slices, reducing story size, applying SPIDR/Hamburger/capability slicing, avoiding scatter-gather/component stories, or deciding the first valuable slice of product work.
+description: Turn broad requirements, large stories, epics, features, initiatives, or backlog items into small end-to-end child stories without turning them into technical component tasks. Use when refining a backlog, decomposing epics, planning an MVP or walking skeleton, looking for vertical slices, reducing story size, applying SPIDR/Hamburger/capability slicing, avoiding scatter-gather/component stories, or deciding the first valuable story before implementation planning.
 ---
 
 # Story Splitting
@@ -22,7 +22,7 @@ This skill is based on Tim Ottinger's [Splitting Stories - A Resource Listicle](
 
 ## How This Fits With Other Skills
 
-Use `story-splitting` **before** `planning` when the input is a large story, epic, feature idea, roadmap item, or backlog item. This skill discovers small valuable child stories. The `planning` skill then sequences selected child stories into PR-sized slices with TDD execution details.
+Use `story-splitting` **before** `planning` when the input is a large story, epic, feature idea, roadmap item, or backlog item. This skill discovers small valuable child stories. The `planning` skill then sequences one selected child story into PR-sized implementation slices with TDD execution details.
 
 Use `find-gaps` **after** a split or plan exists when you need to tighten missing states, acceptance criteria, edge cases, or unverifiable language. If `find-gaps` discovers that the plan is still horizontal or too large, return here and split again.
 
@@ -31,6 +31,19 @@ Use `grill-me` when the issue is unresolved product or design decision-making ra
 Use `storyboard` when the work spans multiple UX surfaces or mock states; the storyboard can reveal missing screens and flow gaps that become child stories. Use design skills such as `shape`, `critique`, and `polish` to improve the mocks themselves, not to replace product slicing.
 
 This skill must not drive implementation directly. When a selected child story is ready to implement, load `planning` first. Before any code changes for a planned slice, load the full implementation cycle: `tdd`, `testing`, `mutation-testing`, and `refactoring`. Treat this as a mandatory handoff, not a reminder. Use `finding-seams` and `characterisation-tests` when a slice touches legacy code that cannot yet be tested safely. Use domain and architecture skills (`domain-driven-design`, `hexagonal-architecture`, `api-design`, `cli-design`, `twelve-factor`, `production-parity-skill-builder`) to keep each slice coherent; do not split stories by those technical layers.
+
+## Requirement Refinement Pipeline
+
+Use the earliest skill that matches the uncertainty:
+
+| If the problem is... | Use... | Stop when you have... |
+|----------------------|--------|------------------------|
+| "We don't know which decision branch is right." | `grill-me` | A resolved decision tree or a named open decision |
+| "This requirement is too broad or solution-shaped." | `story-splitting` | Independently valuable child stories |
+| "This story/spec/plan/mock has holes." | `find-gaps` | Confirmed artifact updates with testable wording |
+| "We selected a child story and need to build it." | `planning` | PR-sized implementation slices |
+
+Do not use `story-splitting` to interrogate every product decision from scratch; use `grill-me` when the decision tree is the real work. Do not use `story-splitting` to produce implementation tasks; use `planning` after a child story is selected. Do not use `find-gaps` before there is an artifact to inspect; use it to harden a split, plan, AC set, or mock spec.
 
 ## Core Principles
 

--- a/claude/.claude/skills/story-splitting/SKILL.md
+++ b/claude/.claude/skills/story-splitting/SKILL.md
@@ -30,7 +30,7 @@ Use `grill-me` when the issue is unresolved product or design decision-making ra
 
 Use `storyboard` when the work spans multiple UX surfaces or mock states; the storyboard can reveal missing screens and flow gaps that become child stories. Use design skills such as `shape`, `critique`, and `polish` to improve the mocks themselves, not to replace product slicing.
 
-During implementation, use `tdd`, `testing`, `mutation-testing`, and `refactoring` per slice. Use `finding-seams` and `characterisation-tests` when a slice touches legacy code that cannot yet be tested safely. Use domain and architecture skills (`domain-driven-design`, `hexagonal-architecture`, `api-design`, `cli-design`, `twelve-factor`, `production-parity-skill-builder`) to keep each slice coherent; do not split stories by those technical layers.
+This skill must not drive implementation directly. When a selected child story is ready to implement, load `planning` first. Before any code changes for a planned slice, load the full implementation cycle: `tdd`, `testing`, `mutation-testing`, and `refactoring`. Treat this as a mandatory handoff, not a reminder. Use `finding-seams` and `characterisation-tests` when a slice touches legacy code that cannot yet be tested safely. Use domain and architecture skills (`domain-driven-design`, `hexagonal-architecture`, `api-design`, `cli-design`, `twelve-factor`, `production-parity-skill-builder`) to keep each slice coherent; do not split stories by those technical layers.
 
 ## Core Principles
 
@@ -229,7 +229,7 @@ Why this first: [value, risk, learning, or bargain]
 [Component splits, unsafe deferrals, unclear ownership, or missing examples]
 
 ## Next Step
-[Usually: load `planning` for the selected first slice, run `find-gaps` on the split, or ask one decision question]
+[Usually: load `planning` for the selected first slice, run `find-gaps` on the split, or ask one decision question. If implementing, the plan must explicitly require `tdd`, `testing`, `mutation-testing`, and `refactoring` before code changes.]
 ```
 
 If the user wants an interactive refinement session, ask one high-value question at a time rather than dumping a questionnaire. Start with the question that most changes the split: usually actor, outcome, release constraint, highest-value customer segment, or biggest risk.

--- a/claude/.claude/skills/tdd/SKILL.md
+++ b/claude/.claude/skills/tdd/SKILL.md
@@ -37,6 +37,7 @@ TDD is the fundamental practice. Every line of production code must be written i
 
 ### REFACTOR: Assess Improvements
 - Assess AFTER mutation testing confirms test strength
+- Load the `refactoring` skill before deciding what, if anything, to restructure
 - Commit before refactoring
 - All tests must pass after refactoring
 


### PR DESCRIPTION
## Summary
- Clarify the consumer-facing requirements-to-code pipeline: `grill-me` decides, `story-splitting` creates child stories, `find-gaps` tightens written artifacts, `planning` sequences implementation, and the TDD skills execute safely.
- Update README, CLAUDE routing, `/plan`, and skill metadata/bodies so each skill has a distinct artifact, handoff, and skip condition.
- Enforce loading `tdd`, `testing`, `mutation-testing`, and `refactoring` before implementing planned slices, with changeset release-note coverage.

## PR review follow-up
- Fixed `tdd-guardian` so its proactive flow loads all four implementation skills before code changes.
- Removed the manual `CHANGELOG.md` entry to avoid duplicating Changesets-generated release notes.

## Validation
- `git diff --check`
- YAML frontmatter parse
- `npm test`