### PR TITLE
Enable OpenCode TypeScript LSP config

### DIFF
--- a/.changeset/mean-maps-flow.md
+++ b/.changeset/mean-maps-flow.md
@@ -1,0 +1,5 @@
+---
+"@paulhammond/dotfiles": minor
+---
+
+Enable OpenCode's built-in LSP support, including TypeScript, and include the OpenCode package in the stow installer.

--- a/README.md
+++ b/README.md
@@ -1515,7 +1515,7 @@ curl -fsSL https://raw.githubusercontent.com/citypaul/.dotfiles/main/install-cla
 ```
 
 **What gets installed:**
-- `~/.config/opencode/opencode.json` - Configuration that loads:
+- `~/.config/opencode/opencode.json` - Configuration that enables built-in LSP servers, including TypeScript for projects with a TypeScript dependency, and loads:
   - `~/.claude/CLAUDE.md` (core principles)
   - `~/.claude/skills/*/SKILL.md` (all skill patterns)
   - `~/.claude/agents/*.md` (agent instructions)
@@ -1533,6 +1533,7 @@ mkdir -p ~/.config/opencode/command ~/.config/opencode/agent
 cat > ~/.config/opencode/opencode.json << 'EOF'
 {
   "$schema": "https://opencode.ai/config.json",
+  "lsp": true,
   "instructions": [
     "~/.claude/CLAUDE.md",
     "~/.claude/skills/*/SKILL.md",
@@ -1855,6 +1856,7 @@ This will install:
 - ✅ CLAUDE.md + skills (26 from this repo plus external skill bundles) + 10 agents (development guidelines)
 - ✅ Commands (/setup, /pr, /plan, /continue, /generate-pr-review slash commands)
 - ✅ Claude Code settings.json (plugins, hooks, statusline)
+- ✅ OpenCode configuration (guidelines plus built-in LSP servers, including TypeScript)
 - ✅ Git aliases and configuration
 - ✅ Shell configuration (bash/zsh)
 - ✅ Vim, tmux, npm configs

--- a/install.sh
+++ b/install.sh
@@ -25,5 +25,6 @@ git gtr completion zsh >~/.zsh_autocomplete/_git-gtr
 move_with_backup ~/.zshrc
 
 move_with_backup "$HOME/Library/Application Support/com.mitchellh.ghostty/config"
+move_with_backup "$HOME/.config/opencode/opencode.json"
 
-stow zsh tmux gnupg alacritty zellij .oh-my-zsh karabiner ghostty claude
+stow zsh tmux gnupg alacritty zellij .oh-my-zsh karabiner ghostty claude opencode

--- a/opencode/.config/opencode/opencode.json
+++ b/opencode/.config/opencode/opencode.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://opencode.ai/config.json",
+  "lsp": true,
   "instructions": [
     "~/.claude/CLAUDE.md",
     "~/.claude/skills/*/SKILL.md",

--- a/test/opencode-compat.sh
+++ b/test/opencode-compat.sh
@@ -15,6 +15,8 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 AGENTS_DIR="$REPO_ROOT/claude/.claude/agents"
 COMMANDS_DIR="$REPO_ROOT/claude/.claude/commands"
+OPENCODE_CONFIG="$REPO_ROOT/opencode/.config/opencode/opencode.json"
+INSTALL_SCRIPT="$REPO_ROOT/install.sh"
 TMPDIR=$(mktemp -d)
 FAILURES=0
 
@@ -90,6 +92,29 @@ for cmd in "$COMMANDS_DIR"/*.md; do
     fail "$name: frontmatter structure broken after transform"
   fi
 done
+
+echo ""
+
+echo "Testing OpenCode dotfile configuration..."
+echo ""
+
+if [ -f "$OPENCODE_CONFIG" ]; then
+  pass "opencode.json: config file exists"
+else
+  fail "opencode.json: config file missing"
+fi
+
+if grep -qE '"lsp"[[:space:]]*:[[:space:]]*true' "$OPENCODE_CONFIG"; then
+  pass "opencode.json: enables built-in LSP servers (including TypeScript)"
+else
+  fail "opencode.json: missing '\"lsp\": true' to enable TypeScript LSP"
+fi
+
+if grep -qE '^stow .* opencode( |$)' "$INSTALL_SCRIPT"; then
+  pass "install.sh: stows opencode dotfiles"
+else
+  fail "install.sh: missing opencode from stow package list"
+fi
 
 echo ""
 


### PR DESCRIPTION
## Summary
- Enable OpenCode built-in LSP support so TypeScript LSP is available in TypeScript projects
- Include the OpenCode dotfile package in the GNU Stow installer
- Add OpenCode config regression checks and update README/manual install docs

## Tests
- pnpm test
- git diff --check origin/main...HEAD
- python3 -m json.tool opencode/.config/opencode/opencode.json
- stow --simulate --target /private/tmp/codex-opencode-stow-target opencode