### PR TITLE
[codex] teach-me html reading lists

### DIFF
--- a/.changeset/brave-lessons-read.md
+++ b/.changeset/brave-lessons-read.md
@@ -1,0 +1,5 @@
+---
+"@paulhammond/dotfiles": patch
+---
+
+teach-me: add quality-gated reading lists to HTML lessons and indexes

--- a/claude/.claude/skills/teach-me/SKILL.md
+++ b/claude/.claude/skills/teach-me/SKILL.md
@@ -303,12 +303,14 @@ A lesson should be:
 - **Beautiful** — clean, readable typography and generous whitespace; think Tufte. The learner will revisit and may print these.
 - **Short** — one tightly-scoped thing tied to the mission, completable quickly. Working memory is small.
 - **Self-contained** — inline CSS, no external dependencies, works offline and prints well.
-- **Cited** — claims link to sources from `resources.md`; each lesson recommends one primary source to read or watch next.
+- **Cited** — claims link to sources from `resources.md`; each lesson attempts to include a quality-gated reading list of excellent articles, blog posts, videos, papers, or books.
 - **Connected** — links to the previous/next lesson and the cheat sheet; uses glossary terminology.
 - **Interactive where it helps** — a short recap quiz with reveal-on-click answers (vanilla JS only).
 - **An invitation** — ends with a reminder that the tutor is available for follow-up questions via `/teach-me [topic]`.
 
 After writing the file, open it for the learner (`open` on macOS, `xdg-open` on Linux). See `resources/html-lessons.md` for the full format, design principles, and template.
+
+**Reading lists:** HTML lessons and any HTML indexes created for a topic should try to include a compact reading list drawn from world-class resources: canonical docs/specs, seminal books or papers, recognised expert writing, excellent blog posts, or high-signal talks/videos. Use the topic `resources.md` first, search for better sources when needed, and add only resources that are genuinely excellent and relevant to the lesson or index. If no excellent resources can be found, omit the reading list entirely rather than padding with mediocre links.
 
 **Capture mode:** when the learner is short on time — or asks for the material "to read later" — generate the lesson *up front*, at the point where teaching would normally happen, and skip or defer the interactive CHECK/PRACTICE steps. The lesson's recap quiz becomes their asynchronous practice, and the next session's REVIEW covers the captured material as spaced retrieval. Log the lesson as **captured, not taught**: a captured lesson is exposure, not evidence, so nothing from it qualifies for a learning record or counts toward mastery until the learner demonstrates it in a later session.
 

--- a/claude/.claude/skills/teach-me/SKILL.md
+++ b/claude/.claude/skills/teach-me/SKILL.md
@@ -68,7 +68,7 @@ See `resources/course-generation.md` for the plan file template.
 
 ### 4. Ground in Trusted Sources
 
-Do not teach from parametric knowledge alone. Before the first session, search for 2-3 high-trust sources on the topic — primary sources, recognised experts, peer-reviewed work — and record them in `resources.md` with a one-line annotation each: what it covers and when to reach for it. Cite these sources while teaching, and recommend one per session for self-study between sessions.
+Do not teach from parametric knowledge alone. Before the first session, do online research to find 2-3 high-trust sources on the topic — primary sources, recognised experts, peer-reviewed work — and record them in `resources.md` with a one-line annotation each: what it covers and when to reach for it. Cite these sources while teaching, and recommend one per session for self-study between sessions.
 
 This matters most for fast-moving topics (frameworks, tools, APIs) and factual domains (health, law, finance), where parametric knowledge may be stale or wrong. For stable conceptual topics, sources still add depth and give the learner somewhere to go beyond the tutor.
 
@@ -310,7 +310,7 @@ A lesson should be:
 
 After writing the file, open it for the learner (`open` on macOS, `xdg-open` on Linux). See `resources/html-lessons.md` for the full format, design principles, and template.
 
-**Reading lists:** HTML lessons and any HTML indexes created for a topic should try to include a compact reading list drawn from world-class resources: canonical docs/specs, seminal books or papers, recognised expert writing, excellent blog posts, or high-signal talks/videos. Use the topic `resources.md` first, search for better sources when needed, and add only resources that are genuinely excellent and relevant to the lesson or index. If no excellent resources can be found, omit the reading list entirely rather than padding with mediocre links.
+**Reading lists:** HTML lessons and any HTML indexes created for a topic should try to include a compact reading list drawn from world-class resources: canonical docs/specs, seminal books or papers, recognised expert writing, excellent blog posts, or high-signal talks/videos. Use the topic `resources.md` first, perform fresh online research when needed, and add only resources that are genuinely excellent and relevant to the lesson or index. If no excellent resources can be found, omit the reading list entirely rather than padding with mediocre links.
 
 **Capture mode:** when the learner is short on time — or asks for the material "to read later" — generate the lesson *up front*, at the point where teaching would normally happen, and skip or defer the interactive CHECK/PRACTICE steps. The lesson's recap quiz becomes their asynchronous practice, and the next session's REVIEW covers the captured material as spaced retrieval. Log the lesson as **captured, not taught**: a captured lesson is exposure, not evidence, so nothing from it qualifies for a learning record or counts toward mastery until the learner demonstrates it in a later session.
 

--- a/claude/.claude/skills/teach-me/resources/course-generation.md
+++ b/claude/.claude/skills/teach-me/resources/course-generation.md
@@ -134,6 +134,7 @@ The curated set of trusted sources for the topic. Teaching should be grounded in
 **Rules:**
 - High-trust only: primary sources, recognised experts, peer-reviewed work, well-moderated communities. Marketing dressed as education stays out.
 - For HTML lessons and indexes, resources may include articles, blog posts, videos/talks, papers, and books, but only when they are excellent and directly relevant. Do not add a source merely to fill a media type.
+- Finding resources requires online research. Do not fill `resources.md`, lesson reading lists, or index reading lists from memory alone.
 - Annotate every entry — a bare link is useless in three months.
 - Prune ruthlessly: a source that turned out shallow or off-mission is removed, not buried.
 - If the learner has opted out of joining communities, note it here so future sessions stop proposing them.

--- a/claude/.claude/skills/teach-me/resources/course-generation.md
+++ b/claude/.claude/skills/teach-me/resources/course-generation.md
@@ -118,6 +118,8 @@ The curated set of trusted sources for the topic. Teaching should be grounded in
   [One line: what it covers. Use for: when to reach for it.]
 - [Article: "Title" — Author (Site)](url)
   [One line annotation.]
+- [Video: "Title" — Speaker/Channel](url)
+  [One line annotation.]
 
 ## Wisdom (Communities)
 
@@ -131,6 +133,7 @@ The curated set of trusted sources for the topic. Teaching should be grounded in
 
 **Rules:**
 - High-trust only: primary sources, recognised experts, peer-reviewed work, well-moderated communities. Marketing dressed as education stays out.
+- For HTML lessons and indexes, resources may include articles, blog posts, videos/talks, papers, and books, but only when they are excellent and directly relevant. Do not add a source merely to fill a media type.
 - Annotate every entry — a bare link is useless in three months.
 - Prune ruthlessly: a source that turned out shallow or off-mission is removed, not buried.
 - If the learner has opted out of joining communities, note it here so future sessions stop proposing them.

--- a/claude/.claude/skills/teach-me/resources/html-lessons.md
+++ b/claude/.claude/skills/teach-me/resources/html-lessons.md
@@ -226,7 +226,7 @@ If you create an HTML index for a topic, lesson set, or course, treat it as a du
 **Index reading-list rules:**
 - Use the same quality bar as lessons: canonical, recognised expert, peer-reviewed, widely cited, or exceptionally clear and practical.
 - Prefer breadth across media when it helps: one article or blog post, one video or talk, and one book or paper is better than three similar links.
-- Draw from `resources.md` first; if the index reveals a gap, search for a better source and add it to `resources.md` before linking it.
+- Draw from `resources.md` first; if the index reveals a gap, do online research for a better source and add it to `resources.md` before linking it.
 - Keep the list short: 3-7 resources for a full topic index, fewer for a narrow lesson index.
 - If the topic lacks excellent resources, omit the reading list; do not add a placeholder or apology inside the HTML.
 
@@ -238,6 +238,6 @@ If you create an HTML index for a topic, lesson set, or course, treat it as a du
 - **Mirror the session, don't transcribe it.** Use the same examples the learner worked through — familiarity aids review — but compress the dialogue into clean exposition.
 - **Keep difficulty out of the prose.** The body is for knowledge re-acquisition, so it should be the clearest possible telling. The quiz is where desirable difficulty lives.
 - **Cite or cut.** A factual claim with no source from `resources.md` either gets a source found and added, or gets reframed as reasoning the learner can verify themselves.
-- **Quality-gate reading lists.** A lesson or index reading list is not "more links"; it is a curated path to the best material. Include only resources you would confidently assign to a serious learner: primary documentation, seminal papers/books, recognised expert articles, exceptional blog posts, or high-signal talks/videos. Prefer sources that are current for fast-moving topics. Search when `resources.md` is thin, update `resources.md` with any selected resource, and omit the section entirely when the search does not turn up excellent material.
+- **Quality-gate reading lists.** A lesson or index reading list is not "more links"; it is a curated path to the best material. Include only resources you would confidently assign to a serious learner: primary documentation, seminal papers/books, recognised expert articles, exceptional blog posts, or high-signal talks/videos. Prefer sources that are current for fast-moving topics. Do online research when `resources.md` is thin, update `resources.md` with any selected resource, and omit the section entirely when the research does not turn up excellent material.
 - **Glossary discipline.** Use glossary terms exactly as defined. If the lesson needs a term the glossary lacks and the learner has demonstrated understanding of it, add it to the glossary in the same step.
 - **Quiz answers are part of spaced repetition.** Pull at least one quiz question from a *previous* lesson's material (interleaving), and feed quiz topics into the session log's spaced-review schedule.

--- a/claude/.claude/skills/teach-me/resources/html-lessons.md
+++ b/claude/.claude/skills/teach-me/resources/html-lessons.md
@@ -51,7 +51,7 @@ Every lesson contains, in order:
 3. **Body** — the session's teaching, mirrored: concrete examples first (at least two), abstract principle extracted second, diagram where it adds clarity. Use glossary terminology exactly.
 4. **Citations** — claims backed by links to sources from `resources.md`, inline where the claim is made.
 5. **Recap quiz** — 3-5 questions spanning Bloom's levels, answers hidden behind reveal controls. Follow the answer-option hygiene rules in `assessment-patterns.md` (equal-length options, no formatting clues).
-6. **Primary source** — one recommended high-trust resource to read or watch next, with a sentence on why.
+6. **Reading list attempt** — try to add a compact list of world-class resources for the lesson: articles, blog posts, videos/talks, papers, or books. Include only excellent, directly relevant resources; if none meet the bar, omit the section.
 7. **Connections** — links to the previous and next lesson (relative paths), and to `../cheat-sheet.md` and `../glossary.md`.
 8. **Footer reminder** — the tutor is available: *"Questions? Run `/teach-me [topic]` — your tutor remembers where you left off."*
 
@@ -109,10 +109,22 @@ Use this skeleton as the starting point; adapt the content structure to the mate
   figcaption { color: var(--muted); font-size: 0.85rem; margin-top: 0.5rem; }
   .quiz li { margin-bottom: 1.25rem; }
   details summary { cursor: pointer; color: var(--accent); }
-  .source {
+  .reading-list {
     background: #f4f4ec;
     padding: 1rem 1.25rem;
     margin: 2rem 0;
+  }
+  .reading-list h2 {
+    margin-top: 0;
+  }
+  .reading-list li {
+    margin-bottom: 0.75rem;
+  }
+  .resource-kind {
+    color: var(--muted);
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
   }
   footer {
     margin-top: 3.5rem;
@@ -173,10 +185,19 @@ Use this skeleton as the starting point; adapt the content structure to the mate
   </li>
 </ol>
 
-<div class="source">
-  <strong>Go deeper:</strong> <a href="[url]">[Primary source title]</a> —
-  [one sentence on why this is the best next thing to read or watch].
-</div>
+<section class="reading-list" aria-labelledby="reading-list">
+  <h2 id="reading-list">Reading list</h2>
+  <ul>
+    <li>
+      <span class="resource-kind">[Article / Blog post / Video / Book / Paper]</span><br>
+      <a href="[url]">[Resource title]</a> — [one sentence on why this is excellent and when to use it].
+    </li>
+    <li>
+      <span class="resource-kind">[Article / Blog post / Video / Book / Paper]</span><br>
+      <a href="[url]">[Resource title]</a> — [one sentence on why this is excellent and when to use it].
+    </li>
+  </ul>
+</section>
 
 <nav class="lessons">
   <a href="./NNNN-previous-slug.html">← Previous lesson</a>
@@ -194,6 +215,21 @@ Use this skeleton as the starting point; adapt the content structure to the mate
 
 Omit the previous-lesson link in lesson `0001`; omit the next-lesson link until the next lesson exists (add it when generating the following lesson).
 
+Omit the whole reading-list section when no excellent, directly relevant resources can be found.
+
+---
+
+## HTML Indexes
+
+If you create an HTML index for a topic, lesson set, or course, treat it as a durable learning artifact rather than a directory listing. Include the lesson map, mission, current progress, and a topic-level reading list when excellent resources exist.
+
+**Index reading-list rules:**
+- Use the same quality bar as lessons: canonical, recognised expert, peer-reviewed, widely cited, or exceptionally clear and practical.
+- Prefer breadth across media when it helps: one article or blog post, one video or talk, and one book or paper is better than three similar links.
+- Draw from `resources.md` first; if the index reveals a gap, search for a better source and add it to `resources.md` before linking it.
+- Keep the list short: 3-7 resources for a full topic index, fewer for a narrow lesson index.
+- If the topic lacks excellent resources, omit the reading list; do not add a placeholder or apology inside the HTML.
+
 ---
 
 ## Content Rules
@@ -202,5 +238,6 @@ Omit the previous-lesson link in lesson `0001`; omit the next-lesson link until 
 - **Mirror the session, don't transcribe it.** Use the same examples the learner worked through — familiarity aids review — but compress the dialogue into clean exposition.
 - **Keep difficulty out of the prose.** The body is for knowledge re-acquisition, so it should be the clearest possible telling. The quiz is where desirable difficulty lives.
 - **Cite or cut.** A factual claim with no source from `resources.md` either gets a source found and added, or gets reframed as reasoning the learner can verify themselves.
+- **Quality-gate reading lists.** A lesson or index reading list is not "more links"; it is a curated path to the best material. Include only resources you would confidently assign to a serious learner: primary documentation, seminal papers/books, recognised expert articles, exceptional blog posts, or high-signal talks/videos. Prefer sources that are current for fast-moving topics. Search when `resources.md` is thin, update `resources.md` with any selected resource, and omit the section entirely when the search does not turn up excellent material.
 - **Glossary discipline.** Use glossary terms exactly as defined. If the lesson needs a term the glossary lacks and the learner has demonstrated understanding of it, add it to the glossary in the same step.
 - **Quiz answers are part of spaced repetition.** Pull at least one quiz question from a *previous* lesson's material (interleaving), and feed quiz topics into the session log's spaced-review schedule.


### PR DESCRIPTION
## Summary

- Add quality-gated reading lists to teach-me HTML lesson guidance.
- Extend HTML index guidance so topic, lesson, or course indexes include excellent resources when available.
- Update the topic resources.md template to support videos/talks and reinforce quality over filling media types.
- Add a patch changeset for the update.

## Impact

Generated teach-me HTML lessons and indexes now try to include world-class articles, blog posts, videos/talks, papers, or books, while omitting the reading-list section when no excellent resources are available.

## Validation

- pnpm test
- git diff --check