### PR TITLE
fix(structure-codebase): inbound leaf always lives under endpoints/

### DIFF
--- a/.changeset/endpoint-first-inbound-leaf.md
+++ b/.changeset/endpoint-first-inbound-leaf.md
@@ -1,0 +1,5 @@
+---
+"@citypaul/dotfiles": patch
+---
+
+structure-codebase: resolve the endpoint-first-BFF vs in-BFF-hexagon ambiguity. When a BFF legitimately owns an internal capability hexagon, the hexagon owns the use-case, ports, and driven adapters — but the inbound HTTP leaf always stays at `endpoints/<url>/<method>.ts`, discoverable by its URL. States the underlying principle once (the public interface's shape — URL tree, command tree — is the primary navigation axis) and adds the buried-route-leaf anti-pattern.

--- a/claude/.claude/skills/structure-codebase/SKILL.md
+++ b/claude/.claude/skills/structure-codebase/SKILL.md
@@ -189,6 +189,7 @@ Reject these structures:
 - Ports that reproduce SQL, HTTP, ORM, or SDK APIs.
 - Test adapters and reusable fakes beneath `hexagon/`.
 - Business behavior, provider construction, or shared runtime state hidden in endpoint handlers.
+- HTTP route leaves or CLI command entries buried inside capability or hexagon folders instead of the public interface tree (`endpoints/`, `commands/`).
 - Production code importing development-only routes or test packages.
 - `shared`, `common`, `utils`, `helpers`, or `services` as unowned dumping grounds.
 - Empty folder skeletons added for symmetry.

--- a/claude/.claude/skills/structure-codebase/references/backend-patterns.md
+++ b/claude/.claude/skills/structure-codebase/references/backend-patterns.md
@@ -2,6 +2,8 @@
 
 Use these patterns after classifying the project. They are starting grammars, not templates to reproduce blindly. Create only directories that own real code.
 
+When a system's public interface has a shape — an HTTP URL tree, a CLI command tree — that shape is the primary navigation axis: every entry leaf lives under it (`endpoints/`, `commands/`), whatever internal capability fulfils the request.
+
 ## Contents
 
 1. Feature-first service
@@ -109,6 +111,8 @@ Apply these rules:
 
 Do not give the BFF a hexagon merely because it calls hexagonal packages. Extract a provider-free inside package only when the BFF itself owns substantial, durable application policy.
 
+When the BFF does earn an internal capability hexagon, that hexagon owns the use-case, its ports, and the driven adapters — never the inbound HTTP translation. The endpoint's transport-thin leaf still lives at `endpoints/<url>/<method>.ts` and delegates into the capability's use-case, exactly like a leaf that calls an external hexagonal package. Every route must be discoverable by its URL under `endpoints/`, whatever internal capability fulfils it — in the tree above, `sessions/by-room-id/init/post.ts` stays in `endpoints/` even when an in-BFF capability behind `composition/video.ts` fulfils it. A route file inside a capability folder's `inbound-adapters/` is a structure smell: move the leaf to `endpoints/`, keep the use-case and driven adapters in the hexagon.
+
 ## Framework-Constrained Backend
 
 Preserve required framework locations and keep them thin:
@@ -173,7 +177,7 @@ src/
 └── main.ts
 ```
 
-For a command-line application, command names are often the most useful navigation axis:
+For a command-line application, command names are often the most useful navigation axis — the same public-shape rule as `endpoints/` in a BFF: a command's entry leaf lives under `commands/` whatever internal capability implements it:
 
 ```text
 src/


### PR DESCRIPTION
## The gap

`references/backend-patterns.md` showed every route's transport-thin leaf under `src/endpoints/<url>/<method>.ts`, and separately cautioned against giving the BFF a hexagon it hasn't earned — but never connected the two. When a BFF *does* legitimately own an internal capability hexagon, the skill didn't say where that capability's HTTP route leaf belongs. In practice this caused real drift: a `POST /api/sessions/{roomId}/init` handler landed in a capability folder's `inbound-adapters/` instead of `endpoints/sessions/by-room-id/init/post.ts` — registered in the router but undiscoverable by browsing `endpoints/`.

## The fix

- **Endpoint-First BFF**: a new paragraph directly after the don't-over-hexagon caution (kept intact — it still governs *whether* a hexagon is earned; the addition governs only *where the inbound adapter goes*). The hexagon owns the use-case, ports, and driven adapters — never the inbound HTTP translation. The transport-thin leaf stays at `endpoints/<url>/<method>.ts` and delegates into the capability's use-case; a route file under a capability's `inbound-adapters/` is named as a structure smell with its correction. Grounded in the section's own tree (`sessions/by-room-id/init/post.ts` + `composition/video.ts`).
- **The underlying principle, stated once** in the file intro: the public interface's shape is the primary navigation axis — URL tree under `endpoints/`, command tree under `commands/` — whatever internal capability fulfils the request. The CLI section now references the same rule.
- **SKILL.md anti-patterns**: route leaves / command entries buried inside capability or hexagon folders.
- Changeset: patch.

Verified coherent with the surrounding endpoint-first rules (transport-thin leaves, route-independent workflows, dev-route one-way import); no contradiction with the hexagon-extraction caution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
