### PR TITLE
feat(testing): honest Playwright E2E evidence — the browser must do the work

### DIFF
--- a/.changeset/playwright-e2e-evidence.md
+++ b/.changeset/playwright-e2e-evidence.md
@@ -1,0 +1,5 @@
+---
+"@citypaul/dotfiles": minor
+---
+
+testing + front-end-testing: honest Playwright E2E evidence. The general testing skill's "Test Through Public API Only" is now "Test Through the Subject's Public Interface" with a claim→interface table — an HTTP endpoint can be public and still be the wrong interface for a browser claim. front-end-testing gains a routed deep dive (`resources/playwright-e2e.md`): the user-action/automatic-work/direct-call decision rule, an evidence-boundary table, safe request observation (listener before the action, precise method+path predicates, rendered-outcome assertions), a direct-transport audit procedure with a seven-field ledger, false-browser-confidence anti-patterns (page.request journeys, page.evaluate(fetch), forged Sec-Fetch-*/Origin headers), honest fixture/readiness/diagnostic/deployment roles, and an auth/lifecycle evidence contract routed to secure-oauth-oidc and bff-entry-points.

--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -42,7 +42,7 @@ I follow Test-Driven Development (TDD) with a strong emphasis on behavior-driven
 
 **Quick reference:**
 - Write behavior tests first for new or changed behavior (TDD non-negotiable)
-- Test through public API exclusively
+- Test through the subject's public interface at the layer the claim names (an HTTP endpoint is the wrong interface for a browser claim)
 - Use factory functions for test data (no `let`/`beforeEach`)
 - Tests must document expected business behavior
 - No 1:1 mapping between test files and implementation files

--- a/claude/.claude/agents/pr-reviewer.md
+++ b/claude/.claude/agents/pr-reviewer.md
@@ -520,7 +520,7 @@ Analyzing..."
 - Tests verify behavior, not that code was called
 
 ### Testing Rules
-- Test through public API only
+- Test through the subject's public interface at the layer the claim names
 - No `let`/`beforeEach` - use factory functions
 - No spying on internal methods
 - No mocking the function being tested

--- a/claude/.claude/agents/tdd-guardian.md
+++ b/claude/.claude/agents/tdd-guardian.md
@@ -82,7 +82,7 @@ For each behavior-changing production code change:
 Check that tests follow principles:
 - ✅ Tests describe WHAT the code should do (behavior)
 - ❌ Tests do NOT describe HOW it does it (implementation)
-- ✅ Tests use the public API only
+- ✅ Tests use the subject's public interface at the layer the claim names
 - ❌ Tests do NOT access private methods or internal state
 - ✅ Tests have descriptive names documenting business behavior
 - ❌ Tests do NOT have names like "should call X method"

--- a/claude/.claude/commands/generate-pr-review.md
+++ b/claude/.claude/commands/generate-pr-review.md
@@ -156,7 +156,7 @@ This reviewer enforces:
 - Any tests verify behavior, not implementation
 
 ### Testing Quality
-- Test through public API only
+- Test through the subject's public interface at the layer the claim names
 - No `let`/`beforeEach` - use factory functions
 - Factory functions validate with real schemas (don't redefine)
 - No spying on internal methods

--- a/claude/.claude/skills/front-end-testing/SKILL.md
+++ b/claude/.claude/skills/front-end-testing/SKILL.md
@@ -1,16 +1,17 @@
 ---
 name: front-end-testing
-description: Behavior-driven UI testing patterns. Covers Vitest Browser Mode (preferred) and DOM Testing Library. Use when testing any front-end application, writing UI tests, querying DOM elements, or simulating user interactions. For React-specific patterns, see the react-testing skill.
+description: Behavior-driven UI testing patterns. Covers Vitest Browser Mode (preferred), Playwright E2E evidence boundaries, and DOM Testing Library. Use when testing any front-end application, writing UI or end-to-end tests, querying DOM elements, simulating user interactions, or reviewing whether a browser/user-journey test actually proves what it claims. For React-specific patterns, see the react-testing skill.
 ---
 
 # Front-End Testing
 
-For React-specific patterns (components, hooks, context), load the `react-testing` skill. For TDD workflow, load the `tdd` skill. For general testing patterns (factories, public API testing), load the `testing` skill.
+For React-specific patterns (components, hooks, context), load the `react-testing` skill. For TDD workflow, load the `tdd` skill. For general testing patterns (factories, public-interface testing), load the `testing` skill.
 
 **Deep-dive resources** are in the `resources/` directory. Load them on demand:
 
 | Resource | Load when... |
 |----------|-------------|
+| `resources/playwright-e2e.md` | Writing or auditing Playwright Test E2E/user-journey suites against a running app — who may initiate requests, observing network without performing it, the direct-transport audit, auth/lifecycle evidence |
 | `resources/async-patterns.md` | Using `findBy`/`waitFor`/`waitForElementToBeRemoved`, testing loading states, debounce, or reviewing waitFor usage |
 | `resources/msw.md` | Mocking APIs — full setupWorker (Browser Mode) and setupServer (Node/jsdom) setup, per-test overrides |
 | `resources/dom-testing-library-legacy.md` | Working in a jsdom/`@testing-library/dom` codebase — screen object, fireEvent vs userEvent, jest-dom matchers, ESLint plugins |
@@ -219,6 +220,14 @@ it('creates and displays a user', async () => {
 
 ---
 
+## Playwright E2E Is a Different Subject
+
+Vitest Browser Mode tests a **component in isolation**; Playwright Test against a running application tests **whatever the test's claim names** — a user journey, the frontend's own network behavior, cookie/CSRF posture, redirects, rendering. Same browser engines, different subject and harness: never assume guidance transfers between them.
+
+The one rule that governs E2E suites: **a browser or user-journey claim must be proved by a browser initiator** — an accessible locator action or a navigation — never by a direct HTTP call standing in for the user or the frontend. `page.request.post('/api/...')` in a test named "user creates ..." proves an HTTP contract, not a journey; it stays green when the button, cookie policy, CSRF check, redirect, or rendering breaks. Load `resources/playwright-e2e.md` before writing or reviewing any E2E/journey suite — it carries the decision rule, the evidence-boundary table, safe request observation, the direct-transport audit procedure, and the auth/lifecycle evidence contract.
+
+---
+
 ## Query Selection Priority
 
 **Most critical skill: choosing the right query.** Near-identical for Browser Mode locators and Testing Library queries — the two naming differences are flagged below.
@@ -339,6 +348,7 @@ For factory patterns, see the `testing` skill.
 4. **Fetch/axios mocking instead of MSW** — see `resources/msw.md`.
 5. **waitFor misuse** — see `resources/async-patterns.md`.
 6. **jsdom-specific anti-patterns** (skipping `screen`, `fireEvent`, manual `cleanup()`, property assertions instead of jest-dom matchers, missing ESLint plugins) — see `resources/dom-testing-library-legacy.md`.
+7. **HTTP-level shortcuts wearing browser names** — `page.request`/`page.evaluate(fetch)` performing work a "journey"/"browser"/"E2E" test claims the user or frontend did, or forged browser headers (`Sec-Fetch-*`, `Origin`) admitting a non-browser client — see `resources/playwright-e2e.md`.
 
 ---
 
@@ -357,4 +367,5 @@ Before merging UI tests, verify:
 - [ ] MSW for API mocking — `setupWorker` in Browser Mode, `setupServer` in Node/jsdom
 - [ ] Following TDD workflow (see `tdd` skill)
 - [ ] Using test factories for data (see `testing` skill)
+- [ ] In Playwright E2E suites: every browser/journey claim has a browser initiator, and direct HTTP appears only in the narrowly named roles `resources/playwright-e2e.md` classifies (contract, setup, readiness, post-condition, diagnostic, external actor) — never borrowed as browser evidence
 - [ ] For React-specific patterns (hooks, context, components), see `react-testing` skill

--- a/claude/.claude/skills/front-end-testing/resources/playwright-e2e.md
+++ b/claude/.claude/skills/front-end-testing/resources/playwright-e2e.md
@@ -1,0 +1,131 @@
+# Playwright E2E Evidence: The Browser Must Do the Work
+
+This resource covers **Playwright Test running against a running application** — E2E and user-journey suites. It is not about Vitest Browser Mode: both use browser engines, but their subjects differ. Browser Mode renders a component in isolation and its subject is that component's contract; Playwright E2E drives the served application through real navigation, and its subject is whatever the test's *claim* says it is. Do not transfer harness assumptions between the two merely because both say "browser".
+
+**The core rule: a test's evidence must come from the public interface of the subject its claim names.** A browser or user-journey test must prove that the browser/frontend initiated the work it claims. A direct HTTP client must not silently stand in for a user, the frontend, browser cookie policy, CSRF/Fetch Metadata checks, redirects, loading/error state, or rendering. An HTTP endpoint can be perfectly public and still be the wrong interface for a browser claim.
+
+Why it matters: a "user creates a session" test that calls the endpoint directly stays green when the button's handler is deleted, when the cookie stops being sent, when CSRF middleware rejects the real frontend, when the redirect breaks, or when the result never renders. The test then certifies a journey no user can complete.
+
+---
+
+## The Decision Rule
+
+Classify what each step of the test really is:
+
+- A **user action** is initiated through an accessible locator (`getByRole`, `getByLabel`, ...) and a real locator action — `click`, `fill`, keyboard input. This is the only initiator a "user does X" claim may use.
+- **Automatic frontend work** (a probe on mount, a refresh after navigation, an SSE subscription) is *caused* by navigation, reload, mount, or a UI state transition — then **observed**. The test may listen to the request/response; it must not manufacture the request.
+- A **direct HTTP call** (`page.request`, `APIRequestContext`, `fetch`, an HTTP helper) is allowed only when the test's explicit subject is an HTTP contract, a readiness probe, a fixture/setup seam, a server-side post-condition check after honest browser actions, a diagnostic, or a deliberate external actor. Its test name and comments must state that narrower role — and what it does *not* prove.
+- **Setup evidence cannot be borrowed.** Direct-API setup may create pre-existing state, but the browser claim begins only when the page is created/navigated, and the browser portion must independently prove its stated outcome.
+
+## Evidence Boundaries
+
+| Test claim | Real initiator | Permitted driver | Invalid shortcut | Required observable outcome |
+|---|---|---|---|---|
+| "User creates/joins/edits X" | The user's gesture | Accessible locator action (`getByRole(...).click()`, `fill`) | `page.request.post(...)`, `page.evaluate(fetch)` | User-visible result rendered (`expect(locator).toBeVisible()` on the outcome) |
+| "Frontend probes/refreshes/streams X" | Frontend code on navigation/mount/state change | `page.goto`, `reload`, UI transition + `waitForResponse` observer | Manufacturing the request the frontend should send | Observed browser-initiated request *and* the UI state it produces |
+| "Sign-in / sign-out works" | User through provider UI, redirects, callback | Locator actions across the real redirect flow; fresh navigation to prove session | Direct login endpoint call, injected tokens/cookies presented as flow proof | Authenticated (or unauthenticated) UI after a fresh navigation/reload |
+| "HTTP API contract holds" | An HTTP client (that *is* the subject) | `request` fixture / `APIRequestContext` | Calling it a browser/journey/E2E test | Documented status, headers, body shape asserted |
+| "Service is ready" (harness) | Operator/harness | HTTP probe before the page exists | Citing the probe as UI evidence | Probe success gates the run; the browser claim starts afterwards |
+| "Given pre-existing state, user does X" | Fixture seam, then the user | Direct-API/DB setup, then locator actions from navigation onward | Letting the setup half also serve as the proof of X | The browser portion proves X on its own |
+| "Diagnostic endpoint reports X" | A diagnostic client | Direct call to the diagnostic contract | Citing it as proof a panel loaded/rendered X | The diagnostic response itself — nothing about UI |
+
+Names, comments, CI step labels, docs, and PR prose are evidence too: no "E2E", "browser", or "journey" label may claim more than the driver and assertions prove. A test narrowed to API setup/readback must lose its journey name.
+
+---
+
+## Observing Requests Without Performing Them
+
+Attach the listener **before** the user action, match the method and the *parsed* URL path precisely, drive the action through the UI, then assert both the response (where useful) and the stable user-visible state:
+
+```ts
+// ❌ WRONG: the test performs the frontend's job.
+const response = await page.request.post('/api/sessions', { data })
+
+// ❌ WRONG: broad substring predicate — can match stale or unrelated traffic.
+const anything = page.waitForResponse((r) => r.url().includes('/api/'))
+
+// ✅ CORRECT: the user acts; Playwright observes the request the frontend owns.
+// Note: no await on the next line — attach first, await after the action,
+// or the observer races the response and can hang. (This is the official
+// playwright.dev/docs/network pattern.)
+const created = page.waitForResponse((response) =>
+  response.request().method() === 'POST' &&
+  new URL(response.url()).pathname === '/api/sessions'
+)
+await page.getByRole('button', { name: 'Create' }).click()
+expect((await created).status()).toBe(201)
+await expect(page.getByRole('heading', { name: 'Session created' })).toBeVisible()
+```
+
+`waitForResponse` is an **observer, not proof by itself**. Ownership and user impact are established by the accessible action that initiated the request and by the rendered outcome. A test that only observes a response — with no UI initiator or no rendered assertion — has not proved a browser claim.
+
+Web-first auto-retrying assertions (`await expect(locator).toBeVisible()`) are the default readiness signal; reach for `waitForResponse` only when the network exchange itself is part of the claim. `page.requests()` (v1.56+) reads recent request history for diagnostics — it does not replace a pre-attached observer for awaiting a specific in-flight response.
+
+**Why `page.request` cookies don't make it browser evidence:** `page.request` shares the browser context's cookie jar, so its calls *look* authenticated — but they originate directly from Node.js. They are not initiated by frontend code, not intercepted by `page.route()`, not subject to CORS or service workers, and carry no browser-generated Fetch Metadata from a real user gesture. Shared cookies prove the jar works, not that the frontend, the user, or the browser's security posture did anything.
+
+---
+
+## The Direct-Transport Audit
+
+To audit an existing suite for HTTP-level shortcuts, search and classify — including **indirect wrappers and their callers**; grepping literal `fetch(` is insufficient:
+
+- Playwright `page.request`, the `request` fixture, `APIRequestContext`, and any newly created request contexts
+- Node/global `fetch`, axios and other HTTP clients, and helper functions that wrap any of them (trace each wrapper's definition to every caller)
+- `page.evaluate(() => fetch(...))` or equivalent in-page request construction
+- Manual security/browser headers — `Sec-Fetch-*`, `Origin`, CSRF tokens, cookies — used to impersonate a browser
+- CLI/subprocess helpers that initiate HTTP, and tests that consume the fixture state they created
+- Browser-owned traffic — navigation, `EventSource`, WebSocket, ordinary frontend requests — distinguishing **observation** (legitimate) from **initiation** (the finding)
+
+Also review test names, comments, CI workflow step labels and grep tags, and canonical status/docs for **evidence overclaims** — prose that promises browser proof a direct call delivered.
+
+Record every finding as a ledger row:
+
+| # | Field |
+|---|---|
+| 1 | File and test/callers |
+| 2 | Endpoint/action |
+| 3 | Real initiator in production |
+| 4 | Layers bypassed by the direct call (UI handler, cookie policy, CSRF/Fetch Metadata, redirects, loading/error state, rendering) |
+| 5 | Exact claim the test currently makes (name + prose) |
+| 6 | Disposition: **replace** (drive through UI) · **retain with narrower scope** (rename, restate subject) · **remove** |
+| 7 | Justification and residual coverage gap for anything retained/removed |
+
+---
+
+## Anti-Patterns: False Browser/Security Confidence
+
+- `page.request`/`APIRequestContext` performing sign-in, create, join, edit, or any action the test describes as a browser/user journey.
+- `page.evaluate(fetch)` to trigger frontend-owned work — an in-page transport is still not the frontend's code path.
+- Manually forging `Sec-Fetch-Site`, `Sec-Fetch-Mode`, `Origin`, CSRF tokens, cookies, or other browser-generated evidence so a browser-only endpoint accepts a non-browser client. If an endpoint intentionally accepts only a browser-generated security posture, a direct client cannot turn it into an API contract by copying browser headers — that is fabricating the very evidence the endpoint exists to demand. Use a real browser/frontend initiator, reuse state from a separately honest upstream proof, or withdraw/narrow the claim and document the gap. Do **not** respond by weakening the endpoint. (Legitimate API headers on a real, documented non-browser API contract are fine — that is a different subject.)
+- Injecting authorization/session state and then claiming provider redirects, cookie issuance, same-site/host-only behavior, logout, or frontend coordination worked.
+- `dispatchEvent` or DOM evaluation for ordinary user actions when a real accessible locator action exists.
+- Weakening TLS, insecure protocol substitutions, or ignoring HTTPS errors as a convenience.
+- Arbitrary sleeps (`waitForTimeout`), `waitForLoadState('networkidle')` (officially discouraged — "rely on web assertions to assess readiness instead"), or repeated polling that merely hides lifecycle races (see Lifecycle below).
+- Blanket retries as a *fix*. Configured suite retries that mark retried passes `flaky` — ideally with `failOnFlakyTests` gating CI — are a visibility tool; the fix lives in the app or the test's evidence model, never in retrying until green.
+- Retaining a test under a "journey"/"browser"/"E2E" name after narrowing it to API setup/readback.
+
+---
+
+## Fixtures, Readiness, Diagnostics, Deployment
+
+- A **fixture** may stand in for a missing upstream subsystem (e.g. inject the proposal an AI would have produced), but label it as fixture injection and keep the tested downstream user action real. The test must not claim the real upstream producer was tested.
+- A **process-readiness probe** (`/health` before launching the page) is an operator/harness action — never UI evidence.
+- A **diagnostic API** can be asserted directly when the diagnostic contract is the subject; it must not be cited as proof that a panel loaded or rendered it.
+- **Direct API setup** is acceptable for a test whose subject starts after pre-existing state — but the test must state where the browser claim begins.
+- **Production-only tests** may be skipped locally when required deployment evidence is absent, but keep test discovery, workflow wiring, environment classification, cleanup ownership, and fail-closed parsing verifiable locally.
+- **Never preserve a deployed/scale claim by fabricating the property being claimed.** Honest synthetic data through a legitimate fixture seam (DB seed, admin API) can support a claim explicitly framed as "given N seeded records, the UI ..." — that is ordinary setup. What synthetic setup cannot support is a claim that browsers/users produced the load, or any seeding that only works by forging browser metadata. If no legitimate initiator or fixture seam exists, withdraw the claim, retain the honest lower-layer coverage under an accurate name, and record the deployed gap.
+
+---
+
+## Authentication and Lifecycle Evidence
+
+Protocol and security design live in their own skills — load `secure-oauth-oidc` for OAuth/OIDC flows and `bff-entry-points` for session cookies, CSRF/Origin, and Fetch Metadata policy. The *testing evidence contract* is:
+
+- Provider sign-in is proved through the provider's UI, redirects, and callback — not a direct login endpoint.
+- Application-session cookies are proved through the browser's own cookie transport plus a **fresh navigation/reload** — not by asserting a `Set-Cookie` header arrived.
+- Logout must survive a fresh frontend initialization and show the unauthenticated UI.
+- Observe auth requests without exposing authorization codes, tokens, cookies, or credentials in logs, traces, screenshots, URLs, storage, or history.
+- Run every supported auth/storage profile through the full journey — a flow proved on one profile is unproved on the others.
+- Cached auth state (`storageState`, canonically saved by a setup project and loaded via project dependencies) is a fixture seam: it legitimately skips *re-proving* sign-in in unrelated tests only when the sign-in journey itself is proved by its own honest test. The official docs offer API-based login setup as a speed optimization — take it knowingly: it yields **zero evidence the login UI works**, so keep at least one real UI sign-in test whenever sign-in is a claimed behavior. Never commit saved auth state (it holds live cookies); use one account per parallel worker when tests mutate shared server state.
+- For lifecycle/race-sensitive flows, repeat the **full browser journey** when practical rather than adding retries or sleeps. For time-dependent behavior, prefer the clock API (`page.clock.install()`, `fastForward`) over real waiting.
+- Bound real cold-start readiness with evidence-based timeouts and deterministic failure diagnostics (trace viewer with `trace: 'on-first-retry'`, or `'retain-on-failure'` when runner retries are disabled; `--repeat-each` for reproduction) — and keep the journey itself free of manual/in-test retry loops (configured runner retries remain the visibility tool described above).

--- a/claude/.claude/skills/testing/SKILL.md
+++ b/claude/.claude/skills/testing/SKILL.md
@@ -37,14 +37,26 @@ Do not ask when the gap is plainly a missing assertion, missing boundary, missin
 
 ---
 
-## Test Through Public API Only
+## Test Through the Subject's Public Interface
 
-Never test implementation details. Test behavior through public APIs.
+Never test implementation details. Test behavior through the subject's public interface — **at the layer named by the test's claim**.
 
 **Why this matters:**
 - Tests remain valid when refactoring
 - Tests document intended behavior
 - Tests catch real bugs, not implementation changes
+
+"Public API" does not mean "the HTTP API": every layer has its own public interface, and the claim under test decides which one owns the evidence.
+
+| Claim under test | Public interface that owns the evidence |
+|---|---|
+| Domain/application behavior | Exported domain/application operation |
+| HTTP API contract | HTTP client and documented request/response contract |
+| Component behavior | Rendered component DOM and its public props/events |
+| Browser/frontend behavior | Navigation, accessible UI, browser lifecycle, and browser-observed network |
+| User journey | Accessible user actions and user-visible outcomes across the real journey |
+
+An HTTP endpoint can be public and still be the **wrong** interface for a browser claim: a "user creates X" test that calls the endpoint directly proves an HTTP contract while bypassing the UI handler, cookie policy, CSRF/Fetch Metadata checks, redirects, loading/error state, and rendering — and stays green when any of those break. Test names, comments, CI step labels, docs, and PR prose must state the **narrowest evidence actually proved**. For the E2E evidence model, request observation, and the direct-transport audit, load the `front-end-testing` skill's `resources/playwright-e2e.md`.
 
 ### Examples
 
@@ -480,7 +492,7 @@ tests/
 
 When writing tests, verify:
 
-- [ ] Testing behavior through public API (not implementation details)
+- [ ] Testing behavior through the subject's public interface at the layer the claim names (not implementation details, not a lower layer standing in for it)
 - [ ] No mocks of the function being tested
 - [ ] No tests of private methods or internal state
 - [ ] Factory functions return complete, valid objects


### PR DESCRIPTION
## Before / after

**Before**: the `testing` skill said "Test Through Public API Only" — easy to misread as "call the HTTP API directly," and `front-end-testing` had no guidance for Playwright Test E2E suites at all (only Vitest Browser Mode component testing). A completed audit ([conquer-thoughts#298](https://github.com/citypaul/conquer-thoughts/pull/298)) found tests that looked browser-level but called backend endpoints directly — green while the UI, cookie policy, CSRF, redirects, or rendering could all be broken; one deployed helper forged `Sec-Fetch-Site: same-origin` and that fabricated header was what admitted the write.

**After**: the `testing` skill's section is now **"Test Through the Subject's Public Interface"** with a claim→interface table — the claim under test decides which layer's interface owns the evidence, and an HTTP endpoint can be public while being the *wrong* interface for a browser claim. `front-end-testing` routes to a new deep dive, `resources/playwright-e2e.md`:

- the **decision rule**: user action (accessible locator + real action) / automatic frontend work (caused by navigation-mount-transition, observed not manufactured) / direct HTTP (only for contract, setup, readiness, post-condition, diagnostic, or external-actor subjects — named as such, stating what they do *not* prove); setup evidence cannot be borrowed by the browser claim
- an **evidence-boundary table** (claim / real initiator / permitted driver / invalid shortcut / required observable outcome)
- **safe request observation**: listener attached before the action (official playwright.dev/docs/network pattern, no-await), precise method+parsed-path predicates, `waitForResponse` as observer-not-proof, rendered-outcome assertions; why `page.request`'s shared cookie jar is still not browser evidence (Node-originated, no route interception, no gesture-generated Fetch Metadata)
- a **direct-transport audit** procedure (page.request/APIRequestContext, fetch/axios + wrapper tracing to callers, page.evaluate(fetch), forged Sec-Fetch-*/Origin, CLI helpers, observation-vs-initiation for SSE/WebSocket) with a **seven-field ledger** and overclaim review of names/comments/CI labels/docs
- **anti-patterns**: page.request journeys, `page.evaluate(fetch)`, forged browser security posture (never fixed by weakening the endpoint), injected session state claiming flow proof, dispatchEvent for real user actions, TLS weakening, sleeps/networkidle, blanket retries-as-fix (runner retries stay a visibility tool with `failOnFlakyTests`), journey names on narrowed tests
- **honest roles** for fixtures, readiness probes, diagnostics, direct-API setup, production-only tests, and deployed/scale claims (fabricating the claimed property is prohibited; honest seeded-scale claims stay legitimate)
- **auth/lifecycle evidence contract**: provider-UI sign-in, cookie proof via fresh navigation, logout surviving fresh initialization, secret-free observation, all auth/storage profiles, full-journey repetition over retries, clock API over sleeps — protocol detail routed to `secure-oauth-oidc` and `bff-entry-points`

Aligned one-liners in CLAUDE.md, pr-reviewer, tdd-guardian, generate-pr-review; changeset (minor).

## Acceptance-scenario walk (all eight classify as required)

| # | Seeded case | Classification the text forces |
|---|---|---|
| 1 | "user creates a Session" via `page.request.post`, navigate for readback | Reject or rename/narrow |
| 2 | Logout journey `page.evaluate(() => fetch('/api/me'))` | Reload/navigation must trigger the probe; waitForResponse observes only |
| 3 | Direct API fixture pre-browser, claim starts at navigation | Retain with explicit limits |
| 4 | `/health` poll before page launch | Retain as readiness, never UI evidence |
| 5 | Deployed client forging `Sec-Fetch-Site: same-origin` | Reject; do not weaken the endpoint |
| 6 | `url().includes('/api/')` predicate, no rendered assertion | Strengthen |
| 7 | Fixture-injected AI proposal + accessible confirm + convergence | Retain; no claim about the real producer |
| 8 | 400-record deployed scale seeded via forged metadata | Withdraw/relocate the claim; document the gap |

An independent cross-provider reviewer (codex, xhigh, 2 rounds) produced the same eight classifications from the text alone, found 3 wording-precision issues in round 1 (all fixed: checklist role list, seeded-scale nuance, trace-mode/retry pairing), and returned no-issues in round 2.

## Validation

- `./test/run.sh` — all tests passed (before and after final edits)
- Claims verified against playwright.dev docs (July 2026): api-testing roles, attach-before-act `waitForResponse`, networkidle discouraged, auth storageState setup-project pattern, retries/flaky/`failOnFlakyTests`, APIRequestContext cookie-jar sharing + Node origination
- Grep for contradictions with retained material (MSW, Browser Mode, idempotency, factories): none; remaining "public API" phrasing updated in all four consumer docs
- Deferred intentionally: no lint-rule/mechanical enforcement for the audit procedure (documentation-level in this repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
