### PR TITLE
feat(hexagonal-architecture): reconcile with Cockburn's Hexagonal Architecture Explained

### DIFF
--- a/.changeset/hexagonal-cockburn-refresh.md
+++ b/.changeset/hexagonal-cockburn-refresh.md
@@ -1,0 +1,7 @@
+---
+"@paulhammond/dotfiles": minor
+---
+
+Reconcile the `hexagonal-architecture` and `folder-structure` skills with the source pattern, from a cover-to-cover read of _Hexagonal Architecture Explained_ (Cockburn & Garrido de Paz).
+
+Corrections: the pattern is symmetric (inside vs outside) — the left/right asymmetry exists only in implementation as who-knows-whom (provided vs required interfaces); runtime configurability of driven actors is the actual pattern requirement (parameter injection is one of three sanctioned configurator shapes, kept as this skill's house default). Disclosures: the source convention purpose-names every port (`ForGettingTaxRates`, `ForPaying`) — this skill's role-noun driven ports are now a documented house choice with book-style names as equal alternatives. New: actor/interactor and primary/secondary vocabulary, pattern-requirements vs house-style checklist tiers, the "a port is only real if it has a test interactor" principle, two anti-patterns (port for a domain concept; nested hexagons), a `greenfield-sequence` resource (folders first, disposable first test, walking skeleton), purpose-named `ports/` folder conventions, and per-chapter citations in references. Fakes location reconciled to `adapters/fakes/` across both skills.

--- a/claude/.claude/skills/folder-structure/SKILL.md
+++ b/claude/.claude/skills/folder-structure/SKILL.md
@@ -142,15 +142,15 @@ src/
         collect-payment.test.ts
         index.ts
     adapters/
-      driven/
+      outbound/
         stripe-payment-gateway.ts
         postgres-invoice-repository.ts
         invoice-row.ts
         invoice-mapper.ts
+      inbound/
+        billing-routes.ts         # thin driving adapter when framework allows
       fakes/
         fake-invoice-repository.ts  # in-memory driven actor for tests — needs no adapter
-    delivery/
-      billing-routes.ts           # thin driving adapter when framework allows
 ```
 
 If the framework forces routes elsewhere, keep those files thin and make the dependency direction obvious:
@@ -171,14 +171,14 @@ Placement rules for opted-in DDD/hex code:
 
 - Put entities, value objects, domain services, specifications, domain errors, repository interfaces, gateway interfaces, and business result types in `domain/`.
 - Put use cases/application services in `use-cases/` when separating orchestration from the pure domain model; they are still inside the hexagon and protected from adapters.
-- Put concrete DB, API, queue, email, payment, filesystem, and SDK implementations in `adapters/driven/` or `infrastructure/`.
-- Put route handlers, controllers, CLI commands, queue consumers, cron triggers, and server actions in `delivery/` or framework-required `app/` folders.
+- Put concrete DB, API, queue, email, payment, filesystem, and SDK implementations in `adapters/outbound/` (alternatives: `adapters/driven/`, `infrastructure/`).
+- Put route handlers, controllers, CLI commands, queue consumers, cron triggers, and server actions in `adapters/inbound/` (alternatives: `delivery/`, or framework-required `app/` folders).
 - Keep adapter DTOs, DB rows, SDK response types, mappers, and query DTOs with the adapter. Map them to domain types at the boundary.
 - Keep shared-kernel types tiny. `Money`, `EmailAddress`, and `Clock` can be shared; `Invoice`, `GiftIdea`, and `User` usually belong to a bounded context.
 
-Ports placement has two sound shapes. The default above colocates each driven port with its aggregate. The alternative from the source pattern gathers port definitions into dedicated folders — `ports/driving/` and `ports/driven/` (or `ports/inbound/` and `ports/outbound/`), optionally one file per port named for its purpose (`for-collecting-payment.ts`) — so adapters can depend on the interfaces without the rest of the context, and the application boundary is visible in the tree. Either way, keep driving and driven port definitions visibly separate; practitioners report this is the single biggest readability win for interface definitions.
+Ports placement has two sound shapes. The default above colocates each driven port with its aggregate. The alternative from the source pattern gathers port definitions into dedicated folders — `ports/inbound/` and `ports/outbound/` (or `ports/driving/` and `ports/driven/`), optionally one file per port named for its purpose (`for-collecting-payment.ts`) — so adapters can depend on the interfaces without the rest of the context, and the application boundary is visible in the tree. Either way, keep driving and driven port definitions visibly separate; practitioners report this is the single biggest readability win for interface definitions.
 
-`delivery/` is this skill's name for the driving (inbound) adapter side; `adapters/driven/` is the driven (outbound) side. If "driving" and "driven" read too alike as sibling folder names, `inbound/` and `outbound/` are endorsed alternatives.
+`adapters/inbound/` (driving side) and `adapters/outbound/` (driven side) are this skill's default folder names — "driving" and "driven" read too alike as siblings, and inbound/outbound is the source-endorsed cure. `delivery/` and `adapters/driven/` remain fine alternatives where a codebase already uses them; whatever the names, the inbound/outbound separation itself is the point.
 
 ## Import Boundary Rules
 
@@ -198,6 +198,7 @@ export default [
             group: [
               "**/adapters/**",
               "**/infrastructure/**",
+              "**/adapters/inbound/**",
               "**/delivery/**",
               "**/app/**",
               "**/use-cases/**",
@@ -225,6 +226,7 @@ export default [
             group: [
               "**/adapters/**",
               "**/infrastructure/**",
+              "**/adapters/inbound/**",
               "**/delivery/**",
               "**/app/**",
               "next",
@@ -253,6 +255,7 @@ export default [
               "**/use-cases/**",
               "**/adapters/**",
               "**/infrastructure/**",
+              "**/adapters/inbound/**",
               "**/delivery/**",
               "**/features/**",
             ],

--- a/claude/.claude/skills/folder-structure/SKILL.md
+++ b/claude/.claude/skills/folder-structure/SKILL.md
@@ -42,6 +42,7 @@ Read `references/research-notes.md` when documenting rationale, comparing named 
    - Add 3-6 placement rules that explain where new files go.
    - Add 2-4 import/dependency rules that keep the structure honest.
    - Include lint/import-boundary rules when the project uses DDD, hexagonal architecture, or another explicit layered boundary.
+   - For a new DDD/hex context, create the skeleton folders before writing any code — an empty-but-correct structure makes every later file placement obvious.
 
 ## Feature Anatomy
 
@@ -117,6 +118,8 @@ src/
 
 When a project opts into DDD or hexagonal architecture, make `domain/` visible. This is the deliberate exception to "avoid technical folders": `domain/` marks the protected core of the hexagon, not a framework category.
 
+The ports-and-adapters pattern itself mandates no folder layout — only the inside/outside boundary (*Hexagonal Architecture Explained*, Cockburn & Garrido de Paz). This section is a recommended physical realization of that boundary's intent.
+
 Prefer bounded context first, protected core second:
 
 ```text
@@ -145,7 +148,7 @@ src/
         invoice-row.ts
         invoice-mapper.ts
       fakes/
-        fake-invoice-repository.ts
+        fake-invoice-repository.ts  # in-memory driven actor for tests — needs no adapter
     delivery/
       billing-routes.ts           # thin driving adapter when framework allows
 ```
@@ -172,6 +175,10 @@ Placement rules for opted-in DDD/hex code:
 - Put route handlers, controllers, CLI commands, queue consumers, cron triggers, and server actions in `delivery/` or framework-required `app/` folders.
 - Keep adapter DTOs, DB rows, SDK response types, mappers, and query DTOs with the adapter. Map them to domain types at the boundary.
 - Keep shared-kernel types tiny. `Money`, `EmailAddress`, and `Clock` can be shared; `Invoice`, `GiftIdea`, and `User` usually belong to a bounded context.
+
+Ports placement has two sound shapes. The default above colocates each driven port with its aggregate. The alternative from the source pattern gathers port definitions into dedicated folders — `ports/driving/` and `ports/driven/` (or `ports/inbound/` and `ports/outbound/`), optionally one file per port named for its purpose (`for-collecting-payment.ts`) — so adapters can depend on the interfaces without the rest of the context, and the application boundary is visible in the tree. Either way, keep driving and driven port definitions visibly separate; practitioners report this is the single biggest readability win for interface definitions.
+
+`delivery/` is this skill's name for the driving (inbound) adapter side; `adapters/driven/` is the driven (outbound) side. If "driving" and "driven" read too alike as sibling folder names, `inbound/` and `outbound/` are endorsed alternatives.
 
 ## Import Boundary Rules
 

--- a/claude/.claude/skills/hexagonal-architecture/SKILL.md
+++ b/claude/.claude/skills/hexagonal-architecture/SKILL.md
@@ -20,6 +20,7 @@ If the `folder-structure` skill has been explicitly applied to this project, fol
 | `cqrs-lite.md` | Reads need to JOIN across aggregates, separating read/write paths |
 | `cross-cutting-concerns.md` | Placing auth, logging, transactions, or error formatting |
 | `incremental-adoption.md` | Introducing hex arch into an existing codebase |
+| `greenfield-sequence.md` | Starting a hex project from scratch — ordering the first ports, adapters, and tests |
 | `references.md` | Checking source rationale, especially port/public interface naming |
 
 For authoritative sources and naming rationale, see `resources/references.md`.
@@ -53,7 +54,11 @@ Business logic lives in the center. External systems connect through ports (inte
 **Driving adapters** (left): initiate actions on the application. They *call* use cases.
 **Driven adapters** (right): the application reaches out to them. They *implement* port interfaces.
 
-This asymmetry is fundamental. Driving adapters depend on driving port interfaces exposed by the application. Driven adapters implement repository/gateway interfaces defined by the domain.
+The pattern itself is symmetric: one rule — inside versus outside — and the application knows nothing about what is connected on either side. The left/right asymmetry appears only in implementation, as who knows whom: driving adapters know the application and call the driving port interfaces it exposes; the application knows its driven adapters only as injected parameters implementing the port interfaces it defines. That is why driving ports are provided interfaces and driven ports are required interfaces.
+
+The pattern defines exactly two zones — inside and outside — and says nothing about how either is structured internally. The domain/use-case layering in this skill is our recommended way to keep the inside honest, not part of the pattern.
+
+**Vocabulary:** An *actor* is anything with behavior outside the boundary — a human, a database, another program, a test. *Driving* (= *primary*) actors initiate a conversation with the application; *driven* (= *secondary*) actors are the ones the application calls. These are the only adjective pairs that apply equally to actors, ports, and adapters (inbound/outbound works for ports, adapters, and folders — but not actors). An *interactor* is an actor or its adapter, whichever touches the port directly: not every actor needs an adapter — tests, sibling hexagonal apps, and program-to-program callers can meet a port's interface as-is. Driving ports form the application's *provided interface* (API); driven ports form its *required interface* (SPI).
 
 ---
 
@@ -65,14 +70,14 @@ Use case implementations satisfy the driving port. The driving adapter should de
 
 ### Naming Ports and Public Interfaces
 
-Name every port from the application's point of view, using the domain language of the conversation:
+Name every port from the application's point of view, using the domain language of the conversation. The source pattern names *every* port — driving and driven — for the intention of the conversation: `ForPlacingOrders`, `ForGettingTaxRates`, `ForStoringTickets`. The pattern legislates no naming at all, though. This skill keeps intention names for driving ports and uses role nouns (`OrderRepository`, `PaymentGateway`) for driven ports as a deliberate house choice: both styles are purpose names, never technology names. A codebase already using `For...` names on the driven side is following the source convention — leave it be.
 
 | Boundary | Good names | Avoid | Why |
 |----------|------------|-------|-----|
 | Driving/public API | `ForPlacingOrders`, `ForPledgingToOccasions` | `PlaceOrderUseCase`, `PlaceOrderHandler`, `OrderInputPort` | Names the actor capability, not the pattern |
-| Aggregate persistence | `OrderRepository`, `ContributorRepository` | `OrderDatabase`, `OrderDao`, `SqlOrderPort` | Repository is a domain collection abstraction |
-| External service | `PaymentGateway`, `ExchangeRateProvider` | `StripeClient`, `HttpPaymentPort` | Names the capability the app needs, not the vendor/protocol |
-| Notifications/events | `OrderEventPublisher`, `ReceiptSender` | `SnsAdapter`, `MessageBusPort` | Names the business-side interaction |
+| Aggregate persistence | `OrderRepository`, `ContributorRepository` (or `ForStoringOrders`) | `OrderDatabase`, `OrderDao`, `SqlOrderPort` | Repository is a domain collection abstraction |
+| External service | `PaymentGateway`, `ExchangeRateProvider` (or `ForPaying`, `ForObtainingRates`) | `StripeClient`, `HttpPaymentPort` | Names the capability the app needs, not the vendor/protocol |
+| Notifications/events | `OrderEventPublisher`, `ReceiptSender` (or `ForNotifyingContributors`) | `SnsAdapter`, `MessageBusPort` | Names the business-side interaction |
 
 **Public interface naming rules:**
 - Use `interface` for behavior contracts, not data shapes that are better modeled as `type`/schemas.
@@ -192,7 +197,7 @@ For detailed CQRS-lite guidance, see `resources/cqrs-lite.md`. When the read/wri
 
 ---
 
-## Dependency Injection
+## Dependency Injection and the Configurator
 
 Inject all dependencies via function parameters. No DI container needed. The driving adapter gathers impure dependencies, passes them to the use case, and acts on the result — Seemann's "impureim sandwich" (impure/pure/impure).
 
@@ -244,6 +249,8 @@ export async function POST(request: Request) {
 
 The route handler is thin glue: parse input → wire adapters → call use case → return response. No business logic.
 
+**The configurator:** whatever code knows all the players and introduces them — the composition root here — is the pattern's fifth element. Constructor injection (this skill's default) is one of three sanctioned shapes: a setter or `ForConfiguring...` function allows driven adapters to be swapped while the system runs (hazard: an app constructed but never configured), and dependency lookup hands the application a broker it asks at call time. In tests, the test case itself plays configurator and driving actor at once; in production, the composition root does.
+
 **Non-HTTP driving adapters** follow the same pattern — parse, wire, delegate:
 
 ```typescript
@@ -262,6 +269,8 @@ const handlePledgeMessage = async (message: SQSMessage, env: Env) => {
 The use case doesn't know or care whether it was triggered by an HTTP request, a queue message, a cron job, or a CLI command. Every driving adapter is thin glue.
 
 **Naming:** Use case interfaces and implementations are named after the business capability — `ForPlacingOrders`, `createOrderPlacement`, `pledgeToOccasion`. Never `CreateOrderUseCase` or `PlaceOrderHandler`. Pattern suffixes are technical jargon, not domain language. You can tell a use case implementation from a domain function by its dependencies — use case implementations take driven ports (repositories, gateways) as parameters; domain functions take only domain types.
+
+*Terminology note:* in the source pattern literature, "use case" is a requirements technique — its primary/secondary actors map to driving/driven actors, and ports start out one per actor. This skill uses "use case" for the orchestration object that implements a driving port. Related, not the same thing.
 
 ---
 
@@ -298,6 +307,8 @@ Hex arch's primary benefit is testability. The primary test boundary is the **us
 | **Verification** | E2E (full stack) | User experience works |
 
 **Fakes over mocks:** Fakes implement the real interface and maintain state. Mocks verify call sequences and break on refactoring. See `resources/testing-hex-arch.md` for detailed patterns.
+
+**A port is only real if it is tested.** Every port needs a test interactor — a test driver at each driving port, a fake at each driven port. Without one, the "port" is just a line on a diagram; nothing enforces it as a boundary. The test wall doubles as the leak detector: business logic drifting into an adapter, or technology detail drifting into the domain, breaks a boundary test immediately.
 
 For a complete worked example showing one feature traced through every layer (glossary → types → domain → use case → adapters → tests → file locations), see `resources/worked-example.md`.
 
@@ -372,6 +383,14 @@ const result = await getActiveUsers(userRepo);
 
 Creating a port for every tiny abstraction. Ports should represent meaningful boundaries — one per aggregate (repositories) or per external capability (payment, email, auth).
 
+### Port for a Domain Concept
+
+A driven port represents a conversation with an external system — a database, a payment provider, a notification channel. Wrapping an internal domain abstraction in a port interface adds indirection with no boundary to protect. If nothing outside the hexagon will ever sit behind the interface, it is not a port.
+
+### Nested Hexagons
+
+Hexagons do not nest. The ports-and-adapters boundary belongs at the technology (or team-authority) edge, where system-level tests are worth maintaining. Inner hexagon boundaries duplicate that test wall; the inner tests decay, and the boundary stops being real. Structure the inside with modules, bounded contexts, or plain functions instead.
+
 ### Technology-Shaped Ports
 
 Port methods that expose technology details. Port methods should use domain language.
@@ -414,18 +433,25 @@ const placeOrder = async (...) => ...
 
 ## Checklist
 
-- [ ] Domain logic has zero framework/infrastructure dependencies
+**Required by the pattern:**
+
+- [ ] All external boundaries use ports/public contracts — nothing outside reaches past a port
+- [ ] Domain logic has zero framework/infrastructure dependencies (no source dependencies on any actor or adapter)
+- [ ] Driven actors are configurable at run time — the application never constructs them internally (the pattern leaves the configurator's shape open; parameter injection is this skill's house default)
+- [ ] Ports use business language only; port methods never expose technology types
+- [ ] Swapping any adapter requires zero domain code changes
+- [ ] Every port has a test interactor — a test driver on the driving side, a fake on the driven side
+
+**This skill's additions (house style):**
+
 - [ ] If `folder-structure` has been applied, protected-domain-core lint/import rules are present and passing
-- [ ] All external boundaries use ports/public contracts
 - [ ] Driving adapters (routes) are thin — parse, wire, delegate, respond
 - [ ] Driven adapters (repos) implement ports, contain no business logic
-- [ ] Dependencies injected via parameters, never created internally
 - [ ] Driven port interfaces live in domain, named by business purpose
 - [ ] Public interfaces avoid `I` prefixes, `Interface` suffixes, `Port` suffixes, and `Impl` implementations
 - [ ] Driving port and use case names use business capability language, not `UseCase`/`Handler` pattern names
 - [ ] Schemas defined in domain, not duplicated in adapters
 - [ ] Reads that JOIN across aggregates use query functions (CQRS-lite)
 - [ ] Each layer has behavioral tests at the appropriate level
-- [ ] Swapping any adapter requires zero domain code changes
 - [ ] Cross-cutting concerns (auth, logging, transactions) live in adapters, not domain
 - [ ] Domain returns result types for expected outcomes, never throws for business rules

--- a/claude/.claude/skills/hexagonal-architecture/resources/greenfield-sequence.md
+++ b/claude/.claude/skills/hexagonal-architecture/resources/greenfield-sequence.md
@@ -1,0 +1,68 @@
+# Greenfield Development Sequence
+
+How to start a hexagonal project from scratch. For introducing hex arch into an existing codebase, see `incremental-adoption.md` — this is its greenfield twin. Distilled from *Hexagonal Architecture Explained* (Cockburn & Garrido de Paz), Ch 4.9 and Ch 5.2; citations in `references.md`.
+
+## Step 0: Create the Folders First
+
+Before writing any code, create the skeleton: domain (with port locations), driven adapters (including `fakes/`), driving adapters/delivery, tests. With an empty-but-correct structure in place, every subsequent file placement is obvious — this one habit removes most "where does this go?" confusion. Use the `folder-structure` skill's protected-domain-core layout if it applies.
+
+## Step 1: Driving Side — the App Returns a Constant
+
+Define the first driving port and the smallest possible implementation behind it: no parameters beyond the essentials, returning a constant. Write a test that calls the driving port and expects that constant.
+
+```typescript
+// domain/tax/for-calculating-taxes.ts — first driving port
+interface ForCalculatingTaxes {
+  readonly taxOn: (amount: Money) => Money;
+}
+
+// tests: expect the constant
+it('returns the flat placeholder tax', () => {
+  const calculator = createTaxCalculation();
+  expect(calculator.taxOn(createMoney(100, 'GBP'))).toEqual(createMoney(0, 'GBP'));
+});
+```
+
+This first test is deliberately disposable. Once the app consults a driven port (Step 2), the constant-only behavior disappears, and this test gets rewritten or deleted. That's fine — its job was to prove the driving-side connection.
+
+## Step 2: Driven Side — a Fake Returns a Constant
+
+Define the first driven port and a fake in `adapters/fakes/` that returns a simple value. Change the app to take the driven port as a constructor/factory parameter and consult it instead of hardcoding. Update the test to build the fake, pass it in, and expect the fake's value (use a *different* value than Step 1, to prove the wiring changed).
+
+```typescript
+// domain/tax/tax-rate-provider.ts — first driven port
+interface TaxRateProvider {
+  readonly rateFor: (amount: Money) => TaxRate;
+}
+
+const createTaxCalculation = (rates: TaxRateProvider): ForCalculatingTaxes => ({
+  taxOn: (amount) => applyRate(amount, rates.rateFor(amount)),
+});
+```
+
+**The architecture is now complete.** One driving port, one driven port, a configurator (the test), and an app with zero source dependencies on anything outside. Everything after this point is growth, not architecture.
+
+## Step 3: Add a Real Driving Adapter
+
+Connect the real driver — route handler, CLI command, queue consumer — still against the fake driven port. The driving adapter parses input, wires, delegates to the driving port, and translates the result. Two drivers (tests and the real one) now exercise the same port.
+
+## Step 4: Add a Real Driven Adapter
+
+Choose the real technology (database, HTTP client, file) and implement the driven port in the adapters layer, with a narrow integration test (see `testing-hex-arch.md`). The use case tests keep running on the fake, untouched.
+
+## The Four Wirings
+
+The steps trace a deliberate progression of configurations:
+
+| Wiring | Driver | Driven | When |
+|--------|--------|--------|------|
+| test-to-test | Test cases | Fake | Step 2 — architecture done |
+| real-to-test | Real driving adapter | Fake | Step 3 |
+| test-to-real | Test cases | Real adapter (test DB) | Step 4 integration tests |
+| real-to-real | Real driving adapter | Real adapter | Production |
+
+After Step 2, the remaining wirings can land in any order.
+
+## Walking Skeleton
+
+Connect the real technologies (Steps 3–4) for a nearly-empty transaction *before* building out business logic. This is risk management: technology hookups are where surprises live, and doing them first also stands up the test and delivery pipeline. Then grow the domain, the ports, and the adapters in parallel, in any order the work demands.

--- a/claude/.claude/skills/hexagonal-architecture/resources/greenfield-sequence.md
+++ b/claude/.claude/skills/hexagonal-architecture/resources/greenfield-sequence.md
@@ -8,7 +8,7 @@ Before writing any code, create the skeleton: domain (with port locations), `ada
 
 ## Step 1: Driving Side — the App Returns a Constant
 
-Define the first driving port and the smallest possible implementation behind it: no parameters beyond the essentials, returning a constant. Write a test that calls the driving port and expects that constant.
+Define the first driving port — the interface only. Then RED first: write a unit test that calls the driving port and expects a constant, and watch it fail. Only then write the smallest implementation behind the port: no parameters beyond the essentials, returning that constant (the classic fake-it step).
 
 ```typescript
 // domain/tax/for-calculating-taxes.ts — first driving port
@@ -27,7 +27,7 @@ This first test is deliberately disposable — but be precise about which test t
 
 ## Step 2: Driven Side — a Fake Returns a Constant
 
-Define the first driven port and a fake in `adapters/fakes/` that returns a simple value. Change the app to take the driven port as a constructor/factory parameter and consult it instead of hardcoding. Update the test to build the fake, pass it in, and expect the fake's value (use a *different* value than Step 1, to prove the wiring changed).
+Define the first driven port and a fake in `adapters/fakes/` that returns a simple value. RED first again: update the test to build the fake, pass it in, and expect the fake's value — use a *different* value than Step 1 so the test fails against the hardcoded constant. Then triangulate: change the app to take the driven port as a constructor/factory parameter and consult it instead of hardcoding.
 
 ```typescript
 // domain/tax/tax-rate-provider.ts — first driven port

--- a/claude/.claude/skills/hexagonal-architecture/resources/greenfield-sequence.md
+++ b/claude/.claude/skills/hexagonal-architecture/resources/greenfield-sequence.md
@@ -4,7 +4,7 @@ How to start a hexagonal project from scratch. For introducing hex arch into an 
 
 ## Step 0: Create the Folders First
 
-Before writing any code, create the skeleton: domain (with port locations), driven adapters (including `fakes/`), driving adapters/delivery, tests. With an empty-but-correct structure in place, every subsequent file placement is obvious — this one habit removes most "where does this go?" confusion. Use the `folder-structure` skill's protected-domain-core layout if it applies.
+Before writing any code, create the skeleton: domain (with port locations), `adapters/outbound/` (including `adapters/fakes/`), `adapters/inbound/`, tests. With an empty-but-correct structure in place, every subsequent file placement is obvious — this one habit removes most "where does this go?" confusion. Use the `folder-structure` skill's protected-domain-core layout if it applies.
 
 ## Step 1: Driving Side — the App Returns a Constant
 
@@ -23,7 +23,7 @@ it('returns the flat placeholder tax', () => {
 });
 ```
 
-This first test is deliberately disposable. Once the app consults a driven port (Step 2), the constant-only behavior disappears, and this test gets rewritten or deleted. That's fine — its job was to prove the driving-side connection.
+This first test is deliberately disposable — but be precise about which test that is. It is an inner-loop **unit** test, and returning the constant is the classic fake-it step: Step 2 triangulates the fake away, and rewriting or deleting this unit scaffold then is ordinary red-green work. It is **never** a locked acceptance test: where a project runs an ATDD outer loop with human-approved specs (see the `acceptance-testing` skill, where installed), the walking-skeleton acceptance spec is authored and confirmed failing *before* this sequence begins, asserts end-to-end plumbing rather than the placeholder value, and is not yours to rewrite or delete — this sequence orders the implementation *inside* that outer test, not around it.
 
 ## Step 2: Driven Side — a Fake Returns a Constant
 

--- a/claude/.claude/skills/hexagonal-architecture/resources/references.md
+++ b/claude/.claude/skills/hexagonal-architecture/resources/references.md
@@ -9,11 +9,22 @@ Load this when checking the rationale behind hexagonal architecture guidance, es
   - The port protocol comes from the purpose of the conversation, not from the external device.
   - Multiple adapters can fit the same port.
   - "How many ports?" is contextual; neither one port per tiny operation nor two giant ports is usually best.
-- Alistair Cockburn, "Hexagonal Architecture Explained" updates (2025): https://alistaircockburn.com/hexarch%20v1.1b%20DIFFS%2020250420-1012%20paper%2Bepub.docx.pdf
-  - Driving/driven and primary/secondary apply to actors, adapters, and ports.
-  - Inbound/outbound can be useful folder names, but they are less universal as conceptual labels.
-  - Strong conformance means a driven port is expressed in application language, not SQL/HTTP/vendor language.
-  - Cockburn describes two schools for driving port interfaces, but his named examples use explicit interfaces such as `ForCalculatingTaxes` and `ForGettingTaxRates`.
+- Alistair Cockburn & Juan Manuel Garrido de Paz, "Hexagonal Architecture Explained", Updated 1st ed. (2025): https://alistaircockburn.com/hexarch%20v1.1b%20DIFFS%2020250420-1012%20paper%2Bepub.docx.pdf
+  - The "For + verb-ing" intention name applies to driving AND driven ports. The book's canonical driven ports are `ForGettingTaxRates` (Ch 1.1 "Copy this code"; Ch 3.1) and BlueZone's `ForObtainingRates`, `ForStoringTickets`, `ForPaying` (Ch 3.3 "The BlueZone example"). Repositories are actors behind ports, not port names. This skill's role-noun driven ports (`OrderRepository`, `PaymentGateway`) are a documented deviation the pattern permits.
+  - Naming is a recommendation, not a requirement: the pattern does not legislate port names (Ch 2.4 "What is required, optional, and outside the pattern").
+  - Driving/driven = primary/secondary; these are the only adjective pairs that apply to all of actor, adapter, and port. Inbound/outbound suits ports, adapters, and folders; API/SPI suits ports only (Ch 2.1 Glossary + "The difficulty of naming" sidebar).
+  - An "interactor" is an actor or its adapter, whichever touches the port; some actors (tests, sibling apps, program-to-program callers) need no adapter (Ch 2.1; Ch 6.3 "Comments on the original article").
+  - The pattern is symmetric; the implementation is asymmetric — who knows whom produces provided vs required interfaces (Ch 5.3 "Is the pattern symmetric or asymmetric?"). The asymmetry that matters is inside/outside, not left/right (Ch 6.2, original 2005 article, "Nature of the Solution").
+  - App boundary heuristic: an external system is one whose interface your team can't change; boundaries also sit at team-authority edges (Ch 4.4 "Where do I put the 'app' boundary?").
+  - A driven port represents a conversation with an external system, never a domain concept (Ch 4.3 "What is a port?", Juan's note).
+  - A port without a test driver or test double at it is indistinguishable from any interface line drawn anywhere; tests make the boundary real and act as the leak detector (Ch 4.3; Ch 5.7 "DDD's anti-corruption layers"; Ch 6.4 "Tests or no tests?"; Ch 1.4 benefits).
+  - The pattern defines exactly two zones (inside/outside) and says nothing about internal structure — unlike Clean/Onion, which add required layers (Ch 2.4; Ch 4.6 "How do I structure the inside of my app?"; Ch 5.5 "Layered, onion, clean, hexagonal").
+  - The pattern does not nest; the boundary belongs at the technology/team edge (Ch 5.8 "What about nested hexagons?"; Ch 6.4).
+  - The configurator is the fifth element, with three shapes: constructor injection, setter/for-configuring function (allows live swap; hazard of a constructed-but-unconfigured app), or dependency lookup via a broker. "Configurable Receiver" (Dan North's name) supersedes the earlier "Configurable Dependency" (Ch 2.3 "The 5th element"; Ch 3.1 variants; Ch 6.5 "Configurable Receiver").
+  - Strong conformance means a driven port is expressed in application language, not SQL/HTTP/vendor language (Ch 1.1; Ch 2.4 sidebar "Weak versus strong conformance").
+  - Folder tips (explicitly not pattern requirements): keep driving-port and driven-port definition folders visibly separate, named for each port's purpose; adapters live outside the app space; Inbound/Outbound are endorsed folder names; create the folders before writing code (Ch 4.8 "Where do I put my files?"; Ch 4.9 "What is the development sequence?", step 0).
+  - Greenfield sequence: test-to-test, real-to-test, test-to-real, real-to-real; the architecture is complete once one driving port and one driven port with a test double exist (Ch 4.9; Ch 5.2 "How does this relate to Walking Skeleton?").
+  - Cockburn describes two schools for driving port interfaces (declare-and-use the interface, or use the class directly), but his named examples use explicit interfaces such as `ForCalculatingTaxes` and `ForGettingTaxRates` (Ch 1.1, updated-edition discussion).
   - For this skill, prefer explicit driving interfaces because they make the application boundary reviewable and consistent.
 - Herberto Graca, "DDD, Hexagonal, Onion, Clean, CQRS..." (2017): https://herbertograca.com/2017/11/16/explicit-architecture-01-ddd-hexagonal-onion-clean-cqrs-how-i-put-it-all-together/
   - Ports belong inside the application/business logic; adapters belong outside.
@@ -25,7 +36,7 @@ Load this when checking the rationale behind hexagonal architecture guidance, es
 
 ## Naming Ports and Interfaces
 
-- Cockburn names ports by the purpose/capability of the conversation, for example `ForCalculatingTaxes` and `ForGettingTaxRates`.
+- Cockburn names ports by the purpose/capability of the conversation, for example `ForCalculatingTaxes` and `ForGettingTaxRates` — on both the driving and driven sides. Our role-noun driven-port names are a deliberate deviation; see the "Hexagonal Architecture Explained" entry above.
 - Martin Fowler, "Role Interface": https://martinfowler.com/bliki/RoleInterface.html
   - Prefer role interfaces: small interfaces seen from the client's role, aligned with Interface Segregation.
   - Avoid header interfaces that mirror every public method of a class.

--- a/claude/.claude/skills/hexagonal-architecture/resources/testing-hex-arch.md
+++ b/claude/.claude/skills/hexagonal-architecture/resources/testing-hex-arch.md
@@ -2,6 +2,10 @@
 
 Hex arch's primary value is testability. The architecture creates natural test boundaries — but the primary boundary is the **use case**, not each layer in isolation. This approach follows Use Case Driven Development (UCDD) — see `references.md` for sources.
 
+## A Port Is Only Real If It Is Tested
+
+Every port needs a test interactor: a test driver at each driving port, a fake at each driven port. Without one, the "port" is an arbitrary interface line — nothing enforces it as a boundary. The tests double as the leak detector: business logic drifting into an adapter, or technology detail drifting into the domain, breaks a boundary test the moment it happens. When reviewing, ask of each port: what drives it, or fakes it, in the test suite?
+
 ## Primary Boundary: The Use Case
 
 Test by calling the driving port implementation with driven ports replaced by in-memory fakes. This exercises the full business logic path without touching infrastructure.

--- a/claude/.claude/skills/hexagonal-architecture/resources/worked-example.md
+++ b/claude/.claude/skills/hexagonal-architecture/resources/worked-example.md
@@ -203,7 +203,7 @@ The route handler is thin glue: parse → wire → delegate → translate to HTT
 ## 8. Fakes for Testing
 
 ```typescript
-// test/fakes/fake-occasion-repository.ts
+// adapters/fakes/fake-occasion-repository.ts
 const createFakeOccasionRepository = (
   initial: readonly Occasion[] = [],
 ): OccasionRepository & { readonly savedEntities: readonly Occasion[] } => {
@@ -218,6 +218,8 @@ const createFakeOccasionRepository = (
 ```
 
 Fakes implement the real interface and maintain state. If the interface changes, the fake breaks at compile time.
+
+A fake is a driven *actor* that needs no adapter — it meets the port interface directly. It lives in `adapters/fakes/`, beside the driven adapters it substitutes for, not in test space.
 
 ## 9. Tests
 
@@ -323,6 +325,10 @@ src/
       drizzle-occasion-repository.ts    ← Driven adapter
       drizzle-contributor-repository.ts ← Driven adapter
     schema.ts               ← Drizzle table definitions
+  adapters/
+    fakes/
+      fake-occasion-repository.ts       ← In-memory driven actors (shared fakes)
+      fake-contributor-repository.ts
   app/
     api/occasions/[id]/
       pledge/route.ts       ← Driving adapter (route handler)
@@ -331,10 +337,7 @@ tests/
   occasions/
     pledge-contribution.test.ts  ← Use case tests (primary)
     pledge-rules.test.ts         ← Domain unit tests (complement)
-  fakes/
-    fake-occasion-repository.ts  ← Shared fakes
-    fake-contributor-repository.ts
-    test-factories.ts            ← getTestOccasion, getTestContributor
+  test-factories.ts              ← getTestOccasion, getTestContributor
 ```
 
 ## What Lives Where (Summary)
@@ -346,5 +349,5 @@ tests/
 | Use cases | `domain/` (takes ports as params) | Orchestration of domain operations |
 | Repository impls | `db/repositories/` | Driven adapters, translate domain ↔ DB |
 | Route handlers | `app/api/` | Driving adapters, thin glue |
-| Fakes | `tests/fakes/` | Shared across use case tests |
+| Fakes | `adapters/fakes/` | In-memory driven actors, shared across use case tests |
 | Tests | `tests/{concept}/` | Organized by domain concept, not file |


### PR DESCRIPTION
Read Alistair Cockburn & Juan Manuel Garrido de Paz's *Hexagonal Architecture Explained* cover to cover and reconciled the `hexagonal-architecture` and `folder-structure` skills with the source pattern.

## What changed

- **Port naming disclosed**: the book purpose-names *every* port (`ForGettingTaxRates`, `ForPaying`) — driving *and* driven. This skill's role-noun driven ports (`OrderRepository`, `PaymentGateway`) are now explicitly a house choice, with book-style names added as equal alternatives.
- **Asymmetry corrected**: the pattern is symmetric (inside vs outside); left/right asymmetry exists only in implementation (who knows whom → provided vs required interfaces). The previous "this asymmetry is fundamental" wording taught the wrong claim.
- **Vocabulary added**: actor, driving = primary / driven = secondary (the only adjectives that fit actors, ports, *and* adapters), interactor, API/SPI.
- **Checklist split** into "required by the pattern" (runtime-configurable driven actors — not parameter injection specifically, which is one of three sanctioned configurator shapes) vs "this skill's additions".
- **New principle**: a port is only real if it has a test interactor — tests are the boundary's leak detector.
- **Two new anti-patterns**: port for a domain concept; nested hexagons.
- **New resource** `greenfield-sequence.md`: folders first, disposable first test, architecture complete after step 2, walking skeleton.
- **folder-structure**: optional purpose-named `ports/` conventions (driving|driven / inbound|outbound), folders-before-code, fakes location reconciled to `adapters/fakes/` across both skills.
- **references.md**: chapter/section citation block for every claim above.

Everything distilled in our own words with the book credited; fidelity was independently verified by a second model reading the book text directly (one overclaim found and fixed: parameter injection presented as a pattern requirement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)