### PR TITLE
feat(technical-writing): developer-prose skill — researched, cited, agent-aware

### DIFF
--- a/.changeset/technical-writing-skill.md
+++ b/.changeset/technical-writing-skill.md
@@ -1,0 +1,7 @@
+---
+"@paulhammond/dotfiles": minor
+---
+
+Add a `technical-writing` skill: developer-facing prose that can be skimmed first and trusted enough to finish.
+
+Adapted from Adam Bradley's Developer Writing Playbook (credited) and extended with deep-researched, fully-cited resources: one-mode-per-page as the leading rule (Diátaxis's four modes with the tutorial/how-to distinction most docs miss, plus the model's honest limits), the README cognitive funnel with the short-vs-long tension resolved and README-driven development's failure mode named, a docs-quality enforcement ladder (Vale prose lint, executable examples, link checking, reference generated from spec, friction logs, Google's timeless-docs rule, Every Page is Page One), and an honest 2026 guide to documentation for AI agents (the llms.txt adoption reality, markdown endpoints, RAG-chunkable structure as good-writing-restated). House principles throughout: claims need receipts, docs are verified behavior, idle states must speak, enumerable facts in tables with exact copy-pasteable strings.

--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -4,7 +4,7 @@
 >
 > **Architecture:**
 > - **CLAUDE.md** (this file): Core philosophy + quick reference (~160 lines, always loaded)
-> - **Skills**: Detailed patterns loaded on-demand (specification, ubiquitous-language, tdd, testing, mutation-testing, test-design-reviewer, typescript-strict, functional, refactoring, expectations, planning, story-splitting, front-end-testing, react-testing, ci-debugging, hexagonal-architecture, domain-driven-design, event-sourcing, twelve-factor, api-design, cli-design, folder-structure, finding-seams, characterisation-tests, production-parity-skill-builder, storyboard, teach-me, diagrams, find-skills, find-gaps, double-check)
+> - **Skills**: Detailed patterns loaded on-demand (specification, ubiquitous-language, tdd, testing, mutation-testing, test-design-reviewer, typescript-strict, functional, refactoring, expectations, planning, story-splitting, front-end-testing, react-testing, ci-debugging, hexagonal-architecture, domain-driven-design, event-sourcing, twelve-factor, api-design, cli-design, folder-structure, finding-seams, characterisation-tests, production-parity-skill-builder, storyboard, teach-me, diagrams, technical-writing, find-skills, find-gaps, double-check)
 > - **External skills**: Loaded on-demand from community repos (impeccable + 17 steering commands from [pbakaus/impeccable](https://github.com/pbakaus/impeccable), 6 web quality skills from [addyosmani/web-quality-skills](https://github.com/addyosmani/web-quality-skills), 3 Next.js skills from [vercel-labs/next-skills](https://skills.sh/vercel-labs/next-skills), grill-me from [mattpocock/skills](https://skills.sh/mattpocock/skills/grill-me), seo-audit from [coreyhaines31/marketingskills](https://skills.sh/coreyhaines31/marketingskills/seo-audit))
 > - **Agents**: Specialized subprocesses for verification and analysis
 >
@@ -113,6 +113,7 @@ For making untestable code testable, load the `finding-seams` skill.
 For documenting existing behavior before changes, load the `characterisation-tests` skill.
 For multi-surface design audits before code (embed every mock in a scope on one reviewable page with flow diagram + gap cards + per-mock audit checklists), load the `storyboard` skill.
 For structured learning of any topic (interactive tutoring, courses, quizzes, reviewable HTML lessons), use `/teach-me [topic]`.
+For developer-facing prose — READMEs, guides, tutorials, reference docs, proposals, release notes — load the `technical-writing` skill (reader-first structure, falsifiable claims, agent-readable reference shape).
 For discovering and installing agent skills from the open ecosystem (`npx skills`), load the `find-skills` skill.
 For adversarial review of plans, acceptance criteria, stories, or design mocks — one question at a time, turning each answer into a new AC / plan paragraph / mock-state spec written back to the source of truth — load the `find-gaps` skill.
 For relentless decision-tree interrogation before story splitting, planning, or implementation — one question at a time, with recommended answers and codebase exploration where useful — load the `grill-me` skill.

--- a/claude/.claude/skills/REFERENCES.md
+++ b/claude/.claude/skills/REFERENCES.md
@@ -474,3 +474,15 @@ Sources behind the `event-sourcing` skill. Several foundational names (Chassaing
 - Gojko Adzic, *Specification by Example* (Manning, 2011) — key examples; the counter-example challenge.
 - Matt Wynne, "Introducing Example Mapping" (cucumber.io, 2015) — the card grammar and map-shape diagnostics.
 - George Dinwiddie — the three amigos: business, development, testing in one conversation.
+
+## Technical Writing
+
+- Daniele Procida, Diátaxis (diataxis.fr) — the four-mode typology, compass, tutorial/how-to distinction, bottom-up adoption; Hillel Wayne's four-document-model critique as the honest limit.
+- Google developer documentation style guide + Microsoft Writing Style Guide — voice, front-loading, timeless docs; the Red Hat deltas-only pattern for adopting a guide.
+- noffle's Art of README (cognitive funnel), standard-readme, Preston-Werner's README-driven development.
+- Write the Docs docs-as-code; Vale prose lint; rustdoc doc-tests (executable examples); lychee; *Docs for Developers* (friction logs, errors-as-documentation); Mark Baker's *Every Page is Page One*.
+- Stripe's Markdoc post + DX teardowns (reference-generated-from-spec, runnable examples, errors first-class).
+- llms.txt (Howard) with measured adoption reality (Burridge, OtterlyAI); Kapa.ai RAG-chunkability; Netlify's Agent Experience.
+- John Carroll's minimalism (The Nurnberg Funnel; "Ten Misconceptions") — task-first, error recovery inline, every word earns its place.
+- Adam Bradley (mintuz), "Developer Writing Playbook" — the seed this skill adapted.
+- Full URLs: the skill's resources/references.md.

--- a/claude/.claude/skills/technical-writing/SKILL.md
+++ b/claude/.claude/skills/technical-writing/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: technical-writing
+description: "Writing developer-facing prose that can be skimmed first and trusted enough to finish — READMEs, guides, tutorials, reference docs, proposals, PR descriptions, release notes. Use when creating or editing any technical document, when a doc reads as a wall of text, when claims need receipts, or when docs must serve AI agents as well as humans. Covers reader-first structure, falsifiable claims, docs-as-behavior verification, and agent-readable reference shape. For diagram choice and syntax see diagrams; for API reference semantics see api-design; for CLI help text see cli-design."
+---
+
+# Technical Writing: Skimmed First, Trusted Enough to Finish
+
+Developers skim before they commit. A document earns the full read by
+answering three questions in its first screen: what is this, why should
+I care, and how do I start. Everything below serves that contract.
+
+| Resource | Load when... |
+|----------|-------------|
+| `resources/doc-types.md` | Choosing what KIND of page to write — the four Diátaxis modes, tutorial-vs-how-to, the types the model omits, minimalism scoped per type |
+| `resources/readme.md` | Writing or overhauling a README — the cognitive funnel, short-vs-long resolved, README-driven development |
+| `resources/docs-quality.md` | Making docs enforceable — prose lint, executable examples, link checking, friction logs, timeless-docs, every-page-is-page-one |
+| `resources/agent-docs.md` | Docs serving AI agents — the honest llms.txt verdict, markdown endpoints, RAG-chunkable pages |
+| `resources/formatting.md` | Structural rules — titles, headings, paragraphs, lists, intros/outros, tables of contents |
+| `resources/references.md` | Sources for every claim above |
+
+## One Mode Per Page
+
+The most violated rule in documentation: a page is a tutorial, a
+how-to, a reference, or an explanation — never a blend (Diátaxis; the
+full typology, the tutorial/how-to distinction most docs miss, and the
+model's honest limits live in `resources/doc-types.md`). Decide the
+mode before the first sentence; when a page fights you, it is usually
+two modes wearing one URL.
+
+## Principles
+
+- **Reader-first** — lead with the payoff; the reader's next action is
+  the organizing principle, not the system's internal structure. Name
+  things by what readers recognize, not how the code is built.
+- **Scannable** — clear headings that summarize their section's payoff,
+  short paragraphs, purposeful emphasis. A heading every 200–250 words.
+- **Plain and direct** — active voice, second person for instructions,
+  short sentences for complex ideas. Complete sentences beat fragments
+  and arrow chains: readable matters more than terse.
+- **Selective, not compressed** — the way to keep a doc short is to cut
+  what doesn't change the reader's next step, never to compress the
+  prose into jargon the reader must decode.
+
+## Claims Need Receipts
+
+Every claim in a technical document is checkable or it is marketing.
+
+- **No capability claim without evidence**: numbers a reader can
+  verify, a command they can run, a file they can open. "Fast" is
+  marketing; "the gates run in 14 seconds on this repo's CI" is a
+  claim with a receipt.
+- **Counts and versions rot**: any number quoted in prose (test
+  counts, coverage, versions) is a maintenance liability — either
+  generate it, date it, or bind it to the kept-current rule (updating
+  it is part of every change's definition of done).
+- **Honest limits are content, not confession**: a section naming what
+  the thing does NOT do yet is the most trust-building section in the
+  document. State limits plainly; never imply protection, coverage, or
+  capability that isn't there.
+- **Idle and empty states must speak**: "0 items processed" that reads
+  like success is a lie of layout. Distinguish "nothing to do" from
+  "did nothing" everywhere output appears in docs and examples.
+- **Timeless docs**: never pre-announce; no "coming soon",
+  "currently", or "new in…" — docs outlive releases and these rot
+  faster than any code example (Google's rule).
+
+## Docs Are Behavior — Verify Them
+
+A document that describes a system is a claim about that system, and
+claims get verified:
+
+- **Verify against the source, not memory**: every flag, exit code,
+  config key, and command in a doc is checked against the code before
+  it ships. If a claim can be executed, execute it.
+- **Machine-check what machines can check**: table-of-contents anchors
+  against the renderer's real slug rules, links against files, command
+  examples against the binary. Hand-verification is the fallback, not
+  the default.
+- **Update docs in the same change**: a behavior change that leaves
+  its documentation stale is incomplete work. The doc diff belongs in
+  the same commit as the behavior diff.
+
+## Writing for AI Agents Too
+
+Developer docs now have two audiences. Agent-readable means:
+
+- **Enumerable over prose-only**: anything an agent must choose from —
+  options, flags, exit codes, states — appears in a table row, not
+  only inside a paragraph.
+- **Preconditions and postconditions per operation**: what must be
+  true before, what changes after, what exit codes mean. A
+  state-machine table ("in state X, the one correct next action is Y")
+  outperforms narrative for both audiences.
+- **Exact strings**: agents (and humans under pressure) copy-paste.
+  Give the exact command, the exact config block, the exact error
+  message — never a paraphrase.
+
+## Document Shapes
+
+- **README / landing**: first screen answers what/why/how-to-start;
+  table of contents for anything over ~4 sections; quickstart as one
+  coherent journey in true order; honest limits before credits.
+- **Tutorial**: state the destination up front ("you will have X
+  working"); number steps; every step's output shown so readers know
+  they're on track; end with where to go next.
+- **Reference**: completeness over narrative; one entry per
+  flag/option/state; generated where possible; agent-readable tables.
+- **Proposal / design doc**: the decision requested up front, options
+  with honest trade-offs, a recommendation with reasoning, and what
+  evidence would change it.
+- **PR description / release notes**: what changed for the READER of
+  the change (behavior, migration), not a commit-log paraphrase.
+
+## Boundaries
+
+| Situation | Skill |
+|-----------|-------|
+| Choosing and authoring diagrams | `diagrams` |
+| REST/API reference semantics (errors, pagination, versioning) | `api-design` |
+| CLI help text, exit codes, output design | `cli-design` |
+| Documenting expectations, gotchas, decisions while fresh | `expectations` |
+| Domain vocabulary in prose | `ubiquitous-language` (where installed) |
+
+## Verification Checklist
+
+- [ ] First screen answers what / why / how-to-start
+- [ ] Headings summarize payoffs; one per 200–250 words; ToC where warranted (anchors machine-checked)
+- [ ] Every claim carries a receipt or a date; no marketing verbs without evidence
+- [ ] Every command/flag/code verified against the source; executable claims executed
+- [ ] Honest-limits section present and current
+- [ ] Enumerable facts appear in tables; exact strings given for anything copy-pasteable
+- [ ] Counts/versions bound to the kept-current rule or generated
+- [ ] Doc changes ride the same commit as the behavior they describe

--- a/claude/.claude/skills/technical-writing/resources/agent-docs.md
+++ b/claude/.claude/skills/technical-writing/resources/agent-docs.md
@@ -1,0 +1,42 @@
+# Documentation for AI Agents: What's Real (2026)
+
+The durable finding: good agent docs and good human docs CONVERGE.
+Structure, self-containment, text-over-pixels, and machine-readable
+specs — all pre-AI best practice — are what agents need. Advice that
+departs from plain good writing (keyword-stuffing for embeddings,
+agent-only content) has no evidence behind it.
+
+## llms.txt — the honest verdict
+
+The spec (Jeremy Howard, llmstxt.org): root-level markdown — H1 name,
+blockquote summary, H2 sections of [name](url) links, an "Optional"
+section skippable under context pressure. Measured adoption (Burridge
+crawl; OtterlyAI monitoring): ~5-10% of sites publish one; ~0.1% of
+AI-crawler requests fetch it; Google confirmed it won't support it
+(Illyes, 2025). BUT IDE agents, MCP servers, and in-product
+assistants DO fetch it. Ship it for developer-tool docs — cheap, real
+consumers; skip it as an SEO/GEO tactic (the hype the data refutes).
+
+## Serve clean markdown to agents
+
+Mintlify's traffic data: approaching half of docs traffic is agents;
+they arrive with a task, and their failures are invisible — no bug
+report, no bounce signal. Prescription: one knowledge source, two
+renderings — rich HTML for humans, clean markdown endpoints for
+agents; add agent-traffic analytics so the invisible failures show.
+
+## RAG-chunkable pages (Kapa.ai practice)
+
+Strict heading hierarchy; self-contained sections; code examples with
+imports included and one sentence of context above each;
+troubleshooting as literal Q&A pairs; every screenshot's information
+also stated in text; no load-bearing PDFs; acronyms defined in-page.
+(Every-Page-is-Page-One and accessibility rules, restated.)
+
+## Agent Experience (Netlify's AX framing)
+
+Agents are users who must discover what your service does, call it
+reliably, and recover when something goes wrong. Context files
+(agents.md-style) carry architecture, standards, and integration
+facts — never secrets. Error messages with identifiers and
+remediation serve the recovery leg (see docs-quality).

--- a/claude/.claude/skills/technical-writing/resources/agent-docs.md
+++ b/claude/.claude/skills/technical-writing/resources/agent-docs.md
@@ -17,6 +17,28 @@ AI-crawler requests fetch it; Google confirmed it won't support it
 assistants DO fetch it. Ship it for developer-tool docs — cheap, real
 consumers; skip it as an SEO/GEO tactic (the hype the data refutes).
 
+Refinements from field practice (verified 2026-07):
+
+- **Generate, never hand-author.** Staleness is the failure mode; every
+  major docs platform emits these at build time, and SSG plugins cover
+  the rest (Astro/Starlight: starlight-llms-txt emits llms.txt,
+  llms-full.txt, and llms-small.txt for tight context windows). A
+  build-time artifact has zero marginal maintenance cost.
+- **llms-full.txt is what agents actually consume** — the full-content
+  export is fetched at over twice the rate of the llms.txt index
+  (Mintlify monitoring, 2026). Publish both; the index alone serves
+  little.
+- **The Astro counter-example, read carefully.** Astro removed its
+  llms.txt (May 2026: low measured traffic, ~44s CI cost, MCP server
+  preferred). The critique that followed (Carey) is the durable
+  lesson: raw traffic is the wrong metric when nothing in-page points
+  agents at the file — low traffic is then the *expected* outcome — and
+  MCP serves configured power users while llms.txt serves plain-HTTP
+  discovery. They are complements, not substitutes; keep the cheap
+  primitive, link to it from the page (a `<link>` or visible pointer),
+  and measure agent sessions rather than page views before removing
+  anything.
+
 ## Serve clean markdown to agents
 
 Mintlify's traffic data: approaching half of docs traffic is agents;

--- a/claude/.claude/skills/technical-writing/resources/doc-types.md
+++ b/claude/.claude/skills/technical-writing/resources/doc-types.md
@@ -1,0 +1,66 @@
+# Document Types: One Mode Per Page
+
+The single most violated rule in real-world docs: mixing tutorial,
+how-to, reference, and explanation on one page. Nearly every "Getting
+Started" page is a tutorial/how-to/explanation smoothie.
+
+## The four modes (Diátaxis — Procida, diataxis.fr)
+
+Two axes: action vs cognition, and acquiring skill vs applying it.
+
+| | Serves acquisition (study) | Serves application (work) |
+|---|---|---|
+| **Action** | Tutorial — a lesson | How-to guide — directions |
+| **Cognition** | Explanation — understanding | Reference — information |
+
+When unsure which you're writing, the compass (diataxis.fr/compass):
+does this page inform action or cognition? does it serve study or work?
+
+## Tutorial ≠ how-to (the distinction most docs miss)
+
+- A **tutorial** is a lesson in a contrived, controlled setting: one
+  carefully managed path, no choices, explicit about basics —
+  "responsibility lies with the teacher" (diataxis.fr/tutorials-how-to).
+- A **how-to** serves the already-competent user at work: it forks and
+  branches ("if this, then that"), assumes familiarity, and the user
+  owns getting in and out of trouble.
+- Most pages labelled "tutorial" are how-tos, and fail beginners for
+  exactly that reason.
+
+## Adopt bottom-up, never as a restructure project
+
+Procida's own guidance (diataxis.fr/how-to-use-diataxis): do NOT create
+empty tutorial/how-to/reference/explanation shells. Pick one page,
+assess it against the mode it should be, make one improvement, publish.
+"Every step in the right direction is worth publishing immediately."
+
+## Types the four-mode model doesn't name
+
+Honest limits (Hillel Wayne, "My Problem With the Four-Document
+Model"): the model fits tools best and strains for languages/frameworks
+with dense conceptual models. Two real types it omits:
+
+- **Conceptual overview** — before the tutorial, for readers deciding
+  whether and how to learn.
+- **Snippets/examples** — demonstrating a way of thinking, not a
+  procedure.
+
+The Good Docs Project's Core Pack adds two more first-class types:
+**Troubleshooting** and **Release notes** (thegooddocsproject.dev).
+Use its templates rather than inventing structure per type.
+
+## Minimalism, scoped per type (Carroll)
+
+Carroll's minimalism (The Nurnberg Funnel; van der Meij & Carroll
+1995): start users on a real task immediately; minimize reading; put
+error recognition AND recovery inline in the instruction; make
+activities self-contained. The famous validation: 25 task cards
+replaced a 94-page manual and halved task time.
+
+Two guardrails:
+- Minimalism is NOT "less documentation" — Carroll wrote "Ten
+  Misconceptions about Minimalism" himself. It is documentation
+  designed around action; citing it to avoid writing docs misreads it.
+- "Let users fill gaps" fits HOW-TOS; tutorials must stay explicit
+  about basics (the Diátaxis tutorial rule). Scope minimalism per doc
+  type, never globally.

--- a/claude/.claude/skills/technical-writing/resources/docs-quality.md
+++ b/claude/.claude/skills/technical-writing/resources/docs-quality.md
@@ -1,0 +1,65 @@
+# Docs Quality Engineering: Docs Are Tested Behavior
+
+## Docs-as-code (Write the Docs)
+
+Docs live in version control, plain text, code-reviewed, CI-tested —
+same workflow as code, which is what lets you block feature merges
+that lack docs and gets developers drafting. Honest limit (from
+Stripe's Markdoc experience, stripe.dev/blog/markdoc): version control
+and CI are uncontested, but CODE-LIKE AUTHORING is where it fails
+non-engineer contributors — Stripe deliberately built Markdoc WITHOUT
+loops or variable assignment "to discourage writers from performing
+procedural content generation."
+
+## The enforcement ladder
+
+- **Prose lint (Vale, vale.sh)**: syntax-aware — rules in YAML,
+  heading-only contexts, skips code blocks; ready-made packages
+  implement the Google and Microsoft style guides in CI. This turns
+  style rules from aspiration into a merge gate. Limit: Vale enforces
+  mechanics, not whether the page answers the reader's question —
+  don't over-index on lint-green docs.
+- **Executable examples**: any example not compiled/run in CI is a
+  latent lie. rustdoc doc-tests are the canon ("makes sure that
+  examples within your documentation are up to date and working");
+  Python doctest, mdBook test, and extracting README snippets into CI
+  are the same move.
+- **Link checking (lychee)**: the hypertext layer's equivalent.
+- **Generated reference**: API reference generated from the spec
+  (OpenAPI) cannot drift; hand-written references quietly diverge
+  within months. Spec fields (operationId, description) are
+  user-facing copy — and now agent-facing.
+
+## Style rules that survive across guides
+
+- Second person, active voice, present tense; verbs first; cut "you
+  can" and "there is" (Microsoft's compression example: "If you're
+  ready to purchase Office 365 for your organization, contact your
+  Microsoft account representative" → "Ready to buy? Contact us").
+- Descriptive link text — never "click here"; link text must make
+  sense out of context (accessibility AND agents).
+- **Timeless docs (Google)**: never pre-announce; no "coming soon",
+  "currently", "new in..." — docs outlive releases, and these rot
+  faster than code examples.
+- Mechanically lintable consistency: sentence-case headings, Oxford
+  comma, no heading end-punctuation. Their value is that they END
+  ARGUMENTS — pick ONE style guide, defer to it wholesale, and write
+  down only your deltas (the Red Hat pattern: a supplementary guide
+  over IBM's, never a restatement).
+
+## Process (Docs for Developers — Bhatti et al.)
+
+- **Friction logs** before writing: do the task yourself as a new
+  user and record every stumble; that log is the doc's outline.
+- Draft → edit → publish alongside code releases; maintenance is part
+  of the release, not a backlog.
+- Errors are documentation: every error carries an identifier, cause,
+  and remediation. An API reference documenting only the happy path
+  documents half the API.
+
+## Every page is page one (Baker)
+
+Readers arrive at pages, not sites — search brought them then, RAG
+brings them now. Each page: self-contained, one limited purpose,
+establishes its own context, links richly. The 2013 argument that
+became the single best predictor of RAG-readiness.

--- a/claude/.claude/skills/technical-writing/resources/formatting.md
+++ b/claude/.claude/skills/technical-writing/resources/formatting.md
@@ -1,0 +1,54 @@
+# Formatting: Structural Rules
+
+Adapted from mintuz/skills "Developer Writing Playbook" (credited in
+REFERENCES), extended with house rules.
+
+## Titles and headings
+
+- Title case for the title; 5–8 words; the benefit visible ("X for
+  Faster Y"). Exactly one h1.
+- h2 for sections, h3 for subsections; avoid deeper nesting — if you
+  need h4, the section wants splitting.
+- Headings summarize the section's payoff, not its topic ("Gates run
+  in CI" beats "CI integration").
+
+## Table of contents
+
+- Add one when a doc exceeds ~4 sections; one level deep with at most
+  a few key sub-entries — a map, not an index.
+- Verify anchors against the target renderer's real slug algorithm
+  (GitHub: lowercase, strip punctuation, EACH space becomes a hyphen —
+  adjacent spaces produce doubled hyphens). Machine-check, don't
+  eyeball.
+
+## Paragraphs and lists
+
+- 3–5 sentences per paragraph; lead with the point.
+- Bullets for unordered ideas; numbers only when order carries
+  information — a numbered list claims sequence.
+- Consistent item phrasing and end punctuation; long inline
+  enumerations become lists or tables.
+- Reading width ~65 characters for running prose.
+
+## Emphasis
+
+- Bold for the load-bearing phrase a skimmer must not miss — sparingly:
+  when everything is bold, nothing is.
+- Italics for light emphasis only. Never emphasis as decoration.
+
+## Code and examples
+
+- Every code block runnable as shown (or explicitly marked as a
+  fragment); include expected output where the reader needs to confirm
+  they're on track.
+- Exact strings for commands, paths, config — copy-paste is the
+  primary read mode for both humans and agents.
+- Wide content (tables, code, diagrams) must not force page-level
+  horizontal scroll.
+
+## Intros and outros
+
+- Intro: 1–2 short paragraphs stating goal and payoff; tutorials open
+  with "you will have X working".
+- Outro: takeaways plus the clear next action — every ending is a
+  signpost.

--- a/claude/.claude/skills/technical-writing/resources/readme.md
+++ b/claude/.claude/skills/technical-writing/resources/readme.md
@@ -1,0 +1,46 @@
+# READMEs: The Cognitive Funnel
+
+## Order sections broad-to-narrow (art-of-readme, noffle)
+
+Name → one-liner → usage → API → installation → license. The widest
+end carries the broadest, most pertinent details; depth increases only
+for readers interested enough to keep going. The first screen must let
+a stranger answer "is this the thing I need?" in seconds — and the
+one-liner should state the DIFFERENTIATOR, not the category.
+
+## Short vs long — the resolved tension
+
+- noffle: "as short as it can be without being any shorter" — detailed
+  documentation gets its own pages; the README routes.
+- makeareadme.com: "too long is better than too short."
+- Resolution: makeareadme is right while the README IS the docs
+  (small/solo projects); once a docs site exists, noffle wins — the
+  README's job becomes routing, not teaching.
+
+## What celebrated READMEs share (awesome-readme curation)
+
+- A one-line differentiator, then an immediate demo — screenshot/GIF
+  for end-user tools, a code block for libraries (the visual matters
+  far more for tools than libraries).
+- Copy-paste-complete install.
+- Links out to real docs rather than inlining them.
+- Judicious badges ("what real value does this badge provide?") and
+  never images for critical information — hosts rot, and agents read
+  text.
+
+## A machine-checkable structure, if wanted (standard-readme)
+
+Title → short description (<120 chars, matching the package
+description) → ToC (required over 100 lines) → Background → Install
+(required) → Usage (required) → API → Maintainers → Contributing
+(required) → License (required, last). Low real-world adoption
+relative to fame — treat as a checklist, not a compliance target.
+
+## README-driven development (Preston-Werner)
+
+Write the README before the code: "a perfect implementation of the
+wrong specification is worthless." It forces interface design while
+excitement is fresh and gives collaborators a spec to build against.
+Known failure mode: READMEs describing aspirations that never shipped
+— pair RDD with executable examples and docs CI (see docs-quality) so
+what the README promises is continuously verified.

--- a/claude/.claude/skills/technical-writing/resources/references.md
+++ b/claude/.claude/skills/technical-writing/resources/references.md
@@ -1,0 +1,35 @@
+# References
+
+Researched 2026-07 with primary sources fetched and read; the llms.txt
+adoption figures, the Illyes statement, the friction-log framing, and
+the Red Hat/IBM relationship trace to search summaries of the named
+sources.
+
+- Daniele Procida, Diátaxis — https://diataxis.fr/ (framework, compass, tutorials-vs-how-to, adoption workflow)
+- Hillel Wayne, "My Problem With the Four-Document Model" — https://www.hillelwayne.com/post/problems-with-the-4doc-model/
+- The Good Docs Project templates — https://www.thegooddocsproject.dev/template
+- Google developer documentation style guide highlights — https://developers.google.com/style/highlights
+- Microsoft Writing Style Guide, top 10 — https://learn.microsoft.com/en-us/style-guide/top-10-tips-style-voice
+- Red Hat supplementary style guide (the deltas-only pattern) — https://redhat-documentation.github.io/supplementary-style-guide/
+- noffle, Art of README — https://github.com/noffle/art-of-readme
+- RichardLitt, standard-readme spec — https://github.com/RichardLitt/standard-readme/blob/master/spec.md
+- Make a README — https://www.makeareadme.com/
+- Tom Preston-Werner, "Readme Driven Development" — https://tom.preston-werner.com/2010/08/23/readme-driven-development.html
+- matiassingers, awesome-readme — https://github.com/matiassingers/awesome-readme
+- Write the Docs, "Docs as Code" — https://www.writethedocs.org/guide/docs-as-code/
+- Vale — https://vale.sh/docs
+- rustdoc documentation tests — https://doc.rust-lang.org/rustdoc/write-documentation/documentation-tests.html
+- lychee link checker — https://github.com/lycheeverse/lychee
+- Bhatti, Corleissen, Lambourne, Nunez, Waterhouse, *Docs for Developers* — https://docsfordevelopers.com/
+- Mark Baker, *Every Page is Page One* — https://everypageispageone.com/the-book/
+- Stripe, "How Stripe builds interactive docs with Markdoc" — https://stripe.dev/blog/markdoc
+- Moesif, Stripe DX teardown — https://www.moesif.com/blog/best-practices/api-product-management/the-stripe-developer-experience-and-docs-teardown/
+- Jeremy Howard, llms.txt — https://llmstxt.org/
+- Casey Burridge, state of llms.txt adoption — https://caseyrb.com/blog/state-of-llms-txt-adoption/
+- OtterlyAI, the llms.txt experiment — https://otterly.ai/blog/the-llms-txt-experiment/
+- Mintlify, "AI traffic" — https://www.mintlify.com/blog/ai-traffic
+- Kapa.ai, optimizing technical documentation for LLMs — https://www.kapa.ai/blog/optimizing-technical-documentation-for-llms
+- Netlify, Agent Experience — https://www.netlify.com/agent-experience/ and https://agentexperience.ax/
+- John Carroll, minimalism — https://www.instructionaldesign.org/theories/minimalism/ and "Ten Misconceptions about Minimalism" (1996) — https://ris.utwente.nl/ws/files/249663536/Caroll1996ten.pdf
+- STC, minimalism heuristics revisited — https://www.stc.org/techcomm/2021/02/04/minimalism-heuristics-revisited-developing-a-practical-review-tool/
+- Adam Bradley (mintuz), Developer Writing Playbook — https://github.com/mintuz/skills/blob/main/plugins/core/skills/writing/SKILL.md (the seed this skill adapted)

--- a/claude/.claude/skills/technical-writing/resources/references.md
+++ b/claude/.claude/skills/technical-writing/resources/references.md
@@ -28,6 +28,9 @@ sources.
 - Casey Burridge, state of llms.txt adoption — https://caseyrb.com/blog/state-of-llms-txt-adoption/
 - OtterlyAI, the llms.txt experiment — https://otterly.ai/blog/the-llms-txt-experiment/
 - Mintlify, "AI traffic" — https://www.mintlify.com/blog/ai-traffic
+- Mintlify, best llms.txt platforms and the llms-full.txt fetch-rate finding — https://www.mintlify.com/library/best-llms-txt-platforms
+- delucis, starlight-llms-txt (build-time llms.txt/full/small for Astro Starlight) — https://github.com/delucis/starlight-llms-txt
+- Dachary Carey, "Astro removed its llms.txt" (why traffic is the wrong removal metric; MCP and llms.txt as complements) — https://dacharycarey.com/2026/05/04/astro-removed-llms-txt/
 - Kapa.ai, optimizing technical documentation for LLMs — https://www.kapa.ai/blog/optimizing-technical-documentation-for-llms
 - Netlify, Agent Experience — https://www.netlify.com/agent-experience/ and https://agentexperience.ax/
 - John Carroll, minimalism — https://www.instructionaldesign.org/theories/minimalism/ and "Ten Misconceptions about Minimalism" (1996) — https://ris.utwente.nl/ws/files/249663536/Caroll1996ten.pdf


### PR DESCRIPTION
A skill for developer-facing prose — READMEs, guides, tutorials, reference docs, proposals, release notes — built on the contract that developers skim first and commit only when the first screen answers *what is this, why care, how do I start*.

## What's in it

- **One mode per page** — the single most-violated rule in real docs: a page is a tutorial, how-to, reference, or explanation, never a blend. Diátaxis's four modes with the tutorial≠how-to distinction most docs miss — and the model's honest limits (Hillel Wayne's critique, the types it omits) rather than framework worship.
- **Claims need receipts** — no capability claim without a number, command, or file the reader can check; counts and versions bound to a kept-current rule; honest limits as content; idle/empty states must speak.
- **Docs are behavior** — every flag/exit code/config key verified against source; machine-check what machines can check (ToC anchors against real slug rules, links, executable examples); doc diffs ride the same commit as the behavior.
- **README cognitive funnel** — broad-to-narrow ordering, the short-vs-long tension resolved (route once a docs site exists), README-driven development with its aspirational-README failure mode named and paired with docs CI.
- **Docs-quality enforcement ladder** — Vale prose lint (style guides as merge gates), rustdoc-style executable examples, lychee link checking, reference generated from spec, friction logs, Google's timeless-docs rule, Every Page is Page One.
- **Docs for AI agents, hype-checked** — llms.txt's measured adoption reality (real IDE-agent consumers, ~0.1% of crawler requests, no SEO story), markdown endpoints for agent traffic, RAG-chunkable structure as good-writing-restated.

## Provenance

Adapted from Adam Bradley's [Developer Writing Playbook](https://github.com/mintuz/skills/blob/main/plugins/core/skills/writing/SKILL.md) (credited in the resources). All research claims cited to primary sources in `resources/references.md`, with search-summary provenance flagged where full pages were not fetched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)