### PR TITLE
feat(language): ubiquitous-language + specification skills

### DIFF
--- a/.changeset/language-skills.md
+++ b/.changeset/language-skills.md
@@ -1,0 +1,7 @@
+---
+"@paulhammond/dotfiles": minor
+---
+
+Add two language skills: `ubiquitous-language` and `specification`.
+
+`ubiquitous-language` makes the domain's language a governed artifact: a five-step protocol (SURFACE → CHECK → DECIDE → RECORD → RENAME) so vocabulary is admitted by decision, never by drift; a Contextive-compatible glossary format with per-context path scoping and a deprecation convention that names each term's replacement; brownfield bootstrap guidance; and the taxonomy of mechanical checks (banned weasel suffixes, glossary-driven identifier validation via token classes, test-title and DSL-verb checks) for projects that install an enforcement layer — with the honest note that without one, everything is convention. `specification` turns fuzzy intent into shared understanding before any story is split: one question at a time with recommendations, an example map as data, every assumption forced into a question, write-back into the team's own story artifact — and the agent-facilitated round is explicitly a first draft handed to a real three-amigos conversation via a generated review page (template included), multi-round until stable.

--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -4,7 +4,7 @@
 >
 > **Architecture:**
 > - **CLAUDE.md** (this file): Core philosophy + quick reference (~160 lines, always loaded)
-> - **Skills**: Detailed patterns loaded on-demand (tdd, testing, mutation-testing, test-design-reviewer, typescript-strict, functional, refactoring, expectations, planning, story-splitting, front-end-testing, react-testing, ci-debugging, hexagonal-architecture, domain-driven-design, event-sourcing, twelve-factor, api-design, cli-design, folder-structure, finding-seams, characterisation-tests, production-parity-skill-builder, storyboard, teach-me, diagrams, find-skills, find-gaps, double-check)
+> - **Skills**: Detailed patterns loaded on-demand (specification, ubiquitous-language, tdd, testing, mutation-testing, test-design-reviewer, typescript-strict, functional, refactoring, expectations, planning, story-splitting, front-end-testing, react-testing, ci-debugging, hexagonal-architecture, domain-driven-design, event-sourcing, twelve-factor, api-design, cli-design, folder-structure, finding-seams, characterisation-tests, production-parity-skill-builder, storyboard, teach-me, diagrams, find-skills, find-gaps, double-check)
 > - **External skills**: Loaded on-demand from community repos (impeccable + 17 steering commands from [pbakaus/impeccable](https://github.com/pbakaus/impeccable), 6 web quality skills from [addyosmani/web-quality-skills](https://github.com/addyosmani/web-quality-skills), 3 Next.js skills from [vercel-labs/next-skills](https://skills.sh/vercel-labs/next-skills), grill-me from [mattpocock/skills](https://skills.sh/mattpocock/skills/grill-me), seo-audit from [coreyhaines31/marketingskills](https://skills.sh/coreyhaines31/marketingskills/seo-audit))
 > - **Agents**: Specialized subprocesses for verification and analysis
 >
@@ -95,6 +95,8 @@ For detailed TDD workflow, load the `tdd` skill.
 For implementation of any planned slice, load `tdd`, `testing`, `mutation-testing`, and `refactoring` before code changes begin.
 For refactoring methodology, load the `refactoring` skill.
 For fuzzy product/design decisions, load `grill-me` to pressure-test the decision tree before writing stories or plans.
+For turning fuzzy intent into shared understanding and acceptance criteria — specification as a conversation, agent round first, then a real three-amigos round — load the `specification` skill.
+For naming domain concepts, glossary work, or any new/changed domain term — the five-step language protocol, never silent coinage — load the `ubiquitous-language` skill.
 For broad stories, epics, features, or backlog items, load `story-splitting` to create child stories before planning.
 For tightening an existing story, plan, acceptance criteria set, or mock spec, load `find-gaps` to write confirmed answers back into the artifact.
 For significant implementation work, load `planning` to turn one selected child story or narrow capability into PR-sized plans in `plans/`.

--- a/claude/.claude/skills/REFERENCES.md
+++ b/claude/.claude/skills/REFERENCES.md
@@ -425,3 +425,9 @@ Sources behind the `event-sourcing` skill. Several foundational names (Chassaing
 - **LCP/INP/CLS at p75 of field data; lab measurement "is not a substitute for field measurement"** → Observability skill: frontend note (deferred from v1)
 
 ---
+
+## Specification
+- Jason Gorman (Codemanship) — specification as conversation; specs as educated guesses tested by reality.
+- Gojko Adzic, *Specification by Example* (Manning, 2011) — key examples; the counter-example challenge.
+- Matt Wynne, "Introducing Example Mapping" (cucumber.io, 2015) — the card grammar and map-shape diagnostics.
+- George Dinwiddie — the three amigos: business, development, testing in one conversation.

--- a/claude/.claude/skills/REFERENCES.md
+++ b/claude/.claude/skills/REFERENCES.md
@@ -426,6 +426,49 @@ Sources behind the `event-sourcing` skill. Several foundational names (Chassaing
 
 ---
 
+## Ubiquitous Language
+
+### Eric Evans — "Domain-Driven Design" (2003) + [DDD Reference](https://www.domainlanguage.com/wp-content/uploads/2016/05/DDD_Reference_2015-03.pdf)
+- **"A change in the language is a change to the model"**; awkward terms are signal; rename after deciding → Ubiquitous-language skill: core principle, protocol steps 1 and 5
+
+### Vaughn Vernon — "Implementing Domain-Driven Design" (2013), ch. 1
+- **One UL per bounded context; team speech + code as the only guaranteed-current denotation** → "Where the Language Lives" priority order
+
+### Martin Fowler — [UbiquitousLanguage bliki](https://martinfowler.com/bliki/UbiquitousLanguage.html) + [StranglerFigApplication](https://martinfowler.com/bliki/StranglerFigApplication.html)
+- **UL framing**; **Strangler Fig** → brownfield protected-core ratchet
+
+### Chris Simon — [Contextive](https://github.com/dev-cycles/contextive)
+- **Glossary format + LSP editor experience, folder-scoped contexts** → `resources/glossary-format.md`
+
+### Peter Hilton — ["Living glossaries"](https://hilton.org.uk/blog/living-glossary) + Cyrille Martraire — "Living Documentation"
+- **Glossaries rot unless reconciled against code** → the lint-checked living glossary
+
+### Vladimir Khorikov — ["Ubiquitous Language and Naming"](https://enterprisecraftsmanship.com/posts/ubiquitous-language-naming/)
+- **Weasel-suffix critique** (`Info`, `Base`, `Item`, `Manager`, `Service`, `Dto`) → the banned-vocabulary seed list in SKILL.md
+
+### NDepend — [DDD ubiquitous-language identifier rule](https://blog.ndepend.com/checking-ddd-ubiquitous-language-with-ndepend/)
+- **Prior art (.NET, 2018)** for glossary-driven identifier checking with technical-word customization → the flagship rule's token-class design; no TS equivalent exists
+
+### Greg Young — ["Refactoring and the Ubiquitous Language"](https://gregfyoung.wordpress.com/2013/02/13/refactoring-and-the-ubiquitous-language/)
+- **Internal-vs-published boundary rule** (rename freely inside; version the published language) → protocol step 5
+
+### Olaf Zimmermann — [Y-statements](https://medium.com/olzzio/y-statements-10eb07b5a177)
+- **Micro-ADR template** for model-changing renames → `resources/language-protocol.md` + adr agent
+
+### Tomasz Ducin — ["Speaking Ubiquitous Language"](https://ducin.dev/ddd-speaking-ubiquitous-language)
+- **One word per concept; two phrases must mean two concepts** → DETECT triggers
+
+### Daniel Schleicher — [glossary-steered AI workflow](https://www.danielschleicher.com/software/engineering,/ai,/spec-driven/development/2026/01/04/removing-ambiguity-with-spec-driven-development.html)
+- **Propose-never-adopt semantics** (AI flags and proposes, never adopts without approval) → protocol step 2, adopted wholesale
+
+### Alvin Sng (Factory.ai) — ["Using Linters to Direct Agents"](https://factory.ai/news/using-linters-to-direct-agents) + Addy Osmani — [agent naming drift](https://medium.com/@addyosmani/my-llm-coding-workflow-going-into-2026-52fe1681325e)
+- **Linters as the executable spec inside the agent's loop; terminology-drift failure mode** → "Mechanical Enforcement"
+
+### Evan Czaplicki — ["Compiler Errors for Humans"](https://elm-lang.org/news/compiler-errors-for-humans)
+- **Errors as the documentation people actually read** → three-part teaching messages
+
+### Craig Spence — [Betterer](https://github.com/phenomnomnominal/betterer), Sairyss — [domain-driven-hexagon rules](https://github.com/sairyss/domain-driven-hexagon), typescript-eslint — [naming-convention](https://typescript-eslint.io/rules/naming-convention/), eslint-plugin-vitest — [valid-title](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/valid-title.md)
+
 ## Specification
 - Jason Gorman (Codemanship) — specification as conversation; specs as educated guesses tested by reality.
 - Gojko Adzic, *Specification by Example* (Manning, 2011) — key examples; the counter-example challenge.

--- a/claude/.claude/skills/specification/SKILL.md
+++ b/claude/.claude/skills/specification/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: specification
+description: Turn fuzzy intent into shared understanding and acceptance criteria — specification as a conversation, run one question at a time, before any story is split or planned. Use when an idea, feature request, or problem statement has no agreed rules or examples yet ("let's spec this out", "what should this actually do?", "we need acceptance criteria"). Produces an example map and acceptance criteria written back into the team's own story artifact, plus candidate glossary terms and parked questions. The agent-facilitated round is a first draft for a real conversation between humans — recommended, not optional. For decision trees with no artifact, see grill-me; for tightening an existing artifact, see find-gaps; for slicing agreed work, see story-splitting.
+---
+
+# Specification: the Conversation Is the Product
+
+A specification is not a document. It is a conversation between stakeholders in which shared understanding gets built — and the written result is, at best, an educated guess about what is really required, refined until reality gets the deciding vote (Gorman). The value is in the *planning*, not the plan: asking an agent to "write the spec" while skipping the conversation misses the entire point. This skill exists to *force* the conversation — with you first, then between the humans who own the answers.
+
+**Where this sits**: before `story-splitting`, before `planning`, before any acceptance test exists. Its output feeds all three.
+
+| Resource | Load when... |
+|----------|-------------|
+| `spec-review-template.html` | Presenting a finished map for human review — the three-amigos handoff page |
+| `references.md` | Checking sources for the practices taught here |
+
+---
+
+## The Contract
+
+1. **Find the story's home first.** Ask where this story lives — an issue, a file under `docs/stories/`, a ticket, anywhere the team already keeps it. Everything this skill produces is written back into THAT artifact. If it has no home yet, ask where it should live; never invent a parallel convention silently.
+2. **One question at a time, always with a recommendation.** Never a questionnaire. Each question names its stakes, offers a recommended answer with reasoning, and accepts "park it" — parked questions get an owner and a date, never silence.
+3. **Every assumption becomes a question.** The moment you notice yourself deciding something the human never said, stop and ask it. An answer that changes nothing in the map was not a real question.
+4. **The map is data, not prose.** Build it as you go and keep it visible:
+
+```
+story:     <one line, in the words the human used>
+rules:     # business policies / acceptance criteria
+  - rule: <policy in domain language>
+    examples:
+      - <concrete: real values, real outcome — never a restatement of the rule>
+    questions: # open assumptions attached to THIS rule (optional)
+questions: # cross-cutting open assumptions, each with an owner once parked
+acceptance criteria: # distilled from rules once examples stabilise
+candidate terms:     # vocabulary the conversation coined or contested
+```
+
+5. **Challenge the map before trusting it.** For each rule: the counter-example question ("what would have to be true for this example to come out differently?"), zero–one–many, boundaries, and what-happens-when-it-fails. A rule with one example is a guess; a rule whose examples all agree is a hypothesis.
+6. **Read the map's shape as a diagnostic.** Question-dominated → not ready to build; keep talking, or park with owners and stop. Rule-dominated (more than ~6 rules) → too big; hand the map to `story-splitting`. Balanced, with concrete examples per rule → ready.
+
+## The Recommended Path: Draft, Then Humans
+
+The agent-facilitated conversation above produces a **first draft** of shared understanding — between the human at the keyboard and an agent. That is not yet a specification, because the people whose understanding must be shared were not in the room.
+
+**Recommended flow, multi-round:**
+
+1. **Round 1 (agent-facilitated)**: run the contract above with whoever brought the idea. Write the map back to the story artifact. Generate the review page (below) from it.
+2. **Round 2 (humans, three-amigos style)**: the review page goes to the real conversation — business, development, testing perspectives together (Dinwiddie's three amigos). They talk; they annotate the page (every card takes comments); disagreements become new questions, not silent edits.
+3. **Round 3+ (reconcile)**: their feedback returns to the agent round as answers and new red cards. Update the map and the artifact; regenerate the page. Repeat until a round produces no new rules, no changed examples, and no new questions.
+4. **Then split**: the stabilised map goes to `story-splitting`; each child story carries its rules and examples onward — per-rule questions flatten into the single questions list that downstream mapping expects — and where an acceptance-test outer loop is installed, those examples become the seed of its per-slice mapping.
+
+Reality still gets the final vote: acceptance criteria written here are hypotheses until the shipped slice confirms them. When reality disagrees, the conversation reopens — that is a feature of the method, not a failure of the spec.
+
+## The Review Page
+
+For round 2, generate a single self-contained page from `resources/spec-review-template.html`: fill its JSON data slot (replace ALL occurrences of the double-underscore REVIEW_DATA token, escaping every `<` in string values as backslash-u003c), write to a temp directory, open locally, never commit the generated page. Structure the data as sections sharing one card engine: a **Rules** section (one card per rule — the rule as the card name, its concrete examples as the plain text, its attached questions in the highlight line, the verbatim map entry collapsible beneath), a **Parked questions** section (question as name, owner + context as plain text), and a **Candidate vocabulary** section (term as name, one-line gloss as plain text). Every card takes comments; the copy-feedback control assembles all annotations into one markdown block that returns to the next round. This page is a conversation artifact, not an approval record — regenerate it freely every round.
+
+## Vocabulary Capture
+
+Specification conversations coin vocabulary constantly — that is half their value. Every term the conversation invents, contests, or uses in two different senses goes into `candidate terms` with a one-line gloss. Where the `ubiquitous-language` skill is installed, candidates enter its five-step language protocol individually (extraction gathers candidates; only the protocol admits them); where it is not, the candidate list still travels with the story so the naming conversation happens somewhere.
+
+## Boundaries
+
+| Situation | Skill |
+|-----------|-------|
+| A fuzzy decision tree, no artifact yet, resolving choices | `grill-me` |
+| An existing story/plan/spec that needs holes poked | `find-gaps` |
+| The agreed map is too big; slicing into child stories | `story-splitting` |
+| Turning a child story into PR-sized plans | `planning` |
+| Per-slice executable specification (where installed) | `acceptance-testing` |
+| Naming the vocabulary the conversation surfaced (where installed) | `ubiquitous-language` |
+
+## Verification Checklist
+
+- [ ] The story artifact's home was asked, not assumed; all output written back into it
+- [ ] Questions went one at a time, each with a recommended answer
+- [ ] Every rule has at least one concrete example (real values, real outcome)
+- [ ] Each rule survived the counter-example challenge
+- [ ] Parked questions have owners
+- [ ] Candidate terms captured (and routed to the language protocol where installed)
+- [ ] The review page went to a real human conversation — the agent round was the draft, not the spec
+- [ ] Feedback returned as answers/questions, never as silent edits
+- [ ] Map shape checked: not question-dominated, not rule-dominated, examples concrete

--- a/claude/.claude/skills/specification/resources/references.md
+++ b/claude/.claude/skills/specification/resources/references.md
@@ -1,0 +1,8 @@
+# References
+
+- Jason Gorman (Codemanship) — public writing on software specification, 2026: the two damaging misunderstandings — specification is first and foremost a conversation between stakeholders that builds shared understanding, and specifications are at best educated guesses about what is required; "the map is not the terrain", so guesses are tested against reality before further guesses are stacked on them. The skill's core stance ("the conversation is the product; reality gets the deciding vote") distills this.
+- Gojko Adzic, *Specification by Example* (Manning, 2011): key examples as the shared specification; the counter-example challenge; illustrating requirements with concrete examples rather than restating rules.
+- Matt Wynne, "Introducing Example Mapping" (cucumber.io, 2015): the card grammar — story, rules, examples, questions — and reading the map's shape (question-dominated = not ready; rule-dominated = too big) as a readiness diagnostic.
+- George Dinwiddie, "The Three Amigos" (business, development, testing perspectives in one conversation): the round-2 handoff's structure; agile folklore consolidated in his writing on getting the three perspectives together before development.
+- David Farley & Jez Humble, *Continuous Delivery* / Dave Farley's acceptance-testing writing: executable specifications as the downstream consumer of these conversations — the reason acceptance criteria here are written as concrete examples.
+- This collection's `acceptance-testing` skill (where installed): the per-slice authoring loop whose A2 Example Mapping stage consumes the stabilised map produced here.

--- a/claude/.claude/skills/specification/resources/spec-review-template.html
+++ b/claude/.claude/skills/specification/resources/spec-review-template.html
@@ -1,0 +1,199 @@
+<!doctype html>
+<!--
+  Specification review template (the three-amigos handoff page).
+
+  How to use (any agent, any provider):
+  1. Build the review data as JSON matching the shape below — sections share
+     one card engine: Rules (rule/examples/questions), Parked questions
+     (question/owner), Candidate vocabulary (term/gloss).
+  2. Replace the REVIEW_DATA placeholder token (the double-underscore-wrapped
+     one inside the review-data script tag at the bottom — replace ALL
+     occurrences) with that JSON, escaping every "<" in string values as
+     backslash-u003c so the JSON can never terminate the script tag.
+  3. Write the result to a session temp directory and open it in the
+     reviewers' local browser. Never commit the generated page.
+  4. This is a conversation artifact for the three-amigos round, not an
+     approval record: reviewers annotate any card, disagreements become new
+     questions, and the page is regenerated every round until the map is
+     stable.
+  5. Feedback: reviewers type into the card boxes and click "Copy feedback" —
+     route the pasted markdown back into the next specification round as
+     answers and new questions, never as silent edits.
+
+  Data shape:
+  {
+    "title": "Specification — <story>",
+    "context": {
+      "feature": "the story, in the words its owner used",
+      "background": "where this idea came from and what exists today",
+      "goodLooksLike": "what shared understanding would unlock — the outcome once these rules are agreed"
+    },
+    "banner": {
+      "headline": "Round <N> of this specification — what changed and what needs eyes",
+      "facts": ["how many rules/examples/questions the map holds …", "what feedback does: returns to the next round as answers and new questions …"]
+    },
+    "sections": [{
+      "heading": "<section heading: Rules / Parked questions / Candidate vocabulary>",
+      "intro": "plain-language description of the behaviour under specification",
+      "path": "<optional: the story artifact this map lives in>",
+      "digest": "<optional: content digest, when a round wants byte-accountability>",
+      "specs": [{
+        "name": "<rule — a policy in domain language>",
+        "plain": "the rule's concrete examples, one per line: real values, real outcomes",
+        "red": "open questions attached to this card (empty string when none)",
+        "code": "<the rule's map entry verbatim — rule, examples, questions>"
+      }]
+    }],
+    "footer": "where the working artifact lives and what happens after this round stabilises"
+  }
+-->
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Specification review</title>
+    <style>
+      :root { color-scheme: light dark; }
+      body { font: 15px/1.55 -apple-system, sans-serif; max-width: 60rem; margin: 2rem auto 7rem; padding: 0 1.25rem; }
+      h1 { font-size: 1.5rem; }
+      h2 { font-size: 1.15rem; margin-top: 2.5rem; }
+      .banner { border: 1px solid color-mix(in srgb, currentColor 25%, transparent); border-left: 6px solid #c62828; border-radius: 8px; padding: 0.9rem 1.1rem; }
+      .banner strong { color: #c62828; }
+      .context { border: 1px solid color-mix(in srgb, currentColor 20%, transparent); border-left: 6px solid #1565c0; border-radius: 8px; padding: 0.4rem 1.1rem; margin: 1rem 0; }
+      .context strong { color: #1565c0; }
+      .intro { opacity: 0.85; }
+      .meta { font-size: 0.8rem; opacity: 0.6; word-break: break-all; }
+      .spec { border: 1px solid color-mix(in srgb, currentColor 18%, transparent); border-radius: 8px; margin: 0.7rem 0; padding: 0.15rem 0; }
+      .spec-name { padding: 0.55rem 0.9rem 0; font-weight: 650; }
+      .num { display: inline-block; min-width: 1.7rem; opacity: 0.5; font-variant-numeric: tabular-nums; }
+      .plain { padding: 0.35rem 0.9rem 0.2rem 2.6rem; }
+      .red { padding: 0 0.9rem 0.4rem 2.6rem; font-size: 0.78rem; color: #c62828; }
+      .code { margin: 0 0.9rem 0.6rem 2.6rem; border: 1px solid color-mix(in srgb, currentColor 14%, transparent); border-radius: 6px; }
+      .code summary { cursor: pointer; padding: 0.3rem 0.6rem; font-size: 0.78rem; opacity: 0.75; }
+      pre { margin: 0; padding: 0.7rem 0.9rem; overflow-x: auto; font-size: 0.82rem; line-height: 1.5; }
+      code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+      .note { display: block; width: calc(100% - 1.8rem); box-sizing: border-box; margin: 0 0.9rem 0.6rem; border: 1px dashed color-mix(in srgb, currentColor 25%, transparent); border-radius: 6px; background: color-mix(in srgb, currentColor 4%, transparent); padding: 0.5rem 0.7rem; font: 0.82rem/1.5 ui-monospace, Menlo, monospace; min-height: 2.3rem; resize: vertical; }
+      .note:focus { outline: 2px solid #1565c0; min-height: 4.5rem; }
+      .footer { margin-top: 3rem; font-size: 0.85rem; border-top: 1px solid color-mix(in srgb, currentColor 15%, transparent); padding-top: 1rem; opacity: 0.8; }
+      #bar { position: fixed; bottom: 0; left: 0; right: 0; display: flex; gap: 0.8rem; align-items: center; justify-content: center; padding: 0.7rem; background: Canvas; border-top: 1px solid color-mix(in srgb, currentColor 20%, transparent); }
+      #bar button { font: 600 0.9rem/1 -apple-system, sans-serif; padding: 0.55rem 1.1rem; border-radius: 6px; border: none; background: #1565c0; color: white; cursor: pointer; }
+      #status { font-size: 0.85rem; opacity: 0.75; min-width: 14rem; }
+    </style>
+  </head>
+  <body>
+    <main id="app"></main>
+    <div id="bar">
+      <span id="status">Type suggestions in any box, then</span>
+      <button id="copy">Copy feedback</button>
+    </div>
+    <textarea id="export" hidden></textarea>
+    <script id="review-data" type="application/json">
+      __REVIEW_DATA__
+    </script>
+    <script>
+      const data = JSON.parse(document.getElementById("review-data").textContent);
+      document.title = data.title;
+      const el = (tag, cls, text) => {
+        const node = document.createElement(tag);
+        if (cls) node.className = cls;
+        if (text !== undefined) node.textContent = text;
+        return node;
+      };
+      const app = document.getElementById("app");
+      app.append(el("h1", "", data.title));
+      if (data.context) {
+        const ctx = el("section", "context");
+        const rows = [
+          ["The feature", data.context.feature],
+          ["Where this fits", data.context.background],
+          ["What good looks like", data.context.goodLooksLike],
+        ];
+        for (const [label, text] of rows) {
+          if (!text) continue;
+          const p = el("p");
+          p.append(el("strong", "", label + ". "), text);
+          ctx.append(p);
+        }
+        app.append(ctx);
+      }
+      const banner = el("p", "banner");
+      banner.append(el("strong", "", data.banner.headline), " ");
+      banner.append(data.banner.facts.join(" "));
+      app.append(banner);
+
+      const noteBoxes = [];
+      const addNote = (parent, label) => {
+        const box = el("textarea", "note");
+        box.placeholder = "Suggest an improvement here (leave empty if it's fine)…";
+        box.dataset.spec = label;
+        parent.append(box);
+        noteBoxes.push(box);
+      };
+
+      for (const section of data.sections) {
+        app.append(el("h2", "", section.heading));
+        app.append(el("p", "intro", section.intro));
+        if (section.path !== undefined || section.digest !== undefined) {
+          const meta = el("p", "meta");
+          if (section.path !== undefined) meta.append(section.path);
+          if (section.path !== undefined && section.digest !== undefined)
+            meta.append(document.createElement("br"));
+          if (section.digest !== undefined) meta.append(section.digest);
+          app.append(meta);
+        }
+        section.specs.forEach((spec, index) => {
+          const card = el("div", "spec");
+          const name = el("div", "spec-name");
+          name.append(el("span", "num", String(index + 1)), spec.name);
+          card.append(name);
+          card.append(el("p", "plain", spec.plain));
+          card.append(el("p", "red", spec.red));
+          const codeBox = el("details", "code");
+          codeBox.append(el("summary", "", "the map entry, verbatim"));
+          const pre = el("pre");
+          pre.append(el("code", "", spec.code));
+          codeBox.append(pre);
+          card.append(codeBox);
+          addNote(card, section.heading + " #" + (index + 1) + " — " + spec.name);
+          app.append(card);
+        });
+      }
+      app.append(el("p", "footer", data.footer));
+      const overall = el("div", "spec");
+      overall.append(el("div", "spec-name", "Overall / batch-wide"));
+      addNote(overall, "general");
+      app.append(overall);
+
+      for (const box of noteBoxes) {
+        const key = data.title + "::" + box.dataset.spec;
+        try { box.value = localStorage.getItem(key) ?? ""; } catch {}
+        box.addEventListener("input", () => {
+          try { localStorage.setItem(key, box.value); } catch {}
+        });
+      }
+      const build = () => {
+        const notes = noteBoxes
+          .filter((box) => box.value.trim() !== "")
+          .map((box) => "### " + box.dataset.spec + "\n" + box.value.trim());
+        return notes.length === 0
+          ? "## " + data.title + " — feedback\n(no comments — looks good)"
+          : "## " + data.title + " — feedback\n\n" + notes.join("\n\n");
+      };
+      document.getElementById("copy").addEventListener("click", async () => {
+        const markdown = build();
+        const status = document.getElementById("status");
+        try {
+          await navigator.clipboard.writeText(markdown);
+          status.textContent = "Copied — paste it into the agent session.";
+        } catch {
+          const fallback = document.getElementById("export");
+          fallback.hidden = false;
+          fallback.value = markdown;
+          fallback.select();
+          document.execCommand("copy");
+          status.textContent = "Copied (fallback) — paste it into the agent session.";
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/claude/.claude/skills/ubiquitous-language/SKILL.md
+++ b/claude/.claude/skills/ubiquitous-language/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: ubiquitous-language
+description: "One ubiquitous language per bounded context — mechanically enforced, evolving only by decision. Per-context Contextive-format glossaries reconciled against code by lint; the five-step language protocol (detect, propose, decide, record, rename) for every new or changed domain term; glossary-driven identifier and test-title checking. Use when naming domain concepts, when a term is missing from or fights the glossary, when spotting synonyms or near-duplicates, when bootstrapping a glossary, or when renaming across a bounded context. For DDD building blocks see domain-driven-design; for acceptance-DSL vocabulary see acceptance-testing."
+---
+
+# Ubiquitous Language: Evolution by Decision, Never Drift
+
+A change in the language **is** a change to the model (Evans). One ubiquitous language per bounded context — apply a single language to a whole enterprise and you will fail (Vernon). This skill makes the language a first-class, mechanically-enforced artifact that is *expected* to evolve — but only ever through an explicit, recorded decision.
+
+The documented agent failure mode this kills: terminology drift — `processUserData` vs `processUserInfo` near-duplicates, "booking" quietly becoming "reservation" mid-feature. Prompt-level glossaries steer; deterministic gates enforce.
+
+| Resource | Load when... |
+|----------|-------------|
+| `resources/language-protocol.md` | A term is missing, awkward, or duplicated — running the five steps, writing Y-statement micro-ADRs |
+| `resources/glossary-format.md` | Creating or editing a glossary — Contextive YAML format, context scoping, aliases, bootstrap paths |
+
+---
+
+## Where the Language Lives (priority order)
+
+Team speech and **the model in the code** are the only guaranteed-current denotation of the language (Vernon). So:
+
+1. **Domain code** — identifiers and branded types ARE the language. `CustomerId`, `Receipt`, `placeOrder`. Branded types are the *positive* enforcement: the only way to obtain a `CustomerId` is the named parse, so primitives can't smuggle anonymous concepts through the domain.
+2. **The acceptance harness** — DSL verbs and test titles are the *executable* ubiquitous language. Write for the least technical person who understands the problem domain (Farley); test names as domain sentences is the founding move of BDD (North).
+3. **The glossary** — the *index*, not the source of truth. Per bounded context, in the repo, riding PR review: `<context>.glossary.yml` in Contextive format (LSP-based hover definitions in every major editor; folder scoping maps onto bounded contexts). A glossary that isn't reconciled against code rots — this one is lint-checked against the code, which is precisely what makes it living.
+
+## The Language Protocol (the centrepiece)
+
+Silent evolution is forbidden. Every new, changed, or suspect domain term runs five steps — full guidance in `resources/language-protocol.md`:
+
+1. **DETECT** — you need a term the glossary lacks; you spot a synonym or near-duplicate (one word per concept; two phrases must mean two concepts); a term feels awkward in conversation; or the identifier lint fails on an unknown domain word.
+2. **PROPOSE — never adopt.** STOP and present to the human: the term, a proposed definition, the bounded context, an example sentence, and the alternatives considered. Use the harness's question mechanism with a recommendation attached. An agent never coins a domain term silently.
+3. **DECIDE** — the human approves, renames, or rejects. Cheap because it's one term at a time with a recommendation.
+4. **RECORD** — glossary entry added or updated *in the same PR*; replaced terms become deprecated `aliases` (so lints can name the replacement). Renames that change the **model**, not just a label, get a Y-statement micro-ADR; routine additions need only the glossary diff.
+5. **RENAME** — in that order: decision first, then refactor code, tests, and glossary together in one atomic PR. **Boundary rule**: rename freely *inside* the bounded context; the published language at context boundaries — APIs, events, schemas — is versioned deliberately, never casually renamed.
+
+## Mechanical Enforcement
+
+Where a mechanical enforcement layer is installed (lint rules generated from the glossary), it runs inside the agent's loop, scoped to domain paths — and enforces:
+
+- **Banned vocabulary** — weasel suffixes in domain code (`Info`, `Base`, `Item`, `Manager`, `Helper`, `Util`, `Data`, `Processor`, `Impl`, …): these names mean the concept hasn't been found yet.
+- **Glossary-driven identifier check** (the flagship, novel-in-TypeScript rule) — split identifiers into words; validate domain words against the context's glossary using **token classes**: glossary terms / deprecated aliases (flagged with their replacement) / path-scoped technical stopwords / exempt framework identifiers.
+- **Test-title check** — titles validated against the glossary; deprecated aliases rejected *naming the canonical replacement*.
+- **DSL vocabulary check** — a new acceptance-DSL verb either exists in the glossary or triggers the protocol.
+- **Structural rules** — pure-domain-core dependency rules (no domain→app, no domain→infra except ports, no framework imports in domain).
+
+**Every rule teaches**: three-part messages — what fired, why the rule exists, what to do instead, with a skill pointer. A gate with no exit invites bypass, so the documented-exception process (justified in the PR, recorded) stays open.
+
+**Enforcement status**: until a generated lint layer or equivalent gate is installed in the project, everything here is convention — say so; never imply protection that isn't there. The protocol and glossary stand on their own; enforcement is an amplifier, not a prerequisite.
+
+## The Adoption Spectrum
+
+- **Greenfield** — full rule set from commit one; the walking skeleton is the first passenger.
+- **Brownfield — the protected-core ratchet.** You cannot lint your way to hexagonal in a big ball of mud: a rule that fires 4,000 times on day one is deleted on day two. Instead declare a nearly-empty `domain/` core and enforce *its* purity from day one; legacy stays legally messy outside but reaches in only through ports; every slice touching legacy business logic moves that logic into the core (Strangler Fig). Pre-existing violations freeze in a baseline whose counter may only go down. The glossary rolls out the same way: warn-first, diff-scoped, until it matures.
+- **Spikes** — the declared spike marker exempts language and architecture rules, except quarantine, which never turns off. Vocabulary discovered in a spike enters the glossary through the protocol at promotion time, not during the spike.
+
+## Boundaries
+
+| Situation | Skill |
+|-----------|-------|
+| Value objects, entities, aggregates, bounded contexts | `domain-driven-design` |
+| Ports/adapters structure the arch rules enforce | `hexagonal-architecture` |
+| DSL and test-title vocabulary in the outer loop | `acceptance-testing` |
+| Recording a model-changing rename | `adr` agent (Y-statement template) |
+| Naming questions during authoring-loop interrogation | `grill-me` (A3) |
+
+## Verification Checklist
+
+- [ ] One glossary per bounded context, Contextive format, in the repo
+- [ ] No domain term coined without the five-step protocol — proposals presented, never adopted silently
+- [ ] Glossary diff rides the same PR as the code that introduces the vocabulary
+- [ ] Replaced terms recorded as deprecated aliases with replacements
+- [ ] Model-changing renames carry a Y-statement micro-ADR
+- [ ] Published language at context boundaries versioned, never casually renamed
+- [ ] Lint rules carry three-part teaching messages
+- [ ] Brownfield: baseline counter only ever goes down; new code fully ruled
+- [ ] Spike code exempt by marker only; quarantine always on

--- a/claude/.claude/skills/ubiquitous-language/resources/glossary-format.md
+++ b/claude/.claude/skills/ubiquitous-language/resources/glossary-format.md
@@ -1,0 +1,60 @@
+# Glossary Format and Bootstrap
+
+## Format: Contextive YAML, one glossary per bounded context
+
+`<context>.glossary.yml`, living in the repo (typically beside the context's code or in a `glossaries/` folder — Contextive's folder-based scoping maps contexts in a monorepo). Contextive is the established format with editor support: LSP-based hover definitions and autocomplete for glossary terms across file types in VS Code, IntelliJ, and Neovim — the vocabulary teaches itself ambiently while people type.
+
+```yaml
+# ordering.glossary.yml
+contexts:
+  - name: Ordering
+    domainVisionStatement: >
+      Customers assemble orders and pay; the context owns the order
+      lifecycle from basket to confirmed receipt.
+    paths:
+      - src/ordering
+    terms:
+      - name: Order
+        definition: A customer's request to purchase, from basket to fulfilment.
+        examples:
+          - A customer paying by card receives a confirmed order and a receipt.
+      - name: Receipt
+        definition: The confirmed proof of payment for an order.
+      - name: abandonCheckout
+        definition: >
+          Customer leaves the checkout flow before payment, releasing any
+          held inventory.
+        examples:
+          - Held seats are released when the customer abandons checkout.
+```
+
+Deprecation example — the replaced word becomes an alias **on the canonical term** (Contextive's alias semantics), and the lint convention layers deprecation on top:
+
+```yaml
+      - name: Order
+        definition: A customer's request to purchase, from basket to fulfilment.
+        aliases:
+          - Booking # DEPRECATED 2026-07-04 — lint rejects it naming Order; see ADR
+```
+
+Note: Contextive treats aliases as neutral alternatives (hover on `Booking` shows Order's definition — helpful during migration). Treating an alias as *deprecated* — rejected by the lint with the replacement named — is this framework's convention layered on the same field.
+
+Conventions:
+
+- **Aliases carry deprecations**: when a term is replaced, the old word becomes an `aliases` entry on the new term — this is what lets the lints reject the old word *and name its replacement* in the error message.
+- **Examples matter**: one domain sentence per term where possible — they feed test titles and hover docs.
+- **The glossary is the index, not the truth**: the code and the team's speech are the current language; the glossary is reconciled against them by lint on every build, which is what keeps it alive rather than rotting.
+
+## Bootstrap paths
+
+**Greenfield** — the glossary is born from the authoring loop: the Example Mapping stage (acceptance-testing A2) surfaces the story's nouns and verbs; each one enters through the protocol as it is first used. Small, accurate, and growing — never a big up-front vocabulary exercise.
+
+**From a working conversation** — mine a design session, grill-me transcript, or story-splitting output for candidate terms: recurring nouns and verbs, anything two people used differently, anything that needed explaining. Each candidate goes through PROPOSE individually — extraction gathers candidates; only the protocol admits them.
+
+**Brownfield** — harvest candidates from the code that already speaks the language: exported domain identifiers, event names, database entities. Expect collisions and near-duplicates — surfacing them is the value (each collision is a DETECT trigger). Admit terms as slices touch them, matching the protected-core ratchet: the glossary grows with the strangled core, not ahead of it.
+
+## What does NOT belong in a glossary
+
+- Technical vocabulary (`map`, `parse`, `index`, `id`) — that's the lint layer's stopword list, not the domain language.
+- Framework and library names.
+- Terms from *other* bounded contexts — if Ordering keeps talking about Shipping's concepts, that's a context-mapping conversation (domain-driven-design skill), not a glossary entry.

--- a/claude/.claude/skills/ubiquitous-language/resources/language-protocol.md
+++ b/claude/.claude/skills/ubiquitous-language/resources/language-protocol.md
@@ -1,0 +1,65 @@
+# The Language Protocol — detect → propose → decide → record → rename
+
+The language is *expected* to evolve: persistent use forces its weaknesses into the open, and those changes are changes to the domain model (Evans). What is forbidden is **silent** evolution. Five steps, every time.
+
+## 1 — DETECT
+
+Triggers, any one of which starts the protocol:
+
+- You need a term that is not in the context's glossary (writing a spec, a DSL verb, a domain identifier).
+- You spot a **synonym or near-duplicate** — two names for one concept, or one name doing two jobs. The rule: one word per concept; two phrases must mean two concepts.
+- A term feels **awkward in conversation** — domain experts objecting to a term is signal, not noise.
+- The identifier lint fails on an unknown domain word.
+
+## 2 — PROPOSE — never adopt
+
+STOP. Do not use the term in code, tests, or the DSL yet. Present to the human, with a recommendation:
+
+- **Term** — the word or phrase itself
+- **Proposed definition** — one or two sentences, in domain language
+- **Bounded context** — which glossary it belongs to
+- **Example sentence** — the term used as a domain expert would use it
+- **Alternatives considered** — and why the proposal beats them
+
+Use the harness's question mechanism (one term at a time, recommendation attached — the same semantics as every other human gate in this framework). An agent that coins a domain term silently has already violated the protocol, whatever the lint says.
+
+## 3 — DECIDE
+
+The human approves, renames (picks a different word for the concept), or rejects (the concept doesn't belong in this context). Cheap by design: one term, one recommendation, one decision.
+
+## 4 — RECORD
+
+- Glossary entry added or updated **in the same PR** as the code that introduces the vocabulary — the glossary is in-repo precisely so this is atomic.
+- A replaced term becomes a deprecated **alias** on the new entry, so the lints can reject it *and name its replacement*.
+- **Model-changing renames get a Y-statement micro-ADR.** Label-only changes don't. The test: did the *meaning* move, or just the spelling?
+
+Y-statement template:
+
+```
+In the context of <use case / bounded context>,
+facing <the concern that forced the decision>,
+we decided for <the new term / model shape>
+and against <the old term / alternatives>,
+to achieve <the quality or clarity gained>,
+accepting that <the cost — renames, migration, relearning>.
+```
+
+## 5 — RENAME
+
+In this order — decision first, then mechanics:
+
+1. Refactor code: classes, functions, variables, branded types.
+2. Refactor tests and the acceptance DSL.
+3. Glossary already updated (step 4) — all three land in one PR.
+
+**The boundary rule (internal vs published)**: inside the bounded context, rename freely and aggressively — cheap, atomic, safe. At the context's **published boundary** — APIs, event schemas, database contracts other contexts consume — the language is versioned deliberately: additive evolution, explicit deprecation, never a casual rename. If the rename must cross the boundary, that is a contract change, not a vocabulary change; route it through the api-design skill's compatibility rules.
+
+## Worked example
+
+During a payments slice, the spec wants a verb for a customer abandoning a checkout. The glossary has nothing; `cancelOrder` already means merchant-initiated cancellation.
+
+- DETECT: new concept, and a near-collision with `cancel`.
+- PROPOSE: term `abandonCheckout`; definition "customer leaves the checkout flow before payment, releasing any held inventory"; context `ordering`; example "Held seats are released when the customer abandons checkout"; alternatives: `cancelCheckout` (collides with merchant cancel), `timeoutCheckout` (only one abandonment path).
+- DECIDE: human approves.
+- RECORD: `ordering.glossary.yml` gains `abandonCheckout`; no ADR (new concept, no model change).
+- RENAME: nothing to rename — the term enters spec, DSL, and domain code new-born, all in the same PR.


### PR DESCRIPTION
Two skills that treat the domain's language as the backbone of the work.

## ubiquitous-language

- **The five-step language protocol** — SURFACE → CHECK → DECIDE → RECORD → RENAME: new vocabulary is admitted by explicit decision, never by silent coinage; renames are decision-first and atomic; published language at context boundaries is versioned, never casually renamed
- **Glossary format** — Contextive-compatible YAML, per-context path scoping, aliases, and a deprecation convention where every deprecated term names its replacement
- **Brownfield bootstrap** — harvest candidates from the codebase, admit by decision (extraction gathers candidates; only the protocol admits them)
- **Mechanical enforcement taxonomy** — banned weasel suffixes, glossary-driven identifier validation via token classes, test-title and acceptance-DSL vocabulary checks, structural purity rules — for projects that install an enforcement layer, with the honest note that without one everything here is convention
- Resources: `language-protocol.md`, `glossary-format.md`

## specification

- **Specification is a conversation, not a document** — the skill forces it: one question at a time (always with a recommended answer), an example map built as data (story / rules / examples / questions), every silent assumption converted into an explicit question, counter-example challenges, and map-shape diagnostics (question-dominated = not ready; rule-dominated = split it)
- **Write-back discipline** — everything lands in the team's own story artifact, wherever it lives; no parallel convention invented
- **The agent round is a first draft** — the recommended path hands the generated review page (self-contained HTML template included, per-card comment boxes, copy-feedback) to a real three-amigos conversation; feedback returns as answers and new questions, never silent edits, multi-round until stable
- Resources: `spec-review-template.html`, `references.md`

Both are loader-wired in CLAUDE.md and sourced in REFERENCES.md (Evans, Adzic, Wynne, Dinwiddie, Gorman, North, Farley).

🤖 Generated with [Claude Code](https://claude.com/claude-code)