### PR TITLE
Fix release changeset package validation

### DIFF
--- a/.changeset/secure-oauth-oidc-skill.md
+++ b/.changeset/secure-oauth-oidc-skill.md
@@ -1,5 +1,5 @@
 ---
-"@paulhammond/dotfiles": minor
+"@citypaul/dotfiles": minor
 ---
 
 Add a dedicated RFC 9700-based skill for designing, implementing, auditing, testing, and migrating secure OAuth 2.0 and OpenID Connect systems.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v3
@@ -38,4 +40,4 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Validate changesets
-        run: pnpm changeset status
+        run: pnpm changeset status --since origin/main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,3 +15,27 @@ jobs:
 
       - name: Test OpenCode compatibility
         run: ./test/opencode-compat.sh
+
+  changesets:
+    name: Validate changesets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate changesets
+        run: pnpm changeset status


### PR DESCRIPTION
## Summary

- correct the secure OAuth/OIDC changeset to target the workspace package, `@citypaul/dotfiles`
- add a pull-request CI job that validates Changesets against `origin/main` before changes reach the release workflow

## Root cause

The [failed release job](https://github.com/citypaul/.dotfiles/actions/runs/29344166453/job/87123377010) reached `pnpm changeset version`, then rejected `.changeset/secure-oauth-oidc-skill.md` because it named the nonexistent package `@paulhammond/dotfiles`.

The architecture changeset merged in #202 already used the correct package name; the merge exposed this older latent changeset error when the release workflow ran.

## Why this fix

Correcting the package name unblocks the pending release. Pull-request CI now uses Changesets' own `status` command with full Git history and an explicit `origin/main` base. This catches invalid package references before merge and supports GitHub's detached pull-request checkout without maintaining a bespoke parser.

## Validation

- `pnpm changeset status --since origin/main`
- `pnpm changeset version` in a disposable worktree based on the merged `main`
- `pnpm test`
- parsed `.github/workflows/ci.yml` as YAML
- audited every active changeset package identifier
- `git diff --check`
