### PR TITLE
Harden Vitest watch proof guidance

### DIFF
--- a/.changeset/harden-vitest-watch-proof.md
+++ b/.changeset/harden-vitest-watch-proof.md
@@ -1,0 +1,7 @@
+---
+"@citypaul/dotfiles": patch
+---
+
+Harden Vitest watcher guidance around exact-command proofs, negative affected-test controls,
+headless polling evidence, repository-owned start timing, and cleanup after child-process
+failures.

--- a/claude/.claude/skills/tdd/SKILL.md
+++ b/claude/.claude/skills/tdd/SKILL.md
@@ -21,12 +21,13 @@ The RED-GREEN-REFACTOR inner loop must optimize for fast, relevant feedback. **D
 
 Before RED, inspect package scripts, test configuration, and runner help. Repository-owned commands take precedence over generic examples:
 
-1. **RED** — run the new or changed test file/name and confirm the expected failure.
-2. **Select the watcher deliberately** — prefer a tested repository-owned watch command. It may run the complete relevant development tier once to populate the runtime graph, then rerun only affected tests. For Vitest without such a command, use `--changed <real-base> --watch` only when the installed version and repository configuration have the required live proof.
-3. **GREEN/REFACTOR** — keep one watcher in a dedicated reusable terminal/session. Let the runner or repository graph choose affected tests; do not hand-pick a smaller ongoing GREEN scope.
-4. **AI/non-interactive fallback** — when a persistent watcher cannot be owned reliably, run the equivalent affected one-shot after each edit.
-5. **Repair the right boundary** — restart or reseed for stale or newly graph-visible relationships. For non-import/dynamic dependencies, configuration, global setup, public contracts, or shared-package uncertainty, add repository-owned triggers or widen to the owning suite/tier; restart alone cannot create an absent graph edge.
-6. **PR readiness** — stop every watcher, then follow the repository's mutation/alternate-evidence policy and complete non-watch PR gate. In a monorepo, that final gate includes every configured project and required integration/E2E suite, not only the development subset.
+1. **Honor the repository's watcher start point** — if it requires a proven watcher before the first edit, start it once now. Otherwise strict TDD may write RED first and start the watcher immediately afterwards. Repository timing overrides the generic example below.
+2. **RED** — run the new or changed test file/name and confirm the expected failure.
+3. **Select or reuse the watcher deliberately** — prefer a tested repository-owned watch command. It may run the complete relevant development tier once to populate the runtime graph, then rerun only affected tests. For Vitest without such a command, use `--changed <real-base> --watch` only when the installed version and repository configuration have the required live proof.
+4. **GREEN/REFACTOR** — keep one watcher in a dedicated reusable terminal/session. Let the runner or repository graph choose affected tests; do not hand-pick a smaller ongoing GREEN scope.
+5. **AI/non-interactive fallback** — when a persistent watcher cannot be owned reliably, run the equivalent affected one-shot after each edit.
+6. **Repair the right boundary** — restart or reseed for stale or newly graph-visible relationships. For non-import/dynamic dependencies, configuration, global setup, public contracts, or shared-package uncertainty, add repository-owned triggers or widen to the owning suite/tier; restart alone cannot create an absent graph edge.
+7. **PR readiness** — stop every watcher, then follow the repository's mutation/alternate-evidence policy and complete non-watch PR gate. In a monorepo, that final gate includes every configured project and required integration/E2E suite, not only the development subset.
 
 Read [resources/vitest-watch-feedback.md](resources/vitest-watch-feedback.md) before selecting, adding, or changing a reusable Vitest watcher. It is the canonical detail for seed strategies, native discovery, blind spots, and the required live process proof.
 
@@ -317,9 +318,9 @@ The burden of proof is on the requester. 100% is the default expectation.
 
 ### Adding a New Feature
 
-1. **Write failing test** - describe expected behavior
-2. **Start focused feedback** - prefer the repository-owned watcher; otherwise use a diff-selected Vitest watcher only after its installed version/configuration has passed the canonical live proof, or use the affected one-shot equivalent
-3. **Run the narrow test** - confirm it fails for the expected reason
+1. **Honor the repository start point** - start its proven watcher before the first edit when required; otherwise start it immediately after RED
+2. **Write failing test** - describe expected behavior
+3. **Start or observe focused feedback** - prefer the repository-owned watcher; otherwise use a diff-selected Vitest watcher only after its installed version/configuration has passed the canonical live proof, or use the affected one-shot equivalent; confirm the expected test fails for the expected reason
 4. **Implement minimum** - just enough to pass
 5. **Run focused/affected tests** - confirm the behavior and its related tests pass
 6. **Refactor if applicable and valuable** - improve code structure while focused and affected tests stay green
@@ -331,14 +332,18 @@ The burden of proof is on the requester. 100% is the default expectation.
 ### Workflow Example
 
 ```bash
-# 1. Write failing test
+# 1. If the repository requires its watcher before the first edit, start it now:
+# pnpm test:watch
+
+# 2. Write failing test
 it('should reject empty user names', () => {
   const result = createUser({ id: 'user-123', name: '' });
   expect(result.success).toBe(false);
 }); # ❌ Test fails (no implementation)
 
-# 2. Start the tested repository watcher in a dedicated session. Starting after
-#    RED makes the expected initial execution easy to verify.
+# 3. If it is not already running, start the tested repository watcher now.
+#    Starting after RED makes the expected initial execution easy to verify when
+#    the repository does not mandate an earlier start.
 pnpm test:watch
 # If no repository watcher exists and this Vitest version/configuration has
 # passed the live proof:
@@ -346,29 +351,29 @@ pnpm exec vitest --changed origin/main --watch
 # Or use an affected one-shot:
 pnpm exec vitest --changed origin/main --run
 
-# 3. Confirm the expected RED test executed, then implement minimum code
+# 4. Confirm the expected RED test executed, then implement minimum code
 if (user.name === '') {
   return { success: false, error: 'Name required' };
 } # ✅ Test passes
 
-# 4. Refactor if needed (extract validation, improve naming)
+# 5. Refactor if needed (extract validation, improve naming)
 
-# 5. STOP — present the increment + ordinary verification, wait for commit approval
+# 6. STOP — present the increment + ordinary verification, wait for commit approval
 
-# 6. Commit (after approval)
+# 7. Commit (after approval)
 git add .
 git commit -m "feat: reject empty user names"
 
-# 7. Repeat RED-GREEN-REFACTOR increments without running the mutation harness
+# 8. Repeat RED-GREEN-REFACTOR increments without running the mutation harness
 
-# 8. After the final edit, stop the watcher with Ctrl+C. When the accumulated work
+# 9. After the final edit, stop the watcher with Ctrl+C. When the accumulated work
 #    is otherwise ready to create the PR, run the
 #    end-of-phase mutation gate once and address valuable survivors within it.
 
-# 9. Exit watch mode and finish the remaining PR verification, including the
+# 10. Exit watch mode and finish the remaining PR verification, including the
 #    inspected repository-defined complete non-watch test gate.
 
-# 10. If later verification changes mutation-relevant production or applicable
+#     If later verification changes mutation-relevant production or applicable
 #     tests/evidence, apply the target repository's invalidation rule. Use this
 #     distribution's commands/pr.md freshness model only when no stricter rule exists.
 #     Keep the complete non-watch project verification current for the final tree.

--- a/claude/.claude/skills/tdd/resources/vitest-watch-feedback.md
+++ b/claude/.claude/skills/tdd/resources/vitest-watch-feedback.md
@@ -39,7 +39,9 @@ Static graphs still miss filesystem reads, subprocess targets, templates, genera
 
 ## Prove a Reusable Watch Command
 
-When a repository introduces or changes a reusable watch command, exercise a live process. Prove the setup that command claims:
+When a repository introduces or changes a reusable watch command, exercise a live process through the exact repository-owned command and real test configuration. Do not replace it with raw Vitest or reconstruct a smaller configuration: that can prove a different watcher while broken package-script wiring, plugins, includes, or exclusions remain hidden. A proof may use a tightly validated test-only scope to keep the run bounded, but the production command and watch machinery must stay unchanged.
+
+Prove the setup that command claims:
 
 - **Graph-complete repository watch:** the complete intended development tier executes initially.
 - **Diff-selected strict TDD:** the changed/new RED test executes initially.
@@ -47,14 +49,16 @@ When a repository introduces or changes a reusable watch command, exercise a liv
 
 For every strategy, also prove:
 
-1. A matching test created after startup is discovered and executed.
-2. Changing an imported implementation reruns every affected test.
+1. A matching test created after startup is discovered and executed, imports an implementation, and reruns when that implementation changes.
+2. Changing an imported implementation reruns every affected test, while a graph-independent control test does not rerun.
 3. Tests excluded from the development tier remain excluded.
 4. A test that changes execution tier is not incorrectly retained.
 5. At least one expected test executes after the relevant change; zero tests and `--passWithNoTests` are rejected as test evidence.
 6. Assertions inspect output emitted after the implementation rerun, not a stale waiting marker.
-7. Normal completion and forced timeout leave no watcher process or temporary directory behind.
+7. Normal completion, spawn failure, early child exit, and forced timeout leave no watcher process or temporary directory behind.
 
-For deterministic automated fixtures on macOS, polling may be enabled inside the ephemeral fixture when native events for a newly created temporary root are unreliable. Do not enable polling in the real development command without evidence that it is needed.
+For deterministic automated fixtures on macOS, polling may be enabled inside the ephemeral fixture when native events for a newly created temporary root are unreliable. Do not enable polling in the real development command merely to make a reconstructed fixture pass. If the exact-command proof shows that an intended development environment—including a headless agent filesystem—misses real saves, that is evidence for bounded polling in the real watch configuration. Record the interval and CPU/latency trade-off, then rerun the exact-command proof.
 
 The proof harness is the only finite automation allowed to spawn watch mode. Bound it with a hard timeout, kill the entire watcher process group on every exit path, and remove its ephemeral fixture. Ordinary CI, hook, lint, test, build, and verification commands must remain finite; for Vitest they must use `vitest run`, `--run`, or `--watch=false`. Bare `vitest` can auto-watch in a TTY when neither CI nor Vitest's agent detection disables it, so never rely on environment detection for termination.
+
+Automation guards must inspect each shell command segment and accept watch or finite arguments in any position. A detector that only recognizes `watch`, `run`, or `--watch` immediately after `vitest` will miss commands such as `vitest --config vitest.config.ts --watch` or misclassify `vitest --config vitest.config.ts run`.

--- a/test/tdd-watch-workflow.sh
+++ b/test/tdd-watch-workflow.sh
@@ -112,22 +112,42 @@ assert_forbidden_claim_rejected() {
   fi
 }
 
-is_potential_vitest_watch_command() {
-  local command="$1"
+is_vitest_watch_segment() {
+  local segment="$1"
+  local arguments
 
-  if ! printf '%s\n' "$command" | grep -Eq -- '(^|[[:space:]])vitest([[:space:]]|$)'; then
+  if ! printf '%s\n' "$segment" | grep -Eq -- '(^|[[:space:]])vitest([[:space:]]|$)'; then
     return 1
   fi
 
-  if printf '%s\n' "$command" | grep -Eq -- '(^|[[:space:]])vitest[[:space:]]+watch([[:space:]]|$)|(^|[[:space:]])--watch(=true)?([[:space:]]|$)|(^|[[:space:]])-w(=true)?([[:space:]]|$)'; then
+  arguments="${segment#*vitest}"
+
+  if printf '%s\n' "$arguments" | grep -Eq -- '(^|[[:space:]])watch([[:space:]]|$)|(^|[[:space:]])--watch(=true)?([[:space:]]|$)|(^|[[:space:]])-w(=true)?([[:space:]]|$)'; then
     return 0
   fi
 
-  if printf '%s\n' "$command" | grep -Eq -- '(^|[[:space:]])vitest[[:space:]]+run([[:space:]]|$)|(^|[[:space:]])--run([[:space:]]|$)|--watch=false([[:space:]]|$)'; then
+  if printf '%s\n' "$arguments" | grep -Eq -- '(^|[[:space:]])(run|list|--run|--merge-reports|--help|-h|--version)([[:space:]]|$)|(^|[[:space:]])(--watch=false|-w=false)([[:space:]]|$)'; then
     return 1
   fi
 
   return 0
+}
+
+is_potential_vitest_watch_command() {
+  local command="$1"
+  local normalized segment
+
+  normalized="${command//&&/$'\n'}"
+  normalized="${normalized//||/$'\n'}"
+  normalized="${normalized//;/$'\n'}"
+
+  while IFS= read -r segment; do
+    if is_vitest_watch_segment "$segment"; then
+      return 0
+    fi
+  done <<< "$normalized"
+
+  return 1
 }
 
 require_watch_form_detected() {
@@ -235,8 +255,33 @@ require_text \
 
 require_text \
   "$VITEST_REFERENCE" \
-  "Normal completion and forced timeout leave no watcher process or temporary directory behind" \
+  "Normal completion, spawn failure, early child exit, and forced timeout leave no watcher process or temporary directory behind" \
   "vitest reference: live proof checks all cleanup paths"
+
+require_text \
+  "$VITEST_REFERENCE" \
+  "exact repository-owned command and real test configuration" \
+  "vitest reference: proof exercises the real repository command and config"
+
+require_text \
+  "$VITEST_REFERENCE" \
+  "while a graph-independent control test does not rerun" \
+  "vitest reference: proof checks an unrelated negative control"
+
+require_text \
+  "$VITEST_REFERENCE" \
+  "imports an implementation, and reruns when that implementation changes" \
+  "vitest reference: newly discovered tests retain implementation edges"
+
+require_text \
+  "$VITEST_REFERENCE" \
+  "including a headless agent filesystem" \
+  "vitest reference: exact-command evidence may justify bounded polling"
+
+require_text \
+  "$TDD_SKILL" \
+  "if it requires a proven watcher before the first edit, start it once now" \
+  "tdd: repository start timing overrides the generic after-RED example"
 
 require_regex \
   "$VITEST_REFERENCE" \
@@ -330,6 +375,9 @@ for command in \
   "vitest run --watch" \
   "vitest run -w" \
   "vitest watch --watch=false" \
+  "vitest --config vitest.config.ts --watch" \
+  "vitest run && vitest" \
+  "echo ready; vitest --config vitest.config.ts --watch" \
   "pnpm exec vitest --changed origin/main --watch"; do
   require_watch_form_detected "$command"
 done
@@ -338,7 +386,12 @@ for command in \
   "vitest run" \
   "vitest --run" \
   "vitest --watch=false" \
+  "vitest -w=false" \
   "vitest run --watch=false" \
+  "vitest --config vitest.config.ts run" \
+  "vitest --config vitest.config.ts list" \
+  "vitest --merge-reports .vitest-reports --coverage" \
+  "vitest run && vitest list" \
   "pnpm exec vitest run --coverage"; do
   require_finite_form_allowed "$command"
 done


### PR DESCRIPTION
## Why

Integrating the graph-backed watcher in
[Conquer Thoughts PR #489](https://github.com/citypaul/conquer-thoughts/pull/489) exposed
several gaps that are general enough to feed back into the global skills:

- a live proof can accidentally exercise raw Vitest and reconstructed configuration instead
  of the repository command users will run
- proving that affected tests rerun is incomplete without an unrelated negative control
- newly discovered tests must prove that their implementation edge is retained
- cleanup needs to cover spawn failure and early child exit, not only success and timeout
- repository-owned watcher start timing can conflict with a generic after-RED example
- automation detection must handle shell segments and watch or finite arguments after options
  such as `--config`
- headless filesystems may provide real evidence for bounded polling in the development
  configuration

## What changed

- requires live proofs to exercise the exact repository-owned command and real configuration
- allows only a tightly validated test-only scope to bound that proof
- adds new-test implementation-edge and graph-independent negative-control requirements
- expands cleanup evidence to spawn failure and early child exit
- makes repository-defined watcher start timing authoritative
- records when exact-command evidence can justify bounded polling for headless development
- hardens the policy regression detector for multiple shell segments and argument ordering
- adds a patch changeset

## Impact

Future repository watcher implementations should be harder to validate accidentally against a
different setup than developers and agents actually use. The guidance still leaves Vitest
responsible for native discovery and dependency-graph reruns.

## Validation

- `./test/tdd-watch-workflow.sh`
- `./test/run.sh`
- `git diff --check`

All passed.
