### PR TITLE
Add folder structure skill

### DIFF
--- a/.changeset/fresh-folders-rhyme.md
+++ b/.changeset/fresh-folders-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@paulhammond/dotfiles": minor
+---
+
+Add a `folder-structure` skill for designing screaming, feature-based project structures with source-backed guidance for vertical slices, colocation, protected DDD/hex domain cores, linted import boundaries, shared boundaries, and monorepo organization. Cross-reference it from the DDD and hexagonal architecture skills, while making clear those physical layout and lint rules apply only after `folder-structure` has been adopted.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ It became unexpectedly popular when I shared the [CLAUDE.md file](claude/.claude
 
 This repository now serves two purposes:
 
-1. **[CLAUDE.md](claude/.claude/CLAUDE.md)** + **[Skills](claude/.claude/skills/)** + **[Ten specialized agents](claude/.claude/agents/)** + **[Five slash commands](claude/.claude/commands/)** - Development guidelines, 26 auto-discovered skill patterns + 18 impeccable design skills from [pbakaus/impeccable](https://github.com/pbakaus/impeccable) + 6 web quality skills from [addyosmani/web-quality-skills](https://github.com/addyosmani/web-quality-skills) + 3 Next.js skills from [vercel-labs/next-skills](https://skills.sh/vercel-labs/next-skills) + the `grill-me` planning interview skill from [mattpocock/skills](https://skills.sh/mattpocock/skills/grill-me) + the `seo-audit` marketing skill from [coreyhaines31/marketingskills](https://skills.sh/coreyhaines31/marketingskills/seo-audit), and automated quality guidance (what most visitors want)
+1. **[CLAUDE.md](claude/.claude/CLAUDE.md)** + **[Skills](claude/.claude/skills/)** + **[Ten specialized agents](claude/.claude/agents/)** + **[Five slash commands](claude/.claude/commands/)** - Development guidelines, 27 auto-discovered skill patterns + 18 impeccable design skills from [pbakaus/impeccable](https://github.com/pbakaus/impeccable) + 6 web quality skills from [addyosmani/web-quality-skills](https://github.com/addyosmani/web-quality-skills) + 3 Next.js skills from [vercel-labs/next-skills](https://skills.sh/vercel-labs/next-skills) + the `grill-me` planning interview skill from [mattpocock/skills](https://skills.sh/mattpocock/skills/grill-me) + the `seo-audit` marketing skill from [coreyhaines31/marketingskills](https://skills.sh/coreyhaines31/marketingskills/seo-audit), and automated quality guidance (what most visitors want)
 2. **Personal dotfiles** - My shell configs, git aliases, and tool configurations (what this repo was originally for)
 
 **Most people are here for CLAUDE.md and the agents.** This README focuses primarily on those, with [dotfiles coverage at the end](#-personal-dotfiles-the-original-purpose).
@@ -87,6 +87,7 @@ Unlike typical style guides, CLAUDE.md provides:
 | **Story Splitting** | Turn broad stories, epics, features, and backlog items into independently valuable child stories; based on Tim Ottinger's story-splitting resource list and linked articles | [→ skills/story-splitting](claude/.claude/skills/story-splitting/SKILL.md) |
 | **CI Debugging** | Systematic CI/CD failure diagnosis, hypothesis-first debugging, environment delta analysis | [→ skills/ci-debugging](claude/.claude/skills/ci-debugging/SKILL.md) |
 | **Production Parity Skill Builder** | Creates app-specific skills that inspect docs, code, tests, CI, deployment, infrastructure, config, auth, and environment setup to catch drift between production and non-production environments | [→ skills/production-parity-skill-builder](claude/.claude/skills/production-parity-skill-builder/SKILL.md) |
+| **Folder Structure** | Screaming architecture plus feature-based and vertical-slice organization, protected domain cores, linted import boundaries, and monorepo scope grouping | [→ skills/folder-structure](claude/.claude/skills/folder-structure/SKILL.md) |
 | **Hexagonal Architecture** | Ports and adapters, driving/driven asymmetry, CQRS-lite, composition roots, cross-cutting concerns, DI patterns, anti-patterns with code examples, full worked example, incremental adoption. 5 deep-dive resources | [→ skills/hexagonal-architecture](claude/.claude/skills/hexagonal-architecture/SKILL.md) |
 | **Domain-Driven Design** | Ubiquitous language, value objects, entities, aggregates, domain events (Decider pattern), domain services, specifications, bounded contexts with ACL, error modeling, "Where Does This Code Belong?" decision framework. 6 deep-dive resources | [→ skills/domain-driven-design](claude/.claude/skills/domain-driven-design/SKILL.md) |
 | **Twelve-Factor App** | Config via env vars, stateless processes, graceful shutdown, structured logging, backing services | [→ skills/twelve-factor](claude/.claude/skills/twelve-factor/SKILL.md) |
@@ -140,6 +141,7 @@ Unlike typical style guides, CLAUDE.md provides:
 | Backlog items keep turning into frontend/backend tickets | [story-splitting](claude/.claude/skills/story-splitting/SKILL.md) | Reject component stories; split by capability, path, interface, data, rules, quality, or learning |
 | CI pipeline keeps failing | [ci-debugging](claude/.claude/skills/ci-debugging/SKILL.md) | Every failure is real until proven otherwise, hypothesis-first diagnosis |
 | Local, CI, PR, or staging differs from production | [production-parity-skill-builder](claude/.claude/skills/production-parity-skill-builder/SKILL.md) | Generate an app-specific parity skill that inspects source, infra, config, and auth before asking targeted questions |
+| Project folders hide what the product does | [folder-structure](claude/.claude/skills/folder-structure/SKILL.md) | Organize by business capability first; protect DDD/hex domain code with linted boundaries |
 | Separating domain from infrastructure | [hexagonal-architecture](claude/.claude/skills/hexagonal-architecture/SKILL.md) | Ports define contracts, adapters implement them, domain stays pure |
 | Complex business rules need modeling | [domain-driven-design](claude/.claude/skills/domain-driven-design/SKILL.md) | Ubiquitous language, glossary enforcement, value objects, aggregates |
 | Config scattered in code, not env vars | [twelve-factor](claude/.claude/skills/twelve-factor/SKILL.md) | Validate config at startup with Zod, inject via options objects |
@@ -1656,7 +1658,7 @@ This gives you the complete guidelines (1,818 lines) in a single standalone file
 
 ### Version Note: v1.0.0 vs v2.0.0 vs v3.0.0
 
-**Current version (v3.0.0):** Skills-based architecture with lean CLAUDE.md (~100 lines) + 26 auto-discovered skills + 5 slash commands + planning workflow
+**Current version (v3.0.0):** Skills-based architecture with lean CLAUDE.md (~100 lines) + 27 auto-discovered skills + 5 slash commands + planning workflow
 
 **Previous version (v2.0.0):** Modular structure with main file (156 lines) + 6 detailed docs loaded via @imports (~3000+ lines total)
 

--- a/claude/.claude/skills/domain-driven-design/SKILL.md
+++ b/claude/.claude/skills/domain-driven-design/SKILL.md
@@ -9,6 +9,8 @@ This skill applies only to projects that have opted in to DDD. Do not apply thes
 
 For hexagonal architecture (ports and adapters), load the `hexagonal-architecture` skill. DDD and hexagonal architecture are complementary but independent — a project may use one without the other.
 
+If the `folder-structure` skill has been explicitly applied to this project, follow its protected-domain-core layout and lint/import-boundary rules for DDD/hex contexts. Do not introduce those physical folder or lint rules into projects that have not applied `folder-structure`; in that case, preserve the repo's existing structure while keeping domain logic isolated.
+
 **Deep-dive resources** are in the `resources/` directory. Load them on demand:
 
 | Resource | Load when... |
@@ -55,6 +57,8 @@ DDD adds value for **complex domains** with rich business rules. Not every proje
 
 This is the most common decision in DDD. When unsure, use this framework:
 
+The `domain/` locations below are logical placement guidance. If `folder-structure` has been applied, prefer its context-first protected core shape, such as `src/<bounded-context>/domain/` plus its lint boundary rules. If it has not been applied, adapt to the existing repo structure instead of reorganizing purely to match that layout.
+
 | Question | If yes → | If no ↓ |
 |----------|----------|---------|
 | Does it enforce a business rule or compute a business value? | `domain/` (entity function, value object, or domain service) | ↓ |
@@ -83,6 +87,8 @@ export const calculateCommittedTotal = (items: readonly GiftItem[]) =>
 ```
 
 **Why placement matters:** `domain/` files typically have strict coverage requirements and zero infrastructure imports. Putting code in the wrong layer creates unnecessary testing obligations and architectural violations.
+
+When `folder-structure` has been applied, domain isolation should also be enforced mechanically with its import-boundary lint rules.
 
 ---
 
@@ -485,6 +491,7 @@ Treating the initial model as sacred — refusing to rename types, split aggrega
 - [ ] Discriminated unions have exhaustive switch handling
 - [ ] Expected business outcomes use result types, not exceptions
 - [ ] Domain logic has zero infrastructure dependencies
+- [ ] If `folder-structure` has been applied, protected-domain-core lint/import rules are present and passing
 - [ ] Presentation logic is NOT in domain/ (even if pure)
 - [ ] Tests organized by domain concept, not implementation file
 - [ ] Each layer has behavioral tests at the appropriate level

--- a/claude/.claude/skills/folder-structure/SKILL.md
+++ b/claude/.claude/skills/folder-structure/SKILL.md
@@ -1,0 +1,320 @@
+---
+name: folder-structure
+description: Design and audit project folder structures using screaming architecture, feature-based organization, vertical slices, protected domain cores, ports/adapters boundaries, lint-enforced import rules, and code colocation. Use when creating, reviewing, or refactoring source trees, deciding where files belong, naming domains/features/use cases, setting shared/core/common boundaries, or aligning frontend/backend/monorepo folders with business capabilities instead of technical file types.
+---
+
+# Folder Structure
+
+Create source trees that tell a newcomer what the product does before they notice the framework. Prefer business capabilities, use cases, and vertical slices at the first meaningful levels; use technical folders only where they clarify a slice's internals or an infrastructure edge.
+
+Read `references/research-notes.md` when documenting rationale, comparing named approaches, or needing source links.
+
+## Default Workflow
+
+1. Map the product language before naming folders.
+   - Read routes, tests, domain models, README docs, user stories, and existing UI labels.
+   - Extract nouns and verbs users would recognize: `checkout`, `reserve-ticket`, `send-invoice`, `gift-funding`, `recipient`, `booking`.
+   - If the domain language is unclear, ask one targeted question before inventing generic names.
+
+2. Choose the outer shape from the repo type.
+
+| Context | Prefer |
+|---------|--------|
+| Small or early app | Keep it shallow. Add folders only when files change together or business names become clear. |
+| Single app | `src/app` for composition, then business feature/context folders or `src/features/<capability>`. |
+| Framework-constrained app | Keep required framework folders thin; put real behavior in business slices they call. |
+| DDD or hexagonal app | Bounded context or capability first, with an explicit protected `domain/` core inside each opted-in context. |
+| Monorepo | `apps/<product>` plus `packages` or `libs` grouped by scope: product area first, shared second. |
+
+3. Define slices by cohesion.
+   - A slice is code that changes together to support one user-visible capability, workflow, route group, or domain concept.
+   - Co-locate implementation, tests, schemas, fixtures, styles, and small helpers with the slice that owns them.
+   - Create only the segments a slice actually needs. Empty `api`, `ui`, `model`, or `lib` folders are noise.
+
+4. Set dependency rules before moving files.
+   - Composition imports features; features should not import composition.
+   - Sibling features should not import each other's internals. Share through an explicit public API, a higher-level orchestrator, or a promoted shared/domain module.
+   - In DDD or hexagonal contexts, domain/use-case code must not import framework, database, HTTP, queue, UI, adapter, or infrastructure modules.
+   - Shared code must not import feature code.
+
+5. Propose the tree and the rules together.
+   - Show the directory tree.
+   - Add 3-6 placement rules that explain where new files go.
+   - Add 2-4 import/dependency rules that keep the structure honest.
+   - Include lint/import-boundary rules when the project uses DDD, hexagonal architecture, or another explicit layered boundary.
+
+## Feature Anatomy
+
+Use technical segments inside a feature only after the feature name has already made the business purpose clear.
+
+```text
+src/
+  checkout/
+    apply-discount/
+      apply-discount.ts
+      apply-discount.test.ts
+      apply-discount.schema.ts
+      index.ts
+    collect-payment/
+      collect-payment.ts
+      collect-payment.test.ts
+      ports.ts
+      index.ts
+```
+
+For frontend slices, this shape is often useful:
+
+```text
+src/
+  app/
+    routes.tsx
+    providers.tsx
+  pages/
+    checkout/
+      ui/
+      index.ts
+  features/
+    apply-discount/
+      ui/
+      model/
+      api/
+      index.ts
+  entities/
+    cart/
+      model/
+      ui/
+      index.ts
+  shared/
+    ui/
+    api-client/
+    config/
+```
+
+For backend or service code without DDD/hex, keep the slice shallow:
+
+```text
+src/
+  billing/
+    collect-payment/
+      collect-payment.ts
+      collect-payment.test.ts
+      ports.ts
+      index.ts
+    invoice/
+      invoice.ts
+      invoice.test.ts
+      index.ts
+  infrastructure/
+    billing/
+      stripe-payment-gateway.ts
+      billing-repository.ts
+  app/
+    http/
+      billing-routes.ts
+```
+
+## Protected Domain Core
+
+When a project opts into DDD or hexagonal architecture, make `domain/` visible. This is the deliberate exception to "avoid technical folders": `domain/` marks the protected core of the hexagon, not a framework category.
+
+Prefer bounded context first, protected core second:
+
+```text
+src/
+  billing/
+    domain/
+      invoice/
+        invoice.ts
+        invoice-id.ts
+        invoice-repository.ts     # driven port owned by the aggregate
+        index.ts
+      payment/
+        payment-gateway.ts        # driven port named by business capability
+        payment-result.ts
+        index.ts
+      money.ts                    # shared kernel only if truly universal
+    use-cases/
+      collect-payment/
+        collect-payment.ts
+        collect-payment.test.ts
+        index.ts
+    adapters/
+      driven/
+        stripe-payment-gateway.ts
+        postgres-invoice-repository.ts
+        invoice-row.ts
+        invoice-mapper.ts
+      fakes/
+        fake-invoice-repository.ts
+    delivery/
+      billing-routes.ts           # thin driving adapter when framework allows
+```
+
+If the framework forces routes elsewhere, keep those files thin and make the dependency direction obvious:
+
+```text
+src/
+  app/
+    api/
+      billing/
+        route.ts                  # parse, wire, delegate, respond
+  billing/
+    domain/
+    use-cases/
+    adapters/
+```
+
+Placement rules for opted-in DDD/hex code:
+
+- Put entities, value objects, domain services, specifications, domain errors, repository interfaces, gateway interfaces, and business result types in `domain/`.
+- Put use cases/application services in `use-cases/` when separating orchestration from the pure domain model; they are still inside the hexagon and protected from adapters.
+- Put concrete DB, API, queue, email, payment, filesystem, and SDK implementations in `adapters/driven/` or `infrastructure/`.
+- Put route handlers, controllers, CLI commands, queue consumers, cron triggers, and server actions in `delivery/` or framework-required `app/` folders.
+- Keep adapter DTOs, DB rows, SDK response types, mappers, and query DTOs with the adapter. Map them to domain types at the boundary.
+- Keep shared-kernel types tiny. `Money`, `EmailAddress`, and `Clock` can be shared; `Invoice`, `GiftIdea`, and `User` usually belong to a bounded context.
+
+## Import Boundary Rules
+
+For DDD/hex projects, add lint rules after the first protected slice exists. Prefer the repo's existing lint stack. If there is no boundary tool yet, start with ESLint's built-in `no-restricted-imports`, then move to `eslint-plugin-boundaries`, `eslint-plugin-import`, or Nx module-boundary rules when the repo already uses them.
+
+Use these rules as intent, adapting paths and aliases to the codebase:
+
+```js
+// eslint.config.js
+export default [
+  {
+    files: ["src/**/domain/**/*.{ts,tsx}"],
+    rules: {
+      "no-restricted-imports": ["error", {
+        patterns: [
+          {
+            group: [
+              "**/adapters/**",
+              "**/infrastructure/**",
+              "**/delivery/**",
+              "**/app/**",
+              "**/use-cases/**",
+              "next/**",
+              "react/**",
+              "drizzle-orm",
+              "@prisma/client",
+              "@aws-sdk/**",
+            ],
+            message: "Domain model must not import use cases, adapters, frameworks, or infrastructure.",
+          },
+        ],
+      }],
+    },
+  },
+  {
+    files: ["src/**/use-cases/**/*.{ts,tsx}"],
+    rules: {
+      "no-restricted-imports": ["error", {
+        patterns: [
+          {
+            group: [
+              "**/adapters/**",
+              "**/infrastructure/**",
+              "**/delivery/**",
+              "**/app/**",
+              "next/**",
+              "react/**",
+              "drizzle-orm",
+              "@prisma/client",
+              "@aws-sdk/**",
+            ],
+            message: "Use cases are inside the hexagon and must not import concrete adapters or frameworks.",
+          },
+        ],
+      }],
+    },
+  },
+  {
+    files: ["src/shared/**/*.{ts,tsx}"],
+    rules: {
+      "no-restricted-imports": ["error", {
+        patterns: [
+          {
+            group: [
+              "**/domain/**",
+              "**/use-cases/**",
+              "**/adapters/**",
+              "**/infrastructure/**",
+              "**/delivery/**",
+              "**/features/**",
+            ],
+            message: "Shared code must not depend on product slices or architecture layers.",
+          },
+        ],
+      }],
+    },
+  },
+];
+```
+
+Also enforce these boundaries in review, even before lint exists:
+
+- `domain/` imports only same-context domain modules and intentional shared-kernel modules.
+- `use-cases/` imports domain and port interfaces, but not concrete adapters.
+- Driven adapters import domain ports/types and implement them; the domain never imports adapters.
+- Driving adapters import use cases and adapter factories; they do not contain business rules.
+- Cross-context imports go through explicit public APIs, events, or anti-corruption layers.
+
+For monorepos:
+
+```text
+apps/
+  booking-web/
+  check-in-web/
+packages/
+  booking/
+    reserve-ticket/
+    pay-for-booking/
+  check-in/
+    verify-passenger/
+  shared/
+    date-time/
+    test-factories/
+```
+
+## Naming Rules
+
+- Prefer names from the domain glossary, user journey, or route language.
+- Use verbs for use cases and interactions: `reserve-ticket`, `apply-discount`, `invite-member`.
+- Use nouns for domain concepts: `cart`, `invoice`, `recipient`, `booking`.
+- Avoid top-level `controllers`, `services`, `models`, `components`, `hooks`, `utils`, and `helpers` as the main architecture.
+- If a shared folder is needed, name subfolders by purpose: `shared/money`, `shared/date-time`, `shared/ui`, not `shared/utils`.
+
+## Sharing Rules
+
+Keep code local until reuse is real and the abstraction has a stable name.
+
+Promote code out of a feature only when:
+- At least two slices need it now, not hypothetically.
+- The promoted name describes a business or platform capability.
+- The source slice will no longer feel like the hidden owner.
+- Tests move with the behavior or cover it through the new public API.
+
+Do not create a central shared area for "maybe reusable someday" code. That becomes a dumping ground and makes the architecture whisper "miscellaneous".
+
+## Migration Strategy
+
+When refactoring an existing tree:
+
+1. Pick one vertical slice with tests or add characterization tests first.
+2. Create the target business folder and move only the files needed for that slice.
+3. Add an `index.ts` or equivalent public API where other slices need to depend on it.
+4. Update imports with the smallest safe move.
+5. Add lint/import rules once the first pattern is proven.
+6. Repeat slice by slice; delete empty legacy folders only after their last file moves.
+
+## Review Checklist
+
+- The first two meaningful levels reveal the product domain or user workflows.
+- Files that change together are close together.
+- Tests, fixtures, styles, and schemas live near the code they verify or support.
+- Framework-required files are thin entrypoints, not the architectural center.
+- DDD/hex projects have an explicit protected `domain/` core and lint rules preventing inward dependencies from importing outward layers.
+- Cross-feature imports go through public APIs or higher-level orchestration.
+- Shared folders are small, named by purpose, and free of feature dependencies.
+- No empty template folders exist just to satisfy a pattern.

--- a/claude/.claude/skills/folder-structure/agents/openai.yaml
+++ b/claude/.claude/skills/folder-structure/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Folder Structure"
+  short_description: "Design screaming feature-based folders"
+  default_prompt: "Use $folder-structure to propose a screaming, feature-based project structure for this codebase."

--- a/claude/.claude/skills/folder-structure/references/research-notes.md
+++ b/claude/.claude/skills/folder-structure/references/research-notes.md
@@ -1,0 +1,42 @@
+# Folder Structure Research Notes
+
+Load this only when source-backed rationale matters. The working rules live in `../SKILL.md`.
+
+## Source Principles
+
+- Robert C. Martin's "Screaming Architecture" argues that the highest-level package and directory structure should reveal the system's use cases, not its framework. It also emphasizes deferring framework, database, and web-server decisions so use cases remain testable without those tools.
+  Source: https://blog.cleancoder.com/uncle-bob/2011/09/30/Screaming-Architecture.html
+
+- Martin's "Clean Architecture" frames related architectures around separation of concerns: business rules should be independent of frameworks, UI, databases, and external agencies.
+  Source: https://blog.cleancoder.com/uncle-bob/2012/08/13/the-clean-architecture.html
+
+- React's legacy file-structure guidance lists feature/route grouping as a common approach, recommends colocating CSS, JS, and tests, warns against deep nesting, and says files that change together should stay close together.
+  Source: https://legacy.reactjs.org/docs/faq-structure.html
+
+- Angular's current style guide recommends organizing projects by feature areas and grouping closely related files, including tests, in the same directory.
+  Source: https://angular.dev/style-guide
+
+- Nx recommends planning monorepo folder structure around scope: the app or larger application section a project belongs to. It also recommends grouping projects that are usually updated together and moving shared work into explicit shared areas when reuse is real.
+  Source: https://nx.dev/docs/concepts/decisions/folder-structure
+
+- Microsoft's feature-slices article explains the cost of type-first MVC folders and recommends feature folders for vertical-slice work so controllers, views, and view models for one capability stay together.
+  Source: https://learn.microsoft.com/en-us/archive/msdn-magazine/2016/september/asp-net-core-feature-slices-for-asp-net-core-mvc
+
+- Feature-Sliced Design provides a frontend vocabulary of layers (`app`, `pages`, `widgets`, `features`, `entities`, `shared`), slice independence, downward-only imports, and explicit public APIs.
+  Sources:
+  - https://fsd.how/docs/reference/layers/
+  - https://fsd.how/docs/reference/slices-segments/
+  - https://fsd.how/docs/reference/public-api/
+
+- Bulletproof React is a pragmatic reference implementation for production React apps. Its project-structure guide organizes most code under feature modules, allows feature-local `api`, `components`, `hooks`, `stores`, `types`, and `utils`, and recommends unidirectional flow from shared code to features to app.
+  Source: https://github.com/alan2207/bulletproof-react/blob/master/docs/project-structure.md
+
+## Synthesis
+
+The strongest common pattern is:
+
+1. Put business meaning at the first meaningful level.
+2. Keep files that change together close.
+3. Hide framework and infrastructure details behind thin entrypoints or adapters.
+4. Treat "shared" as earned by real reuse, not as a default destination.
+5. Enforce boundaries with public APIs and import rules after the first successful slice proves the shape.

--- a/claude/.claude/skills/hexagonal-architecture/SKILL.md
+++ b/claude/.claude/skills/hexagonal-architecture/SKILL.md
@@ -9,6 +9,8 @@ This skill applies only to projects that have opted in to hexagonal architecture
 
 For domain modeling (entities, value objects, aggregates, ubiquitous language), load the `domain-driven-design` skill. Hex arch and DDD are complementary but independent — hex arch provides structural isolation (how the outside connects), DDD provides the domain model (what lives in the center). A project may use one without the other.
 
+If the `folder-structure` skill has been explicitly applied to this project, follow its protected-domain-core layout and lint/import-boundary rules for DDD/hex contexts. Do not introduce those physical folder or lint rules into projects that have not applied `folder-structure`; in that case, preserve the repo's existing structure while enforcing the dependency direction described here.
+
 **Deep-dive resources** are in the `resources/` directory. Load them on demand:
 
 | Resource | Load when... |
@@ -231,6 +233,8 @@ The use case doesn't know or care whether it was triggered by an HTTP request, a
 
 ## File Organization
 
+The locations below describe the logical layers. If `folder-structure` has been applied, prefer its context-first protected core shape, such as `src/<bounded-context>/domain/`, `src/<bounded-context>/use-cases/`, `src/<bounded-context>/adapters/`, and its lint boundary rules. If it has not been applied, use these locations as examples and adapt to the existing codebase without reorganizing solely for this skill.
+
 | Layer | Location | Contains | Tests |
 |-------|----------|----------|-------|
 | Domain | `src/domain/` | Business logic (pure functions), types, port interfaces, use cases (orchestration) | Unit + use case tests (fakes) |
@@ -244,6 +248,7 @@ The use case doesn't know or care whether it was triggered by an HTTP request, a
 - Schemas co-locate with their entity in domain
 - Adapters import from domain, never the reverse
 - Route handlers are thin — parse, wire, delegate, respond
+- When `folder-structure` has been applied, enforce these rules with its recommended import-boundary lint configuration.
 
 ---
 
@@ -356,6 +361,7 @@ interface UserRepository {
 ## Checklist
 
 - [ ] Domain logic has zero framework/infrastructure dependencies
+- [ ] If `folder-structure` has been applied, protected-domain-core lint/import rules are present and passing
 - [ ] All external boundaries use ports (interfaces)
 - [ ] Driving adapters (routes) are thin — parse, wire, delegate, respond
 - [ ] Driven adapters (repos) implement ports, contain no business logic


### PR DESCRIPTION
## Summary
- Add a folder-structure skill for screaming, feature-based project organization
- Include protected DDD/hex domain core guidance and lint import-boundary examples
- Cross-reference folder-structure from the DDD and hexagonal architecture skills

## Tests
- pnpm test