### PR TITLE
Improve hexagonal architecture port naming guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Unlike typical style guides, CLAUDE.md provides:
 | **CI Debugging** | Systematic CI/CD failure diagnosis, hypothesis-first debugging, environment delta analysis | [→ skills/ci-debugging](claude/.claude/skills/ci-debugging/SKILL.md) |
 | **Production Parity Skill Builder** | Creates app-specific skills that inspect docs, code, tests, CI, deployment, infrastructure, config, auth, and environment setup to catch drift between production and non-production environments | [→ skills/production-parity-skill-builder](claude/.claude/skills/production-parity-skill-builder/SKILL.md) |
 | **Folder Structure** | Screaming architecture plus feature-based and vertical-slice organization, protected domain cores, linted import boundaries, and monorepo scope grouping | [→ skills/folder-structure](claude/.claude/skills/folder-structure/SKILL.md) |
-| **Hexagonal Architecture** | Ports and adapters, driving/driven asymmetry, CQRS-lite, composition roots, cross-cutting concerns, DI patterns, anti-patterns with code examples, full worked example, incremental adoption. 5 deep-dive resources | [→ skills/hexagonal-architecture](claude/.claude/skills/hexagonal-architecture/SKILL.md) |
+| **Hexagonal Architecture** | Ports and adapters, driving/driven asymmetry, CQRS-lite, composition roots, cross-cutting concerns, DI patterns, anti-patterns with code examples, full worked example, incremental adoption. 6 resources including source notes | [→ skills/hexagonal-architecture](claude/.claude/skills/hexagonal-architecture/SKILL.md) |
 | **Domain-Driven Design** | Ubiquitous language, value objects, entities, aggregates, domain events (Decider pattern), domain services, specifications, bounded contexts with ACL, error modeling, "Where Does This Code Belong?" decision framework. 6 deep-dive resources | [→ skills/domain-driven-design](claude/.claude/skills/domain-driven-design/SKILL.md) |
 | **Twelve-Factor App** | Config via env vars, stateless processes, graceful shutdown, structured logging, backing services | [→ skills/twelve-factor](claude/.claude/skills/twelve-factor/SKILL.md) |
 | **Impeccable Design** | Comprehensive frontend design vocabulary: distinctive interfaces, systematic typography, OKLCH color, anti-AI-slop methodology + 17 steering commands | [→ impeccable](https://impeccable.style/skills/) |
@@ -480,7 +480,7 @@ const wrong = "incorrect approach";
 
 **Problem it solves:** Business logic tangled with database queries and HTTP handlers; untestable code; changing a database requires rewriting business rules
 
-**What's inside (main skill + 5 deep-dive resources):**
+**What's inside (main skill + 6 resources):**
 - **Driving/driven adapter asymmetry** with visual diagram — HTTP routes, queue consumers, cron jobs
 - **Dependency injection** via parameters — wrong/right comparison, composition root pattern
 - **CQRS-lite** — reads bypass repositories, query functions JOIN freely

--- a/claude/.claude/skills/hexagonal-architecture/SKILL.md
+++ b/claude/.claude/skills/hexagonal-architecture/SKILL.md
@@ -20,8 +20,9 @@ If the `folder-structure` skill has been explicitly applied to this project, fol
 | `cqrs-lite.md` | Reads need to JOIN across aggregates, separating read/write paths |
 | `cross-cutting-concerns.md` | Placing auth, logging, transactions, or error formatting |
 | `incremental-adoption.md` | Introducing hex arch into an existing codebase |
+| `references.md` | Checking source rationale, especially port/public interface naming |
 
-For authoritative sources, see `../REFERENCES.md`.
+For authoritative sources and naming rationale, see `resources/references.md`.
 
 ---
 
@@ -52,15 +53,41 @@ Business logic lives in the center. External systems connect through ports (inte
 **Driving adapters** (left): initiate actions on the application. They *call* use cases.
 **Driven adapters** (right): the application reaches out to them. They *implement* port interfaces.
 
-This asymmetry is fundamental. Driving adapters depend on use case interfaces. Driven adapters implement repository/gateway interfaces defined by the domain.
+This asymmetry is fundamental. Driving adapters depend on driving port interfaces exposed by the application. Driven adapters implement repository/gateway interfaces defined by the domain.
 
 ---
 
-## Ports = Interfaces
+## Ports = Public Contracts
 
-Ports define contracts between layers. They are always `interface` types (behavior contracts, not data shapes).
+A port is a named, purposeful conversation at the application boundary. In TypeScript, represent ports as explicit `interface` types when the boundary is public or architectural: driving adapters call driving port interfaces, and driven adapters/fakes implement driven port interfaces.
+
+Use case implementations satisfy the driving port. The driving adapter should depend on the port's role-shaped interface, not a framework-specific controller, handler class, or concrete adapter.
+
+### Naming Ports and Public Interfaces
+
+Name every port from the application's point of view, using the domain language of the conversation:
+
+| Boundary | Good names | Avoid | Why |
+|----------|------------|-------|-----|
+| Driving/public API | `ForPlacingOrders`, `ForPledgingToOccasions` | `PlaceOrderUseCase`, `PlaceOrderHandler`, `OrderInputPort` | Names the actor capability, not the pattern |
+| Aggregate persistence | `OrderRepository`, `ContributorRepository` | `OrderDatabase`, `OrderDao`, `SqlOrderPort` | Repository is a domain collection abstraction |
+| External service | `PaymentGateway`, `ExchangeRateProvider` | `StripeClient`, `HttpPaymentPort` | Names the capability the app needs, not the vendor/protocol |
+| Notifications/events | `OrderEventPublisher`, `ReceiptSender` | `SnsAdapter`, `MessageBusPort` | Names the business-side interaction |
+
+**Public interface naming rules:**
+- Use `interface` for behavior contracts, not data shapes that are better modeled as `type`/schemas.
+- Do not prefix interfaces with `I` or suffix them with `Interface`; name the role (`PaymentGateway`, not `IPaymentGateway` or `PaymentGatewayInterface`).
+- Avoid `Port` in type names. A name like `PaymentPort` says "architecture" instead of "conversation."
+- Avoid `Impl` in implementation names. Name the concrete technology or strategy: `createStripePaymentGateway`, `createFakePaymentGateway`, `createDrizzleOrderRepository`.
+- Prefer role interfaces over header interfaces: include only the methods the use case needs, not every method an adapter happens to expose.
+- Make names stable under adapter swaps. If moving from Stripe to PayPal, SQL to DynamoDB, or HTTP to a queue forces a port rename, the port name leaked infrastructure.
 
 ```typescript
+// Driving port — exposed by the application, called by driving adapters
+interface ForPlacingOrders {
+  readonly placeOrder: (command: PlaceOrderCommand) => Promise<PlaceOrderResult>;
+}
+
 // Driven port — defined in domain, implemented by adapters
 interface UserRepository {
   readonly findById: (id: UserId) => Promise<User | undefined>;
@@ -177,17 +204,22 @@ const createOrder = async (order: NewOrder) => {
   // ...
 };
 
-// RIGHT — dependencies as parameters (testable, swappable)
-const createOrder = async (
+// RIGHT — dependencies injected into a use case implementation
+interface ForPlacingOrders {
+  readonly placeOrder: (order: NewOrder) => Promise<OrderResult>;
+}
+
+const createOrderPlacement = (
   repo: OrderRepository,
   gateway: PaymentGateway,
-  order: NewOrder,
-): Promise<OrderResult> => {
-  const charge = await gateway.charge(order.total, order.payment);
-  if (!charge.success) return { success: false, reason: charge.error };
-  const saved = await repo.save({ ...order, chargeId: charge.id });
-  return { success: true, order: saved };
-};
+): ForPlacingOrders => ({
+  placeOrder: async (order) => {
+    const charge = await gateway.charge(order.total, order.payment);
+    if (!charge.success) return { success: false, reason: charge.error };
+    const saved = await repo.save({ ...order, chargeId: charge.id });
+    return { success: true, order: saved };
+  },
+});
 ```
 
 **Composition root:** Wiring happens at the application entry point — where adapters are created from environment/config and injected into use cases. This is the only place that knows about concrete implementations.
@@ -201,10 +233,11 @@ export async function POST(request: Request) {
   // Wire adapters
   const repo = createDrizzleOrderRepository(db);
   const gateway = createStripeGateway(env.STRIPE_KEY);
+  const orderPlacement: ForPlacingOrders = createOrderPlacement(repo, gateway);
 
   // Call use case
   const body = CreateOrderSchema.parse(await request.json());
-  const result = await createOrder(repo, gateway, body);
+  const result = await orderPlacement.placeOrder(body);
   return NextResponse.json(result);
 }
 ```
@@ -219,15 +252,16 @@ const handlePledgeMessage = async (message: SQSMessage, env: Env) => {
   const db = createDb(env.DB);
   const occasionRepo = createDrizzleOccasionRepository(db);
   const contributorRepo = createDrizzleContributorRepository(db);
+  const pledging: ForPledgingToOccasions = createPledgingToOccasions(occasionRepo, contributorRepo);
 
   const dto = PledgeSchema.parse(JSON.parse(message.body));
-  await handlePledge(occasionRepo, contributorRepo, dto);
+  await pledging.pledgeToOccasion(dto);
 };
 ```
 
 The use case doesn't know or care whether it was triggered by an HTTP request, a queue message, a cron job, or a CLI command. Every driving adapter is thin glue.
 
-**Naming:** Use cases are named after the business operation — `createOrder`, `placeOrder`, `handlePledge`. Never `createOrderUseCase` or `PlaceOrderHandler`. Pattern suffixes are technical jargon, not domain language. You can tell a use case from a domain function by its signature — use cases take ports (repositories, gateways) as parameters; domain functions take only domain types.
+**Naming:** Use case interfaces and implementations are named after the business capability — `ForPlacingOrders`, `createOrderPlacement`, `pledgeToOccasion`. Never `CreateOrderUseCase` or `PlaceOrderHandler`. Pattern suffixes are technical jargon, not domain language. You can tell a use case implementation from a domain function by its dependencies — use case implementations take driven ports (repositories, gateways) as parameters; domain functions take only domain types.
 
 ---
 
@@ -244,7 +278,7 @@ The locations below describe the logical layers. If `folder-structure` has been 
 
 **Key rules:**
 - Domain has zero external dependencies (no framework, database, or HTTP imports)
-- Port interfaces live in domain alongside the entity they serve
+- Driven port interfaces live in domain alongside the entity or capability they serve
 - Schemas co-locate with their entity in domain
 - Adapters import from domain, never the reverse
 - Route handlers are thin — parse, wire, delegate, respond
@@ -356,17 +390,39 @@ interface UserRepository {
 }
 ```
 
+### Pattern-Shaped Public Names
+
+Names that advertise the architecture pattern instead of the business role make code harder to read and easier to cargo-cult.
+
+```typescript
+// ❌ Names the pattern or type mechanism
+interface IPaymentPort {
+  readonly charge: (amount: Money, paymentInfo: PaymentInfo) => Promise<ChargeResult>;
+}
+const createPaymentGatewayImpl = (): IPaymentPort => ...
+const placeOrderUseCase = async (...) => ...
+
+// ✅ Names the role and the concrete adapter
+interface PaymentGateway {
+  readonly charge: (amount: Money, paymentInfo: PaymentInfo) => Promise<ChargeResult>;
+}
+const createStripePaymentGateway = (): PaymentGateway => ...
+const placeOrder = async (...) => ...
+```
+
 ---
 
 ## Checklist
 
 - [ ] Domain logic has zero framework/infrastructure dependencies
 - [ ] If `folder-structure` has been applied, protected-domain-core lint/import rules are present and passing
-- [ ] All external boundaries use ports (interfaces)
+- [ ] All external boundaries use ports/public contracts
 - [ ] Driving adapters (routes) are thin — parse, wire, delegate, respond
 - [ ] Driven adapters (repos) implement ports, contain no business logic
 - [ ] Dependencies injected via parameters, never created internally
-- [ ] Port interfaces live in domain, named by business purpose
+- [ ] Driven port interfaces live in domain, named by business purpose
+- [ ] Public interfaces avoid `I` prefixes, `Interface` suffixes, `Port` suffixes, and `Impl` implementations
+- [ ] Driving port and use case names use business capability language, not `UseCase`/`Handler` pattern names
 - [ ] Schemas defined in domain, not duplicated in adapters
 - [ ] Reads that JOIN across aggregates use query functions (CQRS-lite)
 - [ ] Each layer has behavioral tests at the appropriate level

--- a/claude/.claude/skills/hexagonal-architecture/resources/cross-cutting-concerns.md
+++ b/claude/.claude/skills/hexagonal-architecture/resources/cross-cutting-concerns.md
@@ -15,9 +15,10 @@ Cross-cutting concerns live in adapters, never in domain. The domain is pure bus
 export async function POST(request: Request) {
   const userId = await authenticateRequest(request);  // middleware / adapter concern
   if (!userId) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  const pledging: ForPledgingToOccasions = createPledgingToOccasions(occasionRepo, contributorRepo);
 
   // Pass validated identity to use case as a domain type
-  const result = await handlePledge(occasionRepo, contributorRepo, {
+  const result = await pledging.pledgeToOccasion({
     ...body,
     contributorId: userId,  // already a branded ContributorId
   });
@@ -27,14 +28,15 @@ export async function POST(request: Request) {
 
 ```typescript
 // Domain: receives identity, applies business rules
-const handlePledge = async (
+const createPledgingToOccasions = (
   occasionRepo: OccasionRepository,
   contributorRepo: ContributorRepository,
-  dto: { readonly contributorId: ContributorId; ... },
-): Promise<PledgeResult> => {
-  // The domain doesn't check JWT tokens or session cookies.
-  // It receives a ContributorId and applies business rules.
-};
+): ForPledgingToOccasions => ({
+  pledgeToOccasion: async (dto: { readonly contributorId: ContributorId; ... }) => {
+    // The domain doesn't check JWT tokens or session cookies.
+    // It receives a ContributorId and applies business rules.
+  },
+});
 ```
 
 **Authorization (business rules about who can do what)** is domain logic:
@@ -59,7 +61,8 @@ const closeFunding = (occasion: Occasion, requesterId: ContributorId): CloseResu
 // Driving adapter: log the request/response cycle
 export async function POST(request: Request) {
   const body = PledgeSchema.parse(await request.json());
-  const result = await handlePledge(occasionRepo, contributorRepo, body);
+  const pledging: ForPledgingToOccasions = createPledgingToOccasions(occasionRepo, contributorRepo);
+  const result = await pledging.pledgeToOccasion(body);
 
   if (!result.success) {
     logger.warn('Pledge rejected', { reason: result.reason, occasionId: body.occasionId });
@@ -84,16 +87,18 @@ const createDrizzleOccasionRepository = (db: Database, logger: Logger): Occasion
 
 ```typescript
 // Driving adapter wraps the use case in a transaction
-const createTransactionalPledgeHandler = (db: Database) =>
-  async (dto: PledgeDto): Promise<PledgeResult> =>
+const createTransactionalPledgingToOccasions = (db: Database): ForPledgingToOccasions => ({
+  pledgeToOccasion: async (dto) =>
     db.transaction(async (tx) => {
       const occasionRepo = createDrizzleOccasionRepository(tx);
       const contributorRepo = createDrizzleContributorRepository(tx);
-      return handlePledge(occasionRepo, contributorRepo, dto);
-    });
+      const pledging = createPledgingToOccasions(occasionRepo, contributorRepo);
+      return pledging.pledgeToOccasion(dto);
+    }),
+});
 ```
 
-The use case function (`handlePledge`) is unchanged — it still takes repositories as parameters. The driving adapter passes transactional repositories. The domain doesn't know or care.
+The driving port (`ForPledgingToOccasions`) is unchanged — the transactional implementation still satisfies the same interface. The domain doesn't know or care.
 
 **When transactions aren't needed:** For single-aggregate saves, no transaction wrapper is necessary. Only add transactions when multiple aggregates must be saved atomically. See `aggregate-design.md` for guidance on one-aggregate-per-transaction.
 

--- a/claude/.claude/skills/hexagonal-architecture/resources/incremental-adoption.md
+++ b/claude/.claude/skills/hexagonal-architecture/resources/incremental-adoption.md
@@ -77,17 +77,22 @@ const createDrizzleUserRepository = (db: Database): UserRepository => ({
 Wire the domain function to the port.
 
 ```typescript
-// domain/billing/handle-deduction.ts — use case
-const handleDeduction = async (
+// domain/billing/deduct-user-balance.ts — driving port + implementation
+interface ForDeductingUserBalances {
+  readonly deductUserBalance: (dto: { readonly userId: UserId; readonly amount: Money }) => Promise<DeductResult>;
+}
+
+const createUserBalanceDeduction = (
   userRepo: UserRepository,
-  dto: { readonly userId: UserId; readonly amount: Money },
-): Promise<DeductResult> => {
-  const user = await userRepo.findById(dto.userId);
-  if (!user) return { success: false, reason: 'not-found' };
-  const result = deductBalance(user, dto.amount);
-  if (result.success) await userRepo.save(result.user);
-  return result;
-};
+): ForDeductingUserBalances => ({
+  deductUserBalance: async (dto) => {
+    const user = await userRepo.findById(dto.userId);
+    if (!user) return { success: false, reason: 'not-found' };
+    const result = deductBalance(user, dto.amount);
+    if (result.success) await userRepo.save(result.user);
+    return result;
+  },
+});
 ```
 
 ### Step 6: Thin Out the Route Handler
@@ -97,8 +102,9 @@ const handleDeduction = async (
 export async function POST(request: Request) {
   const db = createDb(env.DB);
   const userRepo = createDrizzleUserRepository(db);
+  const balanceDeduction: ForDeductingUserBalances = createUserBalanceDeduction(userRepo);
   const body = DeductSchema.parse(await request.json());
-  const result = await handleDeduction(userRepo, body);
+  const result = await balanceDeduction.deductUserBalance(body);
   if (!result.success) {
     return NextResponse.json({ error: result.reason }, { status: result.reason === 'not-found' ? 404 : 422 });
   }

--- a/claude/.claude/skills/hexagonal-architecture/resources/references.md
+++ b/claude/.claude/skills/hexagonal-architecture/resources/references.md
@@ -1,0 +1,46 @@
+# Source Notes
+
+Load this when checking the rationale behind hexagonal architecture guidance, especially port and public interface naming.
+
+## Canonical Architecture
+
+- Alistair Cockburn, "Hexagonal Architecture" (2005): https://alistair.cockburn.us/hexagonal-architecture
+  - A port is a purposeful conversation at the application boundary.
+  - The port protocol comes from the purpose of the conversation, not from the external device.
+  - Multiple adapters can fit the same port.
+  - "How many ports?" is contextual; neither one port per tiny operation nor two giant ports is usually best.
+- Alistair Cockburn, "Hexagonal Architecture Explained" updates (2025): https://alistaircockburn.com/hexarch%20v1.1b%20DIFFS%2020250420-1012%20paper%2Bepub.docx.pdf
+  - Driving/driven and primary/secondary apply to actors, adapters, and ports.
+  - Inbound/outbound can be useful folder names, but they are less universal as conceptual labels.
+  - Strong conformance means a driven port is expressed in application language, not SQL/HTTP/vendor language.
+  - Cockburn describes two schools for driving port interfaces, but his named examples use explicit interfaces such as `ForCalculatingTaxes` and `ForGettingTaxRates`.
+  - For this skill, prefer explicit driving interfaces because they make the application boundary reviewable and consistent.
+- Herberto Graca, "DDD, Hexagonal, Onion, Clean, CQRS..." (2017): https://herbertograca.com/2017/11/16/explicit-architecture-01-ddd-hexagonal-onion-clean-cqrs-how-i-put-it-all-together/
+  - Ports belong inside the application/business logic; adapters belong outside.
+  - Ports should fit the application core needs, not mimic tool APIs.
+- Robert C. Martin, "The Clean Architecture Dependency Rule" excerpt: https://www.informit.com/articles/article.aspx?p=2832399
+  - Source dependencies point inward.
+  - Inner code must not mention names or data formats from outer layers.
+  - Boundary data should be in the form most convenient for the inner layer.
+
+## Naming Ports and Interfaces
+
+- Cockburn names ports by the purpose/capability of the conversation, for example `ForCalculatingTaxes` and `ForGettingTaxRates`.
+- Martin Fowler, "Role Interface": https://martinfowler.com/bliki/RoleInterface.html
+  - Prefer role interfaces: small interfaces seen from the client's role, aligned with Interface Segregation.
+  - Avoid header interfaces that mirror every public method of a class.
+- Growing Object-Oriented Software, Guided by Tests notes: https://conn.dev/books/growing-object-oriented-software.html
+  - Interfaces name object roles and related responsibilities.
+  - `Thing` plus `ThingImpl` is a smell; the interface should be general/domain language and the implementation should say what is specific about it.
+- TypeScript contributor guidelines: https://github.com/microsoft/TypeScript/wiki/Coding-guidelines
+  - Use PascalCase for type names, no `I` prefix for interfaces, and whole words where possible.
+  - The page is for TypeScript's own codebase, not a universal mandate; use it as supporting evidence for TypeScript style.
+- Google TypeScript Style Guide: https://google.github.io/styleguide/tsguide.html
+  - Do not mark interfaces specially with `I...` or `...Interface` unless the environment requires it.
+  - Name an interface for why it exists.
+
+## Testing and Use Cases
+
+- Valentina Cupac/Jemuovic, "TDD and Hexagonal Architecture - Unit Testing Use Cases": https://optivem.com/tdd-and-hexagonal-architecture-unit-testing-use-cases/
+  - Use cases represent actor goals against a black-box application.
+  - Use case tests should describe business behavior, not internal implementation.

--- a/claude/.claude/skills/hexagonal-architecture/resources/testing-hex-arch.md
+++ b/claude/.claude/skills/hexagonal-architecture/resources/testing-hex-arch.md
@@ -1,18 +1,19 @@
 # Testing Strategy for Hexagonal Architecture
 
-Hex arch's primary value is testability. The architecture creates natural test boundaries — but the primary boundary is the **use case**, not each layer in isolation. This approach follows Valentina Jemuović's Use Case Driven Design (UCDD) — see `../../REFERENCES.md` for sources.
+Hex arch's primary value is testability. The architecture creates natural test boundaries — but the primary boundary is the **use case**, not each layer in isolation. This approach follows Use Case Driven Development (UCDD) — see `references.md` for sources.
 
 ## Primary Boundary: The Use Case
 
-Test by calling the use case (driving port) with driven ports replaced by in-memory fakes. This exercises the full business logic path without touching infrastructure.
+Test by calling the driving port implementation with driven ports replaced by in-memory fakes. This exercises the full business logic path without touching infrastructure.
 
 ```typescript
 describe('place order', () => {
   it('saves order and charges payment on success', async () => {
     const orderRepo = createFakeOrderRepo();
     const paymentGateway = createFakePaymentGateway({ alwaysSucceeds: true });
+    const orderPlacement = createOrderPlacement(orderRepo, paymentGateway);
 
-    const result = await placeOrder(orderRepo, paymentGateway, testOrder);
+    const result = await orderPlacement.placeOrder(testOrder);
 
     expect(result.success).toBe(true);
     expect(orderRepo.savedEntities).toHaveLength(1);
@@ -21,8 +22,9 @@ describe('place order', () => {
   it('does not save order when payment fails', async () => {
     const orderRepo = createFakeOrderRepo();
     const paymentGateway = createFakePaymentGateway({ alwaysFails: true });
+    const orderPlacement = createOrderPlacement(orderRepo, paymentGateway);
 
-    const result = await placeOrder(orderRepo, paymentGateway, testOrder);
+    const result = await orderPlacement.placeOrder(testOrder);
 
     expect(result.success).toBe(false);
     expect(orderRepo.savedEntities).toHaveLength(0);

--- a/claude/.claude/skills/hexagonal-architecture/resources/worked-example.md
+++ b/claude/.claude/skills/hexagonal-architecture/resources/worked-example.md
@@ -88,6 +88,15 @@ No ports, no infrastructure, no async. Just domain types in and domain types out
 ## 4. Port Interfaces (Domain Layer)
 
 ```typescript
+// domain/occasion/pledging.ts — driving port
+interface ForPledgingToOccasions {
+  readonly pledgeToOccasion: (dto: {
+    readonly occasionId: OccasionId;
+    readonly contributorId: ContributorId;
+    readonly amount: Money;
+  }) => Promise<PledgeResult>;
+}
+
 // domain/occasion/repository.ts
 interface OccasionRepository {
   readonly findById: (id: OccasionId) => Promise<Occasion | undefined>;
@@ -104,26 +113,27 @@ interface ContributorRepository {
 ## 5. Use Case (Orchestration)
 
 ```typescript
-// domain/occasion/handle-pledge.ts — use case function
-const handlePledge = async (
+// domain/occasion/pledge-to-occasion.ts — use case implementation
+const createPledgingToOccasions = (
   occasionRepo: OccasionRepository,
   contributorRepo: ContributorRepository,
-  dto: { readonly occasionId: OccasionId; readonly contributorId: ContributorId; readonly amount: Money },
-): Promise<PledgeResult> => {
-  const occasion = await occasionRepo.findById(dto.occasionId);
-  const contributor = await contributorRepo.findById(dto.contributorId);
-  if (!occasion || !contributor) return { success: false, reason: 'not-found' };
+): ForPledgingToOccasions => ({
+  pledgeToOccasion: async (dto) => {
+    const occasion = await occasionRepo.findById(dto.occasionId);
+    const contributor = await contributorRepo.findById(dto.contributorId);
+    if (!occasion || !contributor) return { success: false, reason: 'not-found' };
 
-  const result = pledgeContribution(occasion, contributor, dto.amount);
-  if (result.success) {
-    await occasionRepo.save(result.occasion);
-    await contributorRepo.save(result.contributor);
-  }
-  return result;
-};
+    const result = pledgeContribution(occasion, contributor, dto.amount);
+    if (result.success) {
+      await occasionRepo.save(result.occasion);
+      await contributorRepo.save(result.contributor);
+    }
+    return result;
+  },
+});
 ```
 
-The use case is identifiable by its signature — it takes ports as parameters. It contains zero business logic. It loads, delegates to the domain service, and saves.
+The use case implementation is identifiable by its dependencies — it takes driven ports as parameters and returns the driving port interface. It contains zero business logic. It loads, delegates to the domain service, and saves.
 
 **Note:** This use case saves two aggregates. For atomicity, the driving adapter should wrap it in a transaction — see `resources/cross-cutting-concerns.md` for the transaction pattern. The use case itself is unaware of transactions.
 
@@ -167,12 +177,13 @@ export async function POST(request: Request, { params }: { params: { id: string 
   // Wire adapters (composition root)
   const occasionRepo = createDrizzleOccasionRepository(db);
   const contributorRepo = createDrizzleContributorRepository(db);
+  const pledging: ForPledgingToOccasions = createPledgingToOccasions(occasionRepo, contributorRepo);
 
   // Parse input at the boundary
   const body = PledgeSchema.parse(await request.json());
 
   // Call use case
-  const result = await handlePledge(occasionRepo, contributorRepo, {
+  const result = await pledging.pledgeToOccasion({
     occasionId: createOccasionId(params.id),
     contributorId: body.contributorId,
     amount: body.amount,
@@ -221,8 +232,9 @@ describe('pledge contribution', () => {
   it('deducts from contributor and adds to occasion', async () => {
     const occasionRepo = createFakeOccasionRepository([testOccasion]);
     const contributorRepo = createFakeContributorRepository([testContributor]);
+    const pledging = createPledgingToOccasions(occasionRepo, contributorRepo);
 
-    const result = await handlePledge(occasionRepo, contributorRepo, {
+    const result = await pledging.pledgeToOccasion({
       occasionId: testOccasion.id,
       contributorId: testContributor.id,
       amount: createMoney(25, 'GBP'),
@@ -241,8 +253,9 @@ describe('pledge contribution', () => {
     const poorContributor = getTestContributor({ walletBalance: createMoney(10, 'GBP') });
     const occasionRepo = createFakeOccasionRepository([testOccasion]);
     const contributorRepo = createFakeContributorRepository([poorContributor]);
+    const pledging = createPledgingToOccasions(occasionRepo, contributorRepo);
 
-    const result = await handlePledge(occasionRepo, contributorRepo, {
+    const result = await pledging.pledgeToOccasion({
       occasionId: testOccasion.id,
       contributorId: poorContributor.id,
       amount: createMoney(50, 'GBP'),
@@ -256,8 +269,9 @@ describe('pledge contribution', () => {
     const closedOccasion = getTestOccasion({ isFundingClosed: true });
     const occasionRepo = createFakeOccasionRepository([closedOccasion]);
     const contributorRepo = createFakeContributorRepository([testContributor]);
+    const pledging = createPledgingToOccasions(occasionRepo, contributorRepo);
 
-    const result = await handlePledge(occasionRepo, contributorRepo, {
+    const result = await pledging.pledgeToOccasion({
       occasionId: closedOccasion.id,
       contributorId: testContributor.id,
       amount: createMoney(25, 'GBP'),

--- a/claude/.claude/skills/teach-me/SKILL.md
+++ b/claude/.claude/skills/teach-me/SKILL.md
@@ -225,7 +225,7 @@ When the topic matches an existing Claude Code skill:
 4. **Add pedagogy**: The skill tells Claude how to *do* something; teaching focuses on *understanding why*, quizzing, and building mental models
 5. **Reference resources**: Point learners to specific skill resources for deep-dives after they've built foundational understanding
 
-Example: `/teach-me hexagonal-architecture` should discover and use the `hexagonal-architecture` skill + its 5 resources as curriculum backbone, while adding discovery interview, Socratic questioning, exercises, Feynman checks, and progress tracking.
+Example: `/teach-me hexagonal-architecture` should discover and use the `hexagonal-architecture` skill + its 6 resources as curriculum backbone, while adding discovery interview, Socratic questioning, exercises, Feynman checks, and progress tracking.
 
 ---
 


### PR DESCRIPTION
## Summary
- clarify that architectural ports should be explicit TypeScript interfaces, including driving ports
- add Cockburn-style port naming guidance and anti-pattern examples for pattern-shaped names
- update worked examples/testing docs to use role-shaped driving interfaces
- add source notes for Cockburn, Graca, Fowler/GOOS, and TypeScript naming guidance

## Validation
- git diff --check