### PR TITLE
Add optional stacked pull request workflow

### DIFF
--- a/.changeset/clever-stacks-flow.md
+++ b/.changeset/clever-stacks-flow.md
@@ -1,0 +1,5 @@
+---
+"@paulhammond/dotfiles": minor
+---
+
+Add a stack-pull-requests skill that keeps story splitting vertical while making dependency-ordered PR stacks an optional, tested delivery tactic.

--- a/.changeset/clever-stacks-flow.md
+++ b/.changeset/clever-stacks-flow.md
@@ -1,5 +1,5 @@
 ---
-"@paulhammond/dotfiles": minor
+"@citypaul/dotfiles": minor
 ---
 
 Add a stack-pull-requests skill that keeps story splitting vertical while making dependency-ordered PR stacks an optional, tested delivery tactic.

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Unlike typical style guides, CLAUDE.md provides:
 | **Expectations** | Learning capture guidance, documentation templates, quality criteria | [→ skills/expectations](claude/.claude/skills/expectations/SKILL.md) |
 | **Planning** | Turn a selected child story into vertical implementation slices, or sequence a reducer-defined program, with a delivery shape for each slice | [→ skills/planning](claude/.claude/skills/planning/SKILL.md) |
 | **Story Splitting** | Turn broad stories, epics, features, and backlog items into independently valuable child stories; based on Tim Ottinger's story-splitting resource list and linked articles | [→ skills/story-splitting](claude/.claude/skills/story-splitting/SKILL.md) |
-| **Stack Pull Requests** | Decide whether one fixed implementation slice should use one PR or optional dependency-ordered review layers, then build, verify, review, update, and merge safely | [→ skills/stack-pull-requests](claude/.claude/skills/stack-pull-requests/SKILL.md) |
+| **Stack Pull Requests** | Decide whether vertical implementation work should use independent PRs or an optional hard-/flow-lineage stack across one or more slices, then deliver it safely | [→ skills/stack-pull-requests](claude/.claude/skills/stack-pull-requests/SKILL.md) |
 | **CI Debugging** | Systematic CI/CD failure diagnosis, hypothesis-first debugging, environment delta analysis | [→ skills/ci-debugging](claude/.claude/skills/ci-debugging/SKILL.md) |
 | **Production Parity Skill Builder** | Creates app-specific skills that inspect docs, code, tests, CI, deployment, infrastructure, config, auth, and environment setup to catch drift between production and non-production environments | [→ skills/production-parity-skill-builder](claude/.claude/skills/production-parity-skill-builder/SKILL.md) |
 | **Structure Codebase** | Selects the lightest honest source-tree shape: first-class frontend structures, visible hexagonal boundaries when earned, and feature-, context-, endpoint-, workflow-, framework-, or shallow forms elsewhere; package/import enforcement and safe migrations | [→ skills/structure-codebase](claude/.claude/skills/structure-codebase/SKILL.md) |
@@ -151,7 +151,7 @@ Unlike typical style guides, CLAUDE.md provides:
 | Requirement is still fuzzy or decision-heavy | [grill-me](https://skills.sh/mattpocock/skills/grill-me) | Pressure-test the decision tree one question at a time before writing stories or plans |
 | Turning a broad requirement into stories | [story-splitting](claude/.claude/skills/story-splitting/SKILL.md) | Produce independently valuable child stories with scope, deferrals, and acceptance examples |
 | Planning significant implementation work | [planning](claude/.claude/skills/planning/SKILL.md) | Sequence a selected child story vertically, or a reducer-defined program, and choose each slice's delivery shape |
-| One planned slice is too large for effective review | [stack-pull-requests](claude/.claude/skills/stack-pull-requests/SKILL.md) | Choose one PR or a justified dependency-ordered stack without turning technical layers into stories |
+| One slice is too large, or later slices should start before lower PRs merge | [stack-pull-requests](claude/.claude/skills/stack-pull-requests/SKILL.md) | Choose independent PRs or a justified hard-/flow-lineage stack without turning technical layers into stories |
 | Tightening a story, plan, AC set, or mock | [find-gaps](claude/.claude/skills/find-gaps/SKILL.md) | Find missing decisions and write confirmed answers back into the artifact |
 | Backlog items keep turning into frontend/backend tickets | [story-splitting](claude/.claude/skills/story-splitting/SKILL.md) | Reject component stories; split by capability, path, interface, data, rules, quality, or learning |
 | CI pipeline keeps failing | [ci-debugging](claude/.claude/skills/ci-debugging/SKILL.md) | Every failure is real until proven otherwise, hypothesis-first diagnosis |
@@ -207,7 +207,7 @@ Skills are **auto-discovered** by Claude when relevant:
 - Designing API endpoints? → `api-design` skill provides contract-first patterns
 - Building or reviewing OAuth/OIDC? → `secure-oauth-oidc` applies RFC 9700 plus the relevant identity and extension profiles
 - Splitting epics, large stories, or backlog items? → `story-splitting` preserves vertical user-value slices
-- One fixed implementation slice is hard to review as one PR? → `stack-pull-requests` decides whether dependent review layers earn their coordination cost
+- One slice is hard to review, or later slices should start before lower PRs merge? → `stack-pull-requests` decides whether a hard-/flow-lineage stack earns its coordination cost
 - Investigating local/prod drift? → `production-parity-skill-builder` creates an app-specific parity skill from docs, source, tests, config, auth, and infra
 - Code with hard-to-test dependencies? → `finding-seams` skill identifies substitution points
 - Changing code with no tests? → `characterisation-tests` skill documents existing behavior
@@ -226,7 +226,7 @@ For product work, the skills form a requirements-to-code pipeline. Each skill ow
 | 2. Split | What independently valuable child stories exist? | `story-splitting` | Child stories with value, scope, deferrals, acceptance examples, and release constraints |
 | 3. Tighten | What is missing, ambiguous, unverifiable, or unsafe? | `find-gaps` | Confirmed artifact updates: AC, plan paragraphs, mock-state specs, or a return to `story-splitting` |
 | 4. Select technology when needed | Should we reuse, adopt, adapt, combine, build, defer, or do nothing? | `evaluate-existing-solutions` | Current evidence, hard gates, qualitative trade-offs, ownership, and exit strategy |
-| 5. Plan | How do we implement the selected child story safely? | `planning` | Implementation slices with per-slice single-PR or stack delivery in `plans/` |
+| 5. Plan | How do we implement the selected child story safely? | `planning` | Vertical slices with independent-PR or explicit dependency-stack delivery in `plans/` |
 | 6. Build | How do we change code without outrunning tests? | `tdd` + `testing` + applicable `refactoring`, then `mutation-testing` at PR readiness | RED-GREEN-REFACTOR for behavior change; verified preservation path for pure restructuring; one accumulated-scope mutation gate before PR |
 
 Use the earliest stage that matches the uncertainty. Skip `grill-me` when the decision is already clear. Skip `story-splitting` for tiny or already-narrow work. Use `find-gaps` only once there is an artifact to inspect. Use technology selection proportionately for a material generic mechanism or durable new dependency—not domain logic, small glue, routine use of an already-adopted tool, or ordinary fixes. Use `planning` only after one child story or narrow capability and any consequential technology choice have been selected.
@@ -1457,9 +1457,9 @@ This is the full lifecycle for working on a feature, from project setup through 
 /plan  →  Creates a plan in plans/ on a branch with a PR — no code, just the plan
 ```
 
-**Why before code:** Planning in a separate phase prevents the most common friction point — Claude jumping straight to implementation before the approach is agreed. The plan becomes a PR you can review and approve before any code is written. Each slice defaults to one PR; `stack-pull-requests` may give one fixed slice dependent review layers when that improves review without weakening evidence or release safety.
+**Why before code:** Planning in a separate phase prevents the most common friction point — Claude jumping straight to implementation before the approach is agreed. The plan becomes a PR you can review and approve before any code is written. Each slice defaults to one trunk-based PR; `stack-pull-requests` may add review layers inside one slice or link hard-/flow-lineage vertical slices when work should proceed before lower reviews merge.
 
-#### Phase 3: Implement (repeat fast increments within each slice or PR layer)
+#### Phase 3: Implement (repeat fast increments within each slice or PR boundary)
 
 ```
 LOAD         →  Behavior change: tdd + testing + refactoring; preservation: applicable testing/refactoring/reduction skills
@@ -1469,7 +1469,7 @@ REFACTOR / REDUCE →  Run only the applicable assessment and any claimed reduct
 COMMIT       →  Wait for approval, then commit
 ```
 
-**Why this order:** RED-GREEN-REFACTOR keeps implementation feedback fast. The mutation harness does not run after each test, increment, refactor, or commit; it runs once when the current review boundary is otherwise PR-ready. Pure refactors or reductions enter at a passing proportionate-evidence path rather than inventing RED or structural mutants. Tests stay with the earliest stack layer that owns their behavior.
+**Why this order:** RED-GREEN-REFACTOR keeps implementation feedback fast. The mutation harness does not run after each test, increment, refactor, or commit; it runs once when the current review boundary is otherwise PR-ready. Pure refactors or reductions enter at a passing proportionate-evidence path rather than inventing RED or structural mutants. Tests stay with the earliest PR boundary that owns their behavior.
 
 #### Phase 4: Pre-PR Quality Gate
 
@@ -1483,16 +1483,16 @@ Before creating any PR, run these checks in order:
   4. remaining checks  →  Run typecheck + lint + test + build, then create the PR
 ```
 
-**Why evidence at PR readiness:** One focused run per review boundary verifies that the completed implementation and refactoring would catch behavioral faults without taxing every inner TDD loop. A stacked layer uses its immediate parent as the boundary; the top also proves the complete slice. When the affected mechanism is unreachable, declarative, contractual, integrational, or operational, an explicit `N/A` plus proportionate alternate evidence is more honest.
+**Why evidence at PR readiness:** One focused run per review boundary verifies that the completed implementation and refactoring would catch behavioral faults without taxing every inner TDD loop. A stacked boundary uses its immediate parent as the review base; the top proves the cumulative criteria for every included slice. When the affected mechanism is unreachable, declarative, contractual, integrational, or operational, an explicit `N/A` plus proportionate alternate evidence is more honest.
 
 #### Phase 5: Continue
 
 ```
-Sequential slice  →  /continue updates trunk and creates the next independent branch
-Stacked slice     →  /continue adds a layer from the current top or syncs after lower merges
+Independent slice →  /continue updates trunk and creates the next independent branch
+Stack              →  /continue adds a dependent layer or slice from the current top, or syncs after lower merges
 ```
 
-**Why a command for this:** Sequential slices return to trunk after each merge. Stacked layers stay based on the layer below until bottom-up merge and sync. `/continue` reads the per-slice delivery shape before choosing either topology.
+**Why a command for this:** Independent slices return to trunk. Stacked PRs keep an explicit parent branch until bottom-up merge and sync, whether a PR owns a whole dependent slice or an intra-slice layer. `/continue` reads the delivery map before choosing either topology.
 
 #### Phase 6: Capture Knowledge (throughout and at the end)
 

--- a/README.md
+++ b/README.md
@@ -88,8 +88,9 @@ Unlike typical style guides, CLAUDE.md provides:
 | **Evaluate Existing Solutions** | Local-first, current evidence for adopt/adapt/combine/build decisions across primitives, libraries, tools, applications, frameworks, and services | [→ skills/evaluate-existing-solutions](claude/.claude/skills/evaluate-existing-solutions/SKILL.md) |
 | **Functional Programming** | Immutability violations catalog, pure functions, composition patterns | [→ skills/functional](claude/.claude/skills/functional/SKILL.md) |
 | **Expectations** | Learning capture guidance, documentation templates, quality criteria | [→ skills/expectations](claude/.claude/skills/expectations/SKILL.md) |
-| **Planning** | Turn a selected child story into vertical delivery slices, or sequence a reducer-defined program through explicit transition and terminal slices | [→ skills/planning](claude/.claude/skills/planning/SKILL.md) |
+| **Planning** | Turn a selected child story into vertical implementation slices, or sequence a reducer-defined program, with a delivery shape for each slice | [→ skills/planning](claude/.claude/skills/planning/SKILL.md) |
 | **Story Splitting** | Turn broad stories, epics, features, and backlog items into independently valuable child stories; based on Tim Ottinger's story-splitting resource list and linked articles | [→ skills/story-splitting](claude/.claude/skills/story-splitting/SKILL.md) |
+| **Stack Pull Requests** | Decide whether one fixed implementation slice should use one PR or optional dependency-ordered review layers, then build, verify, review, update, and merge safely | [→ skills/stack-pull-requests](claude/.claude/skills/stack-pull-requests/SKILL.md) |
 | **CI Debugging** | Systematic CI/CD failure diagnosis, hypothesis-first debugging, environment delta analysis | [→ skills/ci-debugging](claude/.claude/skills/ci-debugging/SKILL.md) |
 | **Production Parity Skill Builder** | Creates app-specific skills that inspect docs, code, tests, CI, deployment, infrastructure, config, auth, and environment setup to catch drift between production and non-production environments | [→ skills/production-parity-skill-builder](claude/.claude/skills/production-parity-skill-builder/SKILL.md) |
 | **Structure Codebase** | Selects the lightest honest source-tree shape: first-class frontend structures, visible hexagonal boundaries when earned, and feature-, context-, endpoint-, workflow-, framework-, or shallow forms elsewhere; package/import enforcement and safe migrations | [→ skills/structure-codebase](claude/.claude/skills/structure-codebase/SKILL.md) |
@@ -149,7 +150,8 @@ Unlike typical style guides, CLAUDE.md provides:
 | Losing context on complex features | [expectations](claude/.claude/skills/expectations/SKILL.md) | Learning capture framework (7 criteria) |
 | Requirement is still fuzzy or decision-heavy | [grill-me](https://skills.sh/mattpocock/skills/grill-me) | Pressure-test the decision tree one question at a time before writing stories or plans |
 | Turning a broad requirement into stories | [story-splitting](claude/.claude/skills/story-splitting/SKILL.md) | Produce independently valuable child stories with scope, deferrals, and acceptance examples |
-| Planning significant implementation work | [planning](claude/.claude/skills/planning/SKILL.md) | Sequence a selected child story vertically, or a reducer-defined program through truthful transition/terminal slices |
+| Planning significant implementation work | [planning](claude/.claude/skills/planning/SKILL.md) | Sequence a selected child story vertically, or a reducer-defined program, and choose each slice's delivery shape |
+| One planned slice is too large for effective review | [stack-pull-requests](claude/.claude/skills/stack-pull-requests/SKILL.md) | Choose one PR or a justified dependency-ordered stack without turning technical layers into stories |
 | Tightening a story, plan, AC set, or mock | [find-gaps](claude/.claude/skills/find-gaps/SKILL.md) | Find missing decisions and write confirmed answers back into the artifact |
 | Backlog items keep turning into frontend/backend tickets | [story-splitting](claude/.claude/skills/story-splitting/SKILL.md) | Reject component stories; split by capability, path, interface, data, rules, quality, or learning |
 | CI pipeline keeps failing | [ci-debugging](claude/.claude/skills/ci-debugging/SKILL.md) | Every failure is real until proven otherwise, hypothesis-first diagnosis |
@@ -205,6 +207,7 @@ Skills are **auto-discovered** by Claude when relevant:
 - Designing API endpoints? → `api-design` skill provides contract-first patterns
 - Building or reviewing OAuth/OIDC? → `secure-oauth-oidc` applies RFC 9700 plus the relevant identity and extension profiles
 - Splitting epics, large stories, or backlog items? → `story-splitting` preserves vertical user-value slices
+- One fixed implementation slice is hard to review as one PR? → `stack-pull-requests` decides whether dependent review layers earn their coordination cost
 - Investigating local/prod drift? → `production-parity-skill-builder` creates an app-specific parity skill from docs, source, tests, config, auth, and infra
 - Code with hard-to-test dependencies? → `finding-seams` skill identifies substitution points
 - Changing code with no tests? → `characterisation-tests` skill documents existing behavior
@@ -223,7 +226,7 @@ For product work, the skills form a requirements-to-code pipeline. Each skill ow
 | 2. Split | What independently valuable child stories exist? | `story-splitting` | Child stories with value, scope, deferrals, acceptance examples, and release constraints |
 | 3. Tighten | What is missing, ambiguous, unverifiable, or unsafe? | `find-gaps` | Confirmed artifact updates: AC, plan paragraphs, mock-state specs, or a return to `story-splitting` |
 | 4. Select technology when needed | Should we reuse, adopt, adapt, combine, build, defer, or do nothing? | `evaluate-existing-solutions` | Current evidence, hard gates, qualitative trade-offs, ownership, and exit strategy |
-| 5. Plan | How do we implement the selected child story safely? | `planning` | PR-sized implementation slices in `plans/` |
+| 5. Plan | How do we implement the selected child story safely? | `planning` | Implementation slices with per-slice single-PR or stack delivery in `plans/` |
 | 6. Build | How do we change code without outrunning tests? | `tdd` + `testing` + applicable `refactoring`, then `mutation-testing` at PR readiness | RED-GREEN-REFACTOR for behavior change; verified preservation path for pure restructuring; one accumulated-scope mutation gate before PR |
 
 Use the earliest stage that matches the uncertainty. Skip `grill-me` when the decision is already clear. Skip `story-splitting` for tiny or already-narrow work. Use `find-gaps` only once there is an artifact to inspect. Use technology selection proportionately for a material generic mechanism or durable new dependency—not domain logic, small glue, routine use of an already-adopted tool, or ordinary fixes. Use `planning` only after one child story or narrow capability and any consequential technology choice have been selected.
@@ -275,7 +278,7 @@ it("should reject payments with negative amounts", () => {
 **Problem it solves:** 100% code coverage but bugs still slip through; tests that don't actually verify behavior; weak assertions that pass regardless of code correctness
 
 **What's inside:**
-- Stryker-first workflow for full-project, incremental, and diff-against-main mutation runs
+- Stryker-first workflow for full-project, incremental, and focused mutation runs against the current review base
 - A single end-of-phase PR-readiness gate instead of mutation runs after every TDD increment
 - Setup guidance for projects that do not already have a mutation testing harness
 - Survivor triage: fix obvious gaps immediately, ask for human judgment on subtle domain questions
@@ -1429,7 +1432,7 @@ Five slash commands that encode common workflows into single invocations:
 | **`/setup`** | One-shot project onboarding — detect tech stack, create CLAUDE.md, hooks, commands, and PR reviewer | Starting work on a new project (replaces `/init`) |
 | **`/pr`** | Create a pull request following standards | When ready to submit work |
 | **`/plan`** | Create a plan document on a branch with a PR — no code changes | When planning work before implementation |
-| **`/continue`** | Pull merged PR, create new branch, update plan | After a PR is merged and you want to continue |
+| **`/continue`** | Continue after a merged independent PR or advance/sync a stack | Moving to the next slice or dependent layer |
 | **`/generate-pr-review`** | Generate project-specific PR review automation | One-time setup per project |
 
 ### Recommended Flow
@@ -1454,9 +1457,9 @@ This is the full lifecycle for working on a feature, from project setup through 
 /plan  →  Creates a plan in plans/ on a branch with a PR — no code, just the plan
 ```
 
-**Why before code:** Planning in a separate phase prevents the most common friction point — Claude jumping straight to implementation before the approach is agreed. The plan becomes a PR you can review and approve before any code is written. Each behavior-changing slice specifies its failing test; a true behavior-preserving refactor or reduction instead specifies passing proportionate preservation evidence and applicable gates.
+**Why before code:** Planning in a separate phase prevents the most common friction point — Claude jumping straight to implementation before the approach is agreed. The plan becomes a PR you can review and approve before any code is written. Each slice defaults to one PR; `stack-pull-requests` may give one fixed slice dependent review layers when that improves review without weakening evidence or release safety.
 
-#### Phase 3: Implement (repeat fast increments within each slice)
+#### Phase 3: Implement (repeat fast increments within each slice or PR layer)
 
 ```
 LOAD         →  Behavior change: tdd + testing + refactoring; preservation: applicable testing/refactoring/reduction skills
@@ -1466,7 +1469,7 @@ REFACTOR / REDUCE →  Run only the applicable assessment and any claimed reduct
 COMMIT       →  Wait for approval, then commit
 ```
 
-**Why this order:** RED-GREEN-REFACTOR keeps implementation feedback fast. The mutation harness does not run after each test, increment, refactor, or commit; its runtime grows with the codebase. Pure refactors or reductions enter at a passing proportionate-evidence path rather than inventing RED or structural mutants. `tdd-guardian` catches behavior written before tests, `ts-enforcer` catches type safety violations, and `refactor-scan` can run as soon as GREEN provides a passing behavior-test baseline. Each increment remains small and reviewable.
+**Why this order:** RED-GREEN-REFACTOR keeps implementation feedback fast. The mutation harness does not run after each test, increment, refactor, or commit; it runs once when the current review boundary is otherwise PR-ready. Pure refactors or reductions enter at a passing proportionate-evidence path rather than inventing RED or structural mutants. Tests stay with the earliest stack layer that owns their behavior.
 
 #### Phase 4: Pre-PR Quality Gate
 
@@ -1475,20 +1478,21 @@ Before creating any PR, run these checks in order:
 ```
 /pr →
   1. phase complete    →  Verify implementation and applicable refactoring/reduction work are finished
-  2. mutation gate     →  Run mutation testing once for the accumulated PR scope, or record explicit `N/A` plus proportionate alternate evidence
+  2. mutation gate     →  Run mutation testing once against trunk or the immediate stack parent, or record explicit `N/A` plus proportionate alternate evidence
   3. survivor handling →  Address valuable survivors; re-run focused/diff mutation checks inside the same gate
   4. remaining checks  →  Run typecheck + lint + test + build, then create the PR
 ```
 
-**Why evidence at PR readiness:** One accumulated-scope run verifies that the completed implementation and refactoring would catch behavioral faults without taxing every inner TDD loop. Once the gate starts, surviving mutants are handled normally and scoped mutation checks are rerun until the report is ready. When the affected mechanism is unreachable, declarative, contractual, integrational, or operational, an explicit `N/A` plus proportionate alternate evidence is more honest.
+**Why evidence at PR readiness:** One focused run per review boundary verifies that the completed implementation and refactoring would catch behavioral faults without taxing every inner TDD loop. A stacked layer uses its immediate parent as the boundary; the top also proves the complete slice. When the affected mechanism is unreachable, declarative, contractual, integrational, or operational, an explicit `N/A` plus proportionate alternate evidence is more honest.
 
-#### Phase 5: Continue to the Next Slice
+#### Phase 5: Continue
 
 ```
-/continue  →  Pulls merged PR, creates new branch, updates plan, shows next slice
+Sequential slice  →  /continue updates trunk and creates the next independent branch
+Stacked slice     →  /continue adds a layer from the current top or syncs after lower merges
 ```
 
-**Why a command for this:** After a PR is merged, you need to pull main, create a new branch, and figure out where you left off. `/continue` does all of this and updates the plan document so you have immediate context for the next slice. This eliminates the repetitive "pull, branch, update plan" sequence between PRs.
+**Why a command for this:** Sequential slices return to trunk after each merge. Stacked layers stay based on the layer below until bottom-up merge and sync. `/continue` reads the per-slice delivery shape before choosing either topology.
 
 #### Phase 6: Capture Knowledge (throughout and at the end)
 
@@ -1525,7 +1529,7 @@ docs-guardian     →  Updates user-facing documentation
 
 ### How the Workflow Works (Regardless of Installation Method)
 
-Once installed, the full development lifecycle is: `/setup` → `/plan` → fast RED-GREEN-REFACTOR increments → end-of-phase mutation gate in `/pr` → `/continue` → repeat. See the [Recommended Flow](#recommended-flow) in the Slash Commands section for the detailed walkthrough with rationale for each phase.
+Once installed, the full development lifecycle is: `/setup` → `/plan` → single-PR or stack delivery → fast RED-GREEN-REFACTOR or preservation increments → end-of-boundary evidence gate in `/pr` → `/continue` → repeat. See the [Recommended Flow](#recommended-flow) in the Slash Commands section for the detailed walkthrough with rationale for each phase.
 
 **Agent invocation examples:**
 
@@ -1606,7 +1610,7 @@ All three layouts expose the same complete bundle. Include `--agent codex` when 
 **What gets installed:**
 - ✅ `~/.claude/CLAUDE.md` (~160 lines - lean core principles)
 - ✅ `~/.claude/skills/` — installed via [skills.sh](https://skills.sh) (`npx skills add`):
-  - [citypaul/.dotfiles](https://skills.sh/citypaul/.dotfiles) — auto-discovered first-party patterns (tdd, testing, mutation-testing, typescript-strict, functional, refactoring, planning, story-splitting, front-end-testing, react-testing, event-sourcing, and more)
+  - [citypaul/.dotfiles](https://skills.sh/citypaul/.dotfiles) — auto-discovered first-party patterns (tdd, testing, mutation-testing, typescript-strict, functional, refactoring, planning, story-splitting, stack-pull-requests, front-end-testing, react-testing, event-sourcing, and more)
   - [pbakaus/impeccable](https://skills.sh/pbakaus/impeccable) — frontend design vocabulary + 17 steering commands
   - [addyosmani/web-quality-skills](https://skills.sh/addyosmani/web-quality-skills) — accessibility, performance, SEO, core-web-vitals, best-practices, web-quality-audit
   - [vercel-labs/next-skills](https://skills.sh/vercel-labs/next-skills) — Next.js best practices, Cache Components, and upgrade workflow

--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -18,7 +18,7 @@
 
 I follow Test-Driven Development (TDD) with a strong emphasis on behavior-driven testing and functional programming principles. All work should be done in small, incremental changes that maintain a working state throughout development.
 
-For mutation-testing cadence, a **phase of work** means one PR review boundary. Normally that is one PR-sized, independently mergeable slice; inside an approved stack it is one focused dependent layer. It does not mean a multi-PR feature/stack as a whole or the numbered lifecycle phases in `README.md`.
+For mutation-testing cadence, a **phase of work** means one PR review boundary. Normally that is one PR-sized, independently mergeable slice; in a cross-slice stack it is one whole-slice member, and in an intra-slice stack it is one focused dependent layer. It does not mean a multi-PR feature/stack as a whole or the numbered lifecycle phases in `README.md`.
 
 ## Quick Reference
 
@@ -106,7 +106,7 @@ For naming domain concepts, glossary work, or any new/changed domain term — th
 For broad stories, epics, features, or backlog items, load `story-splitting` to create child stories before planning.
 For tightening an existing story, plan, acceptance criteria set, or mock spec, load `find-gaps` to write confirmed answers back into the artifact.
 For significant implementation work, load `planning` to turn one selected child story or narrow capability into implementation plans in `plans/`.
-For a planned vertical implementation slice that may be too large for one effective review, load `stack-pull-requests` with `planning` to choose one PR or an optional dependency-ordered PR stack without turning technical layers into stories or slices.
+When one planned vertical slice may be too large for review, or later slices should start on the same evolving baseline before lower PRs merge, load `stack-pull-requests` with `planning` to choose independent PRs or an explicit hard-/flow-lineage stack without turning technical layers into stories or slices.
 For CI failure diagnosis, load the `ci-debugging` skill.
 For hexagonal architecture projects, load the `hexagonal-architecture` skill.
 For Domain-Driven Design projects, load the `domain-driven-design` skill.

--- a/claude/.claude/CLAUDE.md
+++ b/claude/.claude/CLAUDE.md
@@ -4,7 +4,7 @@
 >
 > **Architecture:**
 > - **CLAUDE.md** (this file): Core philosophy + quick reference (~160 lines, always loaded)
-> - **Skills**: Detailed patterns loaded on-demand (specification, ubiquitous-language, tdd, testing, mutation-testing, test-design-reviewer, typescript-strict, functional, refactoring, reduce-system-complexity, expectations, planning, story-splitting, front-end-testing, react-testing, ci-debugging, hexagonal-architecture, domain-driven-design, event-sourcing, twelve-factor, api-design, bff-design, bff-entry-points, cli-design, codebase-design, improve-codebase-architecture, structure-codebase, evaluate-existing-solutions, finding-seams, characterisation-tests, production-parity-skill-builder, storyboard, teach-me, diagrams, technical-writing, find-skills, find-gaps, double-check)
+> - **Skills**: Detailed patterns loaded on-demand (specification, ubiquitous-language, tdd, testing, mutation-testing, test-design-reviewer, typescript-strict, functional, refactoring, reduce-system-complexity, expectations, planning, story-splitting, stack-pull-requests, front-end-testing, react-testing, ci-debugging, hexagonal-architecture, domain-driven-design, event-sourcing, twelve-factor, api-design, bff-design, bff-entry-points, cli-design, codebase-design, improve-codebase-architecture, structure-codebase, evaluate-existing-solutions, finding-seams, characterisation-tests, production-parity-skill-builder, storyboard, teach-me, diagrams, technical-writing, find-skills, find-gaps, double-check)
 > - **External skills**: Loaded on-demand from community repos (impeccable + 17 steering commands from [pbakaus/impeccable](https://github.com/pbakaus/impeccable), 6 web quality skills from [addyosmani/web-quality-skills](https://github.com/addyosmani/web-quality-skills), 3 Next.js skills from [vercel-labs/next-skills](https://skills.sh/vercel-labs/next-skills), grill-me from [mattpocock/skills](https://skills.sh/mattpocock/skills/grill-me), seo-audit from [coreyhaines31/marketingskills](https://skills.sh/coreyhaines31/marketingskills/seo-audit))
 > - **Agents**: Specialized subprocesses for verification and analysis
 >
@@ -18,7 +18,7 @@
 
 I follow Test-Driven Development (TDD) with a strong emphasis on behavior-driven testing and functional programming principles. All work should be done in small, incremental changes that maintain a working state throughout development.
 
-For mutation-testing cadence, a **phase of work** means one PR-sized, independently mergeable slice: the accumulated scope of one branch and PR. It does not mean a multi-PR feature or the numbered lifecycle phases in `README.md`.
+For mutation-testing cadence, a **phase of work** means one PR review boundary. Normally that is one PR-sized, independently mergeable slice; inside an approved stack it is one focused dependent layer. It does not mean a multi-PR feature/stack as a whole or the numbered lifecycle phases in `README.md`.
 
 ## Quick Reference
 
@@ -105,7 +105,8 @@ For turning fuzzy intent into shared understanding and acceptance criteria — s
 For naming domain concepts, glossary work, or any new/changed domain term — the five-step language protocol, never silent coinage — load the `ubiquitous-language` skill.
 For broad stories, epics, features, or backlog items, load `story-splitting` to create child stories before planning.
 For tightening an existing story, plan, acceptance criteria set, or mock spec, load `find-gaps` to write confirmed answers back into the artifact.
-For significant implementation work, load `planning` to turn one selected child story or narrow capability into PR-sized plans in `plans/`.
+For significant implementation work, load `planning` to turn one selected child story or narrow capability into implementation plans in `plans/`.
+For a planned vertical implementation slice that may be too large for one effective review, load `stack-pull-requests` with `planning` to choose one PR or an optional dependency-ordered PR stack without turning technical layers into stories or slices.
 For CI failure diagnosis, load the `ci-debugging` skill.
 For hexagonal architecture projects, load the `hexagonal-architecture` skill.
 For Domain-Driven Design projects, load the `domain-driven-design` skill.

--- a/claude/.claude/agents/README.md
+++ b/claude/.claude/agents/README.md
@@ -218,13 +218,13 @@ progress-guardian (orchestrates)
     │
     ├─► Creates: plans/<name>.md
     │
-    ├─► For each implementation increment:
+    ├─► For each implementation increment in the current slice or PR layer:
     │   ├─→ tdd-guardian (RED-GREEN-REFACTOR)
     │   ├─→ ts-enforcer (before commits)
     │   └─→ refactor-scan (after GREEN or another passing baseline, when applicable)
     │
-    ├─► At end-of-phase PR readiness:
-    │   └─→ mutation-testing (once for the accumulated scope, then survivor handling)
+    ├─► At end-of-phase PR readiness for each review boundary:
+    │   └─→ mutation-testing (once against trunk or the immediate stack parent, then survivor handling)
     │
     ├─► When decisions arise:
     │   └─→ adr (architectural decisions)
@@ -242,7 +242,7 @@ progress-guardian (orchestrates)
 
 ### Typical Workflow
 
-**Recommended command flow:** `/setup` → `/plan` → behavior-change TDD or preservation-only REFACTOR/reduction path → `/pr` → `/continue` → repeat
+**Recommended command flow:** `/setup` → `/plan` → chosen single-PR or stack delivery → applicable evidence path → `/pr` → `/continue` → repeat
 
 1. **Onboard project** (once)
    - Run `/setup` to detect tech stack and generate project-level config
@@ -250,6 +250,7 @@ progress-guardian (orchestrates)
 
 2. **Plan the work** (before writing any code)
    - Run `/plan` to create a plan in `plans/` on a branch with a PR
+   - Default every implementation slice to one PR; use `stack-pull-requests` only when one fixed slice needs dependent review layers
    - Get approval for the plan before writing any code
 
 3. **For each step in plan**
@@ -274,14 +275,15 @@ progress-guardian (orchestrates)
 7. **Pre-PR quality gate**
    - Verify each implemented slice loaded the skills for its behavior-changing or preservation-only path
    - Confirm implementation and applicable refactoring/reduction assessment are complete
-   - Run mutation testing once for the accumulated PR scope where meaningful, or review the documented alternate evidence and `N/A`
+   - Run mutation testing once for the actual review boundary where meaningful—trunk for one PR, the immediate parent for a stacked layer—or review the documented alternate evidence and `N/A`
    - Address valuable survivors and re-run focused/diff mutation checks within that same gate
    - Invoke `pr-reviewer`: Self-review changes
    - Fix any issues found
    - Run `/pr` to create PR with quality gates (TDD evidence + mutation testing + refactoring assessment + typecheck + lint; project-generated `/pr` commands also run tests and build)
 
 8. **Continue to next step**
-   - After PR is merged, run `/continue` to pull main, create new branch, update plan
+   - Sequential slice: after its PR merges, run `/continue` to update trunk and branch the next independent slice
+   - Stacked slice: run `/continue` from the committed, known-good current top to add the next layer; after lower merges, use it to sync the remaining stack
 
 9. **Feature complete**
    - Verify all acceptance criteria met

--- a/claude/.claude/agents/README.md
+++ b/claude/.claude/agents/README.md
@@ -218,7 +218,7 @@ progress-guardian (orchestrates)
     │
     ├─► Creates: plans/<name>.md
     │
-    ├─► For each implementation increment in the current slice or PR layer:
+    ├─► For each implementation increment in the current slice or PR boundary:
     │   ├─→ tdd-guardian (RED-GREEN-REFACTOR)
     │   ├─→ ts-enforcer (before commits)
     │   └─→ refactor-scan (after GREEN or another passing baseline, when applicable)
@@ -250,7 +250,7 @@ progress-guardian (orchestrates)
 
 2. **Plan the work** (before writing any code)
    - Run `/plan` to create a plan in `plans/` on a branch with a PR
-   - Default every implementation slice to one PR; use `stack-pull-requests` only when one fixed slice needs dependent review layers
+   - Default every implementation slice to one trunk-based PR; use `stack-pull-requests` when one slice needs review layers or later slices should start on the same evolving baseline before lower PRs merge
    - Get approval for the plan before writing any code
 
 3. **For each step in plan**
@@ -275,18 +275,18 @@ progress-guardian (orchestrates)
 7. **Pre-PR quality gate**
    - Verify each implemented slice loaded the skills for its behavior-changing or preservation-only path
    - Confirm implementation and applicable refactoring/reduction assessment are complete
-   - Run mutation testing once for the actual review boundary where meaningful—trunk for one PR, the immediate parent for a stacked layer—or review the documented alternate evidence and `N/A`
+   - Run mutation testing once for the actual review boundary where meaningful—trunk for one PR, the immediate parent for a stacked boundary—or review the documented alternate evidence and `N/A`
    - Address valuable survivors and re-run focused/diff mutation checks within that same gate
    - Invoke `pr-reviewer`: Self-review changes
    - Fix any issues found
    - Run `/pr` to create PR with quality gates (TDD evidence + mutation testing + refactoring assessment + typecheck + lint; project-generated `/pr` commands also run tests and build)
 
 8. **Continue to next step**
-   - Sequential slice: after its PR merges, run `/continue` to update trunk and branch the next independent slice
-   - Stacked slice: run `/continue` from the committed, known-good current top to add the next layer; after lower merges, use it to sync the remaining stack
+   - Independent slice: after its PR merges, run `/continue` to update trunk and branch the next independent slice
+   - Stack: run `/continue` from the committed, known-good current top to add the next intra-slice layer or dependent slice; after lower merges, use it to sync the remaining stack
 
 9. **Feature complete**
-   - Verify all acceptance criteria met
+   - Verify every owning PR landed and all acceptance criteria are met
    - Invoke `learn`: Merge gotchas/patterns → CLAUDE.md
    - Invoke `adr`: Create ADRs for architectural decisions
    - Invoke `docs-guardian`: Update permanent docs

--- a/claude/.claude/agents/progress-guardian.md
+++ b/claude/.claude/agents/progress-guardian.md
@@ -68,7 +68,7 @@ For a behavior-change delivery plan, describe observable behavior. For a reducti
 
 ## Slices
 
-Classify every slice as **behavior change**, **pure refactor**, **reduction transition**, or **terminal reduction**. Delivery slices should be the thinnest useful end-to-end behavior. Default each slice to one PR; if one slice needs dependent review layers, nest the map from `stack-pull-requests` beneath it without expanding scope or terminal obligations. Every reduction transition and terminal reduction loads `reduce-system-complexity` and references the plan-level reduction program. A transition may add a bounded bridge but keeps `mechanism gate: pending — no net-reduction claim`; only the terminal slice may claim net removal after both gates pass.
+Classify every slice as **behavior change**, **pure refactor**, **reduction transition**, or **terminal reduction**. Delivery slices should be the thinnest useful end-to-end behavior. Default each slice to one trunk-based PR. If one slice needs review layers, nest the map from `stack-pull-requests` beneath it; if later slices should start on the same evolving baseline before lower PRs merge, use one shared cross-slice map. Every reduction transition and terminal reduction loads `reduce-system-complexity` and references the plan-level reduction program. A transition may add a bounded bridge but keeps `mechanism gate: pending — no net-reduction claim`; only the terminal slice may claim net removal after both gates pass.
 
 ## Reduction Program (include only when applicable)
 
@@ -82,7 +82,7 @@ Classify every slice as **behavior change**, **pure refactor**, **reduction tran
 - **Value**: Behavior change — actor/outcome; pure refactor — preserved surface/maintenance value; transition — why this increment is necessary for the terminal state; terminal — conserved contract plus retired mechanism/ownership
 - **Path**: Behavior change — entry-to-observable path; pure refactor — preserved surface; either reduction class — affected path, program/terminal link, and mechanism scope
 - **Class**: Behavior change / pure refactor / reduction transition / terminal reduction
-- **Delivery**: Single PR (default), or nested `#### Delivery Shape` map from `stack-pull-requests`
+- **Delivery**: Independent PR against trunk (default); cross-slice stack member referencing the shared `#### Delivery Shape`; or an intra-slice `#### Delivery Shape` map
 - **Required implementation skills**: Behavior change — `tdd`, `testing`, plus applicable refactoring; pure refactor — applicable evidence/refactoring; either reduction class — `reduce-system-complexity` plus applicable evidence skills; at each PR boundary's readiness — `mutation-testing` for the focused scope where meaningful
 - **Reduction program**: For either reduction class, reference the plan-level program and terminal slice; otherwise `N/A`
 - **Transition/terminal evidence**: Transition — `behavior gate: pass`, independent verification, owner/removal/bounded-lifetime metadata for any bridge (`N/A` otherwise), `mechanism gate: pending — no net-reduction claim`; terminal — both gates pass and superseded machinery/expired bridges are gone; otherwise `N/A`
@@ -91,7 +91,8 @@ Classify every slice as **behavior change**, **pure refactor**, **reduction tran
 - **GREEN or preservation change**: Minimum behavior implementation, or smallest mechanism-only change
 - **REFACTOR or REDUCE**: Run the applicable `refactoring` and/or `reduce-system-complexity` skill; record `N/A` when neither applies
 - **PRE-PR MUTATION or alternate evidence**: Once the current review boundary is otherwise PR-ready, run mutation testing once for the focused scope and address valuable survivors within that gate; otherwise record explicit `N/A` plus reachability/configuration/contract/integration/operational evidence
-- **Done when**: Include the end-of-phase mutation or alternate evidence. A transition requires its behavior gate and independent checks to pass while its mechanism gate remains pending with no net claim; a terminal reduction requires both gates and retired old machinery/expired bridges.
+- **PR-ready when**: The current boundary's acceptance criteria and end-of-phase mutation or alternate evidence are complete. A transition requires its behavior gate and independent checks to pass while its mechanism gate remains pending with no net claim; a terminal reduction requires both gates and retired old machinery/expired bridges.
+- **Slice complete when**: Its independent or cross-slice owning PR lands, or the top PR lands for an intra-slice stack.
 
 ### Slice 2: [One sentence observable behaviour]
 
@@ -105,7 +106,7 @@ Before each PR:
 3. Typecheck and lint pass
 4. DDD glossary check (if applicable)
 
-For a stacked slice, also require the nested whole-stack gate from `stack-pull-requests`. Several slices are sequential independent PRs, not a stack.
+For any stack, also require the shared whole-stack gate from `stack-pull-requests`. Do not infer topology from slice count: independent PRs target trunk; a stack has explicit parent-branch dependencies.
 
 ---
 *Delete this file when the plan is complete. If `plans/` is empty, delete the directory.*
@@ -130,10 +131,10 @@ Do you approve this plan change?"
 
 ### 2. Commit Approval Required
 
-After an implementation increment, present its applicable passing baseline and class-specific state before asking for commit approval. Do not require mutation evidence for every commit. A transition must show `behavior gate: pass`, independent verification, optional bridge metadata or `N/A`, and `mechanism gate: pending — no net-reduction claim`; a terminal reduction must link its program/ledger (or authorized single-slice `N/A`), discharge transition obligations, pass both gates, and retire old machinery/expired bridges. When the completed slice is otherwise ready for its PR, run the single end-of-phase mutation gate and present that report separately.
+After an implementation increment, present its applicable passing baseline and class-specific state before asking for commit approval. Do not require mutation evidence for every commit. A transition must show `behavior gate: pass`, independent verification, optional bridge metadata or `N/A`, and `mechanism gate: pending — no net-reduction claim`; a terminal reduction must link its program/ledger (or authorized single-slice `N/A`), discharge transition obligations, pass both gates, and retire old machinery/expired bridges. When the current review boundary is otherwise PR-ready, run the single end-of-phase mutation gate and present that report separately.
 
 ```markdown
-"Slice 3 complete. Applicable tests/evidence pass.
+"Current implementation increment is known-good. Applicable tests/evidence pass.
 
 Change path: [behavior change / pure refactor / reduction transition / terminal reduction]
 Class-specific evidence: [RED/GREEN, preserved contract, transition gate state, or terminal gate/removal result]
@@ -147,12 +148,12 @@ Do you approve this commit?"
 
 ### 3. End-of-Feature Process
 
-When all slices are complete:
+When every slice's owning PR has landed (or the top PR has landed for each intra-slice stack):
 
 1. **Verify completion**
    - All acceptance criteria met?
-   - Applicable tests passing and every PR-ready slice's end-of-phase mutation/alternate evidence complete?
-   - All slices complete?
+   - Applicable tests passing and every PR-ready boundary's end-of-phase mutation/alternate evidence complete?
+   - All owning PRs landed, including every intra-slice stack top?
    - For a reduction program, did the terminal slice pass both gates, discharge transitions, and remove old machinery/expired bridges?
 
 2. **Merge learnings**
@@ -164,7 +165,7 @@ When all slices are complete:
    - `adr` agent for architectural decisions?"
    ```
 
-3. **Delete plan file**
+3. **Delete plan file only after every owning PR has landed**
    ```bash
    rm plans/feature-name.md
    # Delete plans/ directory if empty
@@ -233,7 +234,7 @@ User: "Test passes now"
 progress-guardian: "Slice 1 status: GREEN.
 Next: assess any valuable refactoring, then commit or continue the next RED-GREEN increment. Mutation testing waits until this slice is otherwise ready for its PR."
 
-User: "The slice is complete and ready for a PR"
+User: "The implementation is ready for its PR"
 
 progress-guardian: "Implementation and refactoring are complete.
 Now run mutation testing once for the accumulated slice where meaningful, or record explicit mutation `N/A` plus proportionate alternate evidence. Handle valuable survivors and scoped reruns inside this same gate."

--- a/claude/.claude/agents/progress-guardian.md
+++ b/claude/.claude/agents/progress-guardian.md
@@ -1,7 +1,7 @@
 ---
 name: progress-guardian
 description: >
-  Tracks progress through significant work using vertical-slice or explicitly selected reduction-program plan files in plans/ directory. Use at the start of planned work, to update progress, and at the end to merge learnings.
+  Tracks progress through significant work using vertical-slice or explicitly selected reduction-program plan files in plans/ directory, including optional stacked-PR delivery maps. Use at the start of planned work, to update progress, and at the end to merge learnings.
 tools: Read, Write, Edit, Grep, Glob, Bash
 model: sonnet
 color: green
@@ -68,7 +68,7 @@ For a behavior-change delivery plan, describe observable behavior. For a reducti
 
 ## Slices
 
-Classify every slice as **behavior change**, **pure refactor**, **reduction transition**, or **terminal reduction**. Delivery slices should be the thinnest useful end-to-end behavior. Every reduction transition and terminal reduction loads `reduce-system-complexity` and references the plan-level reduction program. A transition may add a bounded bridge but keeps `mechanism gate: pending — no net-reduction claim`; only the terminal slice may claim net removal after both gates pass.
+Classify every slice as **behavior change**, **pure refactor**, **reduction transition**, or **terminal reduction**. Delivery slices should be the thinnest useful end-to-end behavior. Default each slice to one PR; if one slice needs dependent review layers, nest the map from `stack-pull-requests` beneath it without expanding scope or terminal obligations. Every reduction transition and terminal reduction loads `reduce-system-complexity` and references the plan-level reduction program. A transition may add a bounded bridge but keeps `mechanism gate: pending — no net-reduction claim`; only the terminal slice may claim net removal after both gates pass.
 
 ## Reduction Program (include only when applicable)
 
@@ -82,14 +82,15 @@ Classify every slice as **behavior change**, **pure refactor**, **reduction tran
 - **Value**: Behavior change — actor/outcome; pure refactor — preserved surface/maintenance value; transition — why this increment is necessary for the terminal state; terminal — conserved contract plus retired mechanism/ownership
 - **Path**: Behavior change — entry-to-observable path; pure refactor — preserved surface; either reduction class — affected path, program/terminal link, and mechanism scope
 - **Class**: Behavior change / pure refactor / reduction transition / terminal reduction
-- **Required implementation skills**: Behavior change — `tdd`, `testing`, plus applicable refactoring; pure refactor — applicable evidence/refactoring; either reduction class — `reduce-system-complexity` plus applicable evidence skills; at PR readiness — `mutation-testing` for the accumulated slice where meaningful
+- **Delivery**: Single PR (default), or nested `#### Delivery Shape` map from `stack-pull-requests`
+- **Required implementation skills**: Behavior change — `tdd`, `testing`, plus applicable refactoring; pure refactor — applicable evidence/refactoring; either reduction class — `reduce-system-complexity` plus applicable evidence skills; at each PR boundary's readiness — `mutation-testing` for the focused scope where meaningful
 - **Reduction program**: For either reduction class, reference the plan-level program and terminal slice; otherwise `N/A`
 - **Transition/terminal evidence**: Transition — `behavior gate: pass`, independent verification, owner/removal/bounded-lifetime metadata for any bridge (`N/A` otherwise), `mechanism gate: pending — no net-reduction claim`; terminal — both gates pass and superseded machinery/expired bridges are gone; otherwise `N/A`
 - **Acceptance criteria**: Behavior change — observable outcome; pure refactor — conserved surface/evidence; transition — passing behavior gate, independent verification, optional bridge metadata or `N/A`, pending mechanism gate/no net claim; terminal — both gates and retired old machinery/expired bridges
 - **RED or preservation baseline**: Behavior change — failing behavior test; pure refactor — passing consumer-surface baseline; either reduction class — conserved-contract baseline from the reducer ledger
 - **GREEN or preservation change**: Minimum behavior implementation, or smallest mechanism-only change
 - **REFACTOR or REDUCE**: Run the applicable `refactoring` and/or `reduce-system-complexity` skill; record `N/A` when neither applies
-- **PRE-PR MUTATION or alternate evidence**: Once the slice is otherwise ready for its PR, run mutation testing once for the accumulated scope and address valuable survivors within that gate; otherwise record explicit `N/A` plus reachability/configuration/contract/integration/operational evidence
+- **PRE-PR MUTATION or alternate evidence**: Once the current review boundary is otherwise PR-ready, run mutation testing once for the focused scope and address valuable survivors within that gate; otherwise record explicit `N/A` plus reachability/configuration/contract/integration/operational evidence
 - **Done when**: Include the end-of-phase mutation or alternate evidence. A transition requires its behavior gate and independent checks to pass while its mechanism gate remains pending with no net claim; a terminal reduction requires both gates and retired old machinery/expired bridges.
 
 ### Slice 2: [One sentence observable behaviour]
@@ -103,6 +104,8 @@ Before each PR:
 2. Mutation or alternate evidence — run `mutation-testing` once for the accumulated PR scope where meaningful, address valuable survivors within the same gate, or review the explicit `N/A` rationale and proportionate evidence
 3. Typecheck and lint pass
 4. DDD glossary check (if applicable)
+
+For a stacked slice, also require the nested whole-stack gate from `stack-pull-requests`. Several slices are sequential independent PRs, not a stack.
 
 ---
 *Delete this file when the plan is complete. If `plans/` is empty, delete the directory.*

--- a/claude/.claude/commands/continue.md
+++ b/claude/.claude/commands/continue.md
@@ -18,7 +18,7 @@ Read the active plan and current slice's `Delivery` mode before changing branche
 - If the working tree is dirty, STOP and ask whether to stash, commit, or abort.
 - Do not implement the next slice or layer; only update the plan with approval and prepare the correct branch.
 
-## Single PR Or Sequential Vertical Slices
+## Independent PRs
 
 1. Confirm the current PR is merged with `gh pr view --json state,mergedAt`. If it is open, STOP.
 2. Switch to the detected default branch and pull the latest changes.
@@ -26,18 +26,18 @@ Read the active plan and current slice's `Delivery` mode before changing branche
 4. Create a new branch from updated trunk for the next independent slice.
 5. Summarize what merged and what comes next.
 
-Sequential implementation or reduction slices target trunk one after another. Do not base the next one on an unmerged sibling.
+Independent implementation or reduction slices target trunk. Do not base the next one on an unmerged sibling unless the approved plan explicitly makes both part of a cross-slice stack.
 
-## Stacked PR Layers
+## Stacked PRs
 
 Load `stack-pull-requests` and verify current preview syntax with `gh stack --help`.
 
-- **Advance before lower PRs merge:** Require the current top layer to be committed and known-good. Add the next branch from the current top; do not switch to trunk or require review approval/merge first.
-- **Continue after lower layers merge:** Run interactive `gh stack sync` to update trunk, rebase remaining layers, push safely, and move to the next unmerged layer. Do not recreate that layer from trunk. Use `--prune` only after listing the merged local branches it will delete and obtaining explicit user approval.
-- **Respond to lower-layer feedback:** Check out the owning lower branch, make no implementation change in this command, and report that the eventual fix must be rebased upstack and rechecked.
-- **Finish the stacked slice:** When every layer in the current slice is merged, mark the slice complete with approval, return to the updated default branch, and create the next independent slice branch if the plan has one.
+- **Advance before lower PRs merge:** Require the current top PR boundary to be committed and known-good. Add the next intra-slice layer or dependent slice from the current top; do not switch to trunk or require review approval/merge first.
+- **Continue after lower boundaries merge:** Run interactive `gh stack sync` to update trunk, rebase remaining boundaries, push safely, and move to the next unmerged boundary. Do not recreate that boundary from trunk. Use `--prune` only after listing the merged local branches it will delete and obtaining explicit user approval.
+- **Respond to lower-boundary feedback:** Check out the owning lower branch, make no implementation change in this command, and report that the eventual fix must be rebased upstack and rechecked.
+- **Finish the stack scope:** Mark each cross-slice member complete when its owning PR lands; mark an intra-slice delivery complete when its top lands. When the whole stack is merged, return to updated trunk and create the next independent slice branch if the plan has one.
 
-Update the plan's nested delivery map only with user approval. Summarize the current layer, parent, next layer, and whether the next action is build, review, rebase, or merge.
+Update the plan's delivery map only with user approval. Summarize the current PR boundary, owning slice, parent, next boundary, and whether the next action is build, review, rebase, or merge.
 
 ## Constraints
 

--- a/claude/.claude/commands/continue.md
+++ b/claude/.claude/commands/continue.md
@@ -1,5 +1,5 @@
 ---
-description: Pull merged PR on main, create new branch, update plan, and continue work
+description: Continue after a merged independent PR or advance and sync a dependent PR stack
 allowed-tools: Read, Edit, Bash(git:*), Bash(gh:*)
 ---
 
@@ -11,18 +11,34 @@ Current branch state:
 Working tree:
 !`git status --porcelain`
 
-The previous PR has been merged. Continue the workflow:
+Read the active plan and current slice's `Delivery` mode before changing branches. If no plan exists, use stack metadata only when reliable; otherwise follow the single-PR path.
 
-1. **Safety checks first:**
-   - If the working tree is dirty (`git status --porcelain` shows output), STOP and ask whether to stash, commit, or abort — do not switch branches over uncommitted changes.
-   - Confirm the PR is actually merged: `gh pr view --json state,mergedAt`. If it is still open, STOP and say so.
-2. Switch to main and pull latest: `git checkout main && git pull`
-3. Read the plan file to understand what's next
-4. If the plan needs updating (e.g., marking completed items), update it
-5. Create a new branch for the next piece of work
-6. Summarize: what was just completed, what's next
+## Safety
+
+- If the working tree is dirty, STOP and ask whether to stash, commit, or abort.
+- Do not implement the next slice or layer; only update the plan with approval and prepare the correct branch.
+
+## Single PR Or Sequential Vertical Slices
+
+1. Confirm the current PR is merged with `gh pr view --json state,mergedAt`. If it is open, STOP.
+2. Switch to the detected default branch and pull the latest changes.
+3. Mark the completed implementation slice in the plan, with user approval for the plan edit.
+4. Create a new branch from updated trunk for the next independent slice.
+5. Summarize what merged and what comes next.
+
+Sequential implementation or reduction slices target trunk one after another. Do not base the next one on an unmerged sibling.
+
+## Stacked PR Layers
+
+Load `stack-pull-requests` and verify current preview syntax with `gh stack --help`.
+
+- **Advance before lower PRs merge:** Require the current top layer to be committed and known-good. Add the next branch from the current top; do not switch to trunk or require review approval/merge first.
+- **Continue after lower layers merge:** Run interactive `gh stack sync` to update trunk, rebase remaining layers, push safely, and move to the next unmerged layer. Do not recreate that layer from trunk. Use `--prune` only after listing the merged local branches it will delete and obtaining explicit user approval.
+- **Respond to lower-layer feedback:** Check out the owning lower branch, make no implementation change in this command, and report that the eventual fix must be rebased upstack and rechecked.
+- **Finish the stacked slice:** When every layer in the current slice is merged, mark the slice complete with approval, return to the updated default branch, and create the next independent slice branch if the plan has one.
+
+Update the plan's nested delivery map only with user approval. Summarize the current layer, parent, next layer, and whether the next action is build, review, rebase, or merge.
 
 ## Constraints
 
 - Do NOT start implementing anything yet — just set up the branch and update the plan
-- If no plan file exists in `plans/`, ask what to work on next

--- a/claude/.claude/commands/generate-pr-review.md
+++ b/claude/.claude/commands/generate-pr-review.md
@@ -331,19 +331,23 @@ Create `.claude/commands/pr.md` that runs quality checks before creating the PR:
 ```markdown
 ---
 description: Create a pull request with pre-flight quality checks
-allowed-tools: Bash(git:*), Bash(gh:*), Bash([PACKAGE_MANAGER]:*)
+allowed-tools: Read, Glob, Bash(git:*), Bash(gh:*), Bash([PACKAGE_MANAGER]:*)
 ---
-
-Current branch state:
-!`git log [DETECTED_DEFAULT_BRANCH]..HEAD --oneline`
 
 Current branch:
 !`git branch --show-current`
 
-Changes summary:
-!`git diff [DETECTED_DEFAULT_BRANCH]...HEAD --stat`
+Recent commits:
+!`git log --oneline -5`
 
 If the current branch is `[DETECTED_DEFAULT_BRANCH]`, STOP. Do not create a PR until the work is moved to a feature branch with user approval.
+
+If an active plan exists, read the current slice's `Delivery` field. With no plan, default to one PR against `[DETECTED_DEFAULT_BRANCH]` unless the user explicitly requests a stack or reliable stack metadata identifies the current branch as a layer.
+
+- Single PR: review and verify against `[DETECTED_DEFAULT_BRANCH]`.
+- Stacked layer: load `stack-pull-requests`, target the immediate parent, and review and verify only `git diff <parent>...HEAD`.
+- Confirm required CI runs for the actual base and for `merge_group` when the repository uses a merge queue.
+- Create only the current stacked boundary with `gh pr create --base <parent>` by default. Use `gh stack submit` only after the exact full-stack branches, PRs, bases, and draft states are confirmed and the user intends those effects.
 
 Before creating the PR, run these checks in order:
 
@@ -353,7 +357,7 @@ Before creating the PR, run these checks in order:
    - Pure refactor: verify the passing baseline and complete the refactoring assessment
    - Reduction transition: reference the program/terminal slice and record the conserved contract, `behavior gate: pass`, independent verification, owner/removal/bounded-lifetime metadata for any temporary bridge (`N/A` when none), and `mechanism gate: pending — no net-reduction claim`
    - Terminal reduction: link the reducer program/report/ledger (or state `N/A — authorized single terminal slice`), discharge transition obligations, run both `reduce-system-complexity` gates, and confirm old machinery and expired bridges are gone
-3. Run the end-of-phase mutation gate once for the accumulated PR scope where meaningful, address valuable survivors and scoped reruns inside that gate, or record explicit mutation `N/A` with proportionate alternate evidence. Do not run the automated mutation harness once per prior increment or commit.
+3. Run the end-of-phase mutation gate once for the actual PR boundary where meaningful—default branch for one PR, immediate parent for a stacked layer—address valuable survivors and scoped reruns inside that gate, or record explicit mutation `N/A` with proportionate alternate evidence. Do not run the automated mutation harness once per prior increment or commit.
 4. [DETECTED_TYPE_CHECK_COMMAND]
 5. [DETECTED_LINT_COMMAND]
 6. [DETECTED_TEST_COMMAND]
@@ -373,7 +377,7 @@ Create a PR with:
 - Reduction transition: link the program and terminal slice; name the conserved contract, passing behavior gate, independent verification, owner/removal/bounded-lifetime metadata for any temporary bridge (`N/A` when none), pending mechanism gate without a net claim, plus mutation results or explicit mutation `N/A` with proportionate alternate evidence
 - Terminal reduction: link the reducer program/report/ledger (or state `N/A — authorized single terminal slice`), show discharged transition obligations, passing behavior/mechanism gates, removal of superseded machinery and expired bridges, plus mutation results or explicit mutation `N/A` with proportionate alternate evidence
 
-Use `gh pr create` (or project-specific CLI) with appropriate title and body.
+Use `gh pr create` (or project-specific CLI) with the appropriate base, title, and body. Create only the current boundary unless whole-stack submission was explicitly confirmed.
 ```
 
 Replace `[DETECTED_DEFAULT_BRANCH]` with the repository's detected default branch. Replace every command placeholder with the actual project command; when a check is unavailable, record it as `N/A` with a reason instead of emitting a broken command.

--- a/claude/.claude/commands/generate-pr-review.md
+++ b/claude/.claude/commands/generate-pr-review.md
@@ -150,7 +150,7 @@ This reviewer enforces:
 - New or changed observable behavior needs corresponding tests written before implementation
 - Pure behavior-preserving refactors or reductions need a passing pre/post baseline plus proportionate alternate evidence where tests cannot observe the mechanism
 - Run only the applicable refactoring/reduction assessment during implementation and record `N/A` when neither applies
-- Once the completed phase is otherwise PR-ready, run mutation testing once for the accumulated scope where meaningful; otherwise record an explicit `N/A` rationale and proportionate reachability, configuration, contract, integration, or operational evidence
+- Once the current review boundary is otherwise PR-ready, run mutation testing once for the accumulated scope where meaningful; otherwise record an explicit `N/A` rationale and proportionate reachability, configuration, contract, integration, or operational evidence
 - A reduction transition must reference its program, terminal slice, and conserved contract; pass the behavior gate and independent verification; record owner/removal/bounded-lifetime metadata for any temporary bridge (`N/A` when none); and state `mechanism gate: pending — no net-reduction claim`
 - A terminal reduction must link its reducer program/report/ledger (or state `N/A — authorized single terminal slice`), discharge prior transition obligations, and pass both gates before claiming net reduction
 - Any tests verify behavior, not implementation
@@ -342,12 +342,16 @@ Recent commits:
 
 If the current branch is `[DETECTED_DEFAULT_BRANCH]`, STOP. Do not create a PR until the work is moved to a feature branch with user approval.
 
-If an active plan exists, read the current slice's `Delivery` field. With no plan, default to one PR against `[DETECTED_DEFAULT_BRANCH]` unless the user explicitly requests a stack or reliable stack metadata identifies the current branch as a layer.
+If an active plan exists, read the current slice's `Delivery` field. With no plan, default to one PR against `[DETECTED_DEFAULT_BRANCH]` unless the user explicitly requests a stack or reliable stack metadata identifies the current branch as a stacked boundary.
 
 - Single PR: review and verify against `[DETECTED_DEFAULT_BRANCH]`.
-- Stacked layer: load `stack-pull-requests`, target the immediate parent, and review and verify only `git diff <parent>...HEAD`.
-- Confirm required CI runs for the actual base and for `merge_group` when the repository uses a merge queue.
-- Create only the current stacked boundary with `gh pr create --base <parent>` by default. Use `gh stack submit` only after the exact full-stack branches, PRs, bases, and draft states are confirmed and the user intends those effects.
+- Stacked boundary: load `stack-pull-requests`, target the immediate parent, and review and verify only `git diff <parent>...HEAD`.
+- Identify whether the approved topology is a GitHub-native linked stack or an unlinked dependent chain. Native stacks evaluate CI and rules against the stack trunk; unlinked dependent PRs retain ordinary immediate-base semantics. Confirm `merge_group` handling when the repository uses a merge queue.
+- Create only the current stacked boundary with `gh pr create --base <parent>` by default.
+- For an intended native stack, link the boundary with current `gh stack link` or `gh stack submit` behavior only after confirming the exact affected branches, PRs, bases, and draft states. Until linked, do not assume native stack-trunk CI or rule evaluation.
+- Use `gh stack submit` only when the user intends to create or update the full stack and its whole-stack effects have been confirmed.
+
+If the plan or explicit intent says GitHub-native stack but the boundary remains unlinked, STOP and repair the topology before presenting or updating it as a native stacked PR.
 
 Before creating the PR, run these checks in order:
 
@@ -357,7 +361,7 @@ Before creating the PR, run these checks in order:
    - Pure refactor: verify the passing baseline and complete the refactoring assessment
    - Reduction transition: reference the program/terminal slice and record the conserved contract, `behavior gate: pass`, independent verification, owner/removal/bounded-lifetime metadata for any temporary bridge (`N/A` when none), and `mechanism gate: pending — no net-reduction claim`
    - Terminal reduction: link the reducer program/report/ledger (or state `N/A — authorized single terminal slice`), discharge transition obligations, run both `reduce-system-complexity` gates, and confirm old machinery and expired bridges are gone
-3. Run the end-of-phase mutation gate once for the actual PR boundary where meaningful—default branch for one PR, immediate parent for a stacked layer—address valuable survivors and scoped reruns inside that gate, or record explicit mutation `N/A` with proportionate alternate evidence. Do not run the automated mutation harness once per prior increment or commit.
+3. Run the end-of-phase mutation gate once for the actual PR boundary where meaningful—default branch for one PR, immediate parent for a stacked boundary—address valuable survivors and scoped reruns inside that gate, or record explicit mutation `N/A` with proportionate alternate evidence. Do not run the automated mutation harness once per prior increment or commit.
 4. [DETECTED_TYPE_CHECK_COMMAND]
 5. [DETECTED_LINT_COMMAND]
 6. [DETECTED_TEST_COMMAND]

--- a/claude/.claude/commands/plan.md
+++ b/claude/.claude/commands/plan.md
@@ -19,7 +19,7 @@ Create a vertical-slice plan for the requested work: $ARGUMENTS
 2. Explore the codebase to understand the relevant areas
 3. If the request has unresolved product or design decisions, use `grill-me` before writing stories or plans
 4. If the request is still a large story, epic, broad feature idea, or backlog item, use the `story-splitting` skill first to identify independently valuable child stories
-5. Define independently mergeable implementation slices; default each slice to one PR, and use `stack-pull-requests` only when one fixed slice may be too large for effective review
+5. Define known-good vertical implementation slices; default each to one trunk-based PR, and use `stack-pull-requests` when one slice needs review layers or later slices should start on the same evolving baseline before lower PRs merge
 6. If the selected story, acceptance criteria, or mocks are ambiguous, use `find-gaps` to tighten the artifact before finalizing the plan
 7. For a mechanism-reduction program, use `reduce-system-complexity` first to define the conserved contract, ledger, terminal mechanism-removal state, and behavior/mechanism gates
 8. Write the plan to `plans/<feature-name>.md` (create the directory if needed)
@@ -50,7 +50,7 @@ For a reduction program, define the conserved observable contract, terminal same
 
 ## Slices
 
-Classify every slice as **behavior change**, **pure refactor**, **reduction transition**, or **terminal reduction**. Delivery slices should be the thinnest useful end-to-end behavior. Default each slice to one PR; if one slice needs dependent review layers, nest the delivery map from `stack-pull-requests` beneath that slice without expanding its scope or terminal obligations. Every reduction transition and terminal reduction loads `reduce-system-complexity` and references the plan-level reduction program. A transition may add a bounded bridge but must keep `mechanism gate: pending — no net-reduction claim`; only the terminal slice may claim net removal after both gates pass and old machinery/expired bridges are gone. Read the project's CLAUDE.md and testing rules before writing slices.
+Classify every slice as **behavior change**, **pure refactor**, **reduction transition**, or **terminal reduction**. Delivery slices should be the thinnest useful end-to-end behavior. Default each slice to one trunk-based PR. If one slice needs review layers, nest the delivery map from `stack-pull-requests` beneath it. If later slices should start on the same evolving baseline before lower PRs merge, place one shared cross-slice map before the first included slice and reference it from each. Every reduction transition and terminal reduction loads `reduce-system-complexity` and references the plan-level reduction program. A transition may add a bounded bridge but must keep `mechanism gate: pending — no net-reduction claim`; only the terminal slice may claim net removal after both gates pass and old machinery/expired bridges are gone. Read the project's CLAUDE.md and testing rules before writing slices.
 
 ## Reduction Program (include only when applicable)
 
@@ -67,7 +67,7 @@ Classify every slice as **behavior change**, **pure refactor**, **reduction tran
 **Value**: Behavior change — actor and observable outcome; pure refactor — preserved consumer surface and maintenance value; reduction transition — why this independently verifiable increment is necessary for the terminal state; terminal reduction — conserved contract plus ownership/mechanism retired.
 **Path**: Behavior change — entry point -> business path -> state/output -> observability; pure refactor — preserved public surface; either reduction class — affected trigger-to-outcome path, program/terminal link, and mechanism scope.
 **Class**: Behavior change / pure refactor / reduction transition / terminal reduction.
-**Delivery**: Single PR (default), or a nested `#### Delivery Shape` map from `stack-pull-requests`.
+**Delivery**: Independent PR against trunk (default); cross-slice stack member referencing a shared `#### Delivery Shape`; or a nested intra-slice `#### Delivery Shape` map.
 **Required implementation skills**: Changed behavior loads `tdd`, `testing`, and applicable refactoring guidance. A pure refactor loads applicable testing/refactoring skills. Every reduction transition and terminal reduction loads `reduce-system-complexity` plus applicable evidence skills. At each PR boundary's readiness, load `mutation-testing` for the focused scope where meaningful or record the alternate-evidence `N/A`.
 **Reduction program**: For either reduction class, reference the plan-level program and terminal slice; otherwise `N/A`.
 **Transition/terminal evidence**: Transition — `behavior gate: pass`, independent verification, bridge owner/removal/bounded-lifetime metadata when a bridge exists (`N/A` otherwise), and `mechanism gate: pending — no net-reduction claim`. Terminal — both gates pass and superseded machinery/expired bridges are removed. Otherwise `N/A`.
@@ -88,7 +88,7 @@ Before each PR:
 3. Typecheck and lint pass
 4. DDD glossary check — if the project uses DDD, verify all domain terms match the canonical glossary
 
-For a stacked slice, nest the exact `#### Delivery Shape` and whole-stack gate from `stack-pull-requests` under that slice. Do not set one delivery mode for the whole plan.
+For an intra-slice stack, nest the exact `#### Delivery Shape` and whole-stack gate under that slice. For a cross-slice stack, place one shared map before the first included slice and reference it from each included slice. Never stack the whole plan by default.
 
 ---
 *Delete this file when the plan is complete. If `plans/` is empty, delete the directory.*
@@ -101,7 +101,7 @@ For a stacked slice, nest the exact `#### Delivery Shape` and whole-stack gate f
 - Write the plan to a file, never present it inline in chat
 - **Prefer vertical slices** — break work into the smallest independently mergeable units that deliver observable value through the real production path.
 - **Avoid layer-cake plans** — database-only, API-only, UI-only, and "do all plumbing first" work is allowed only when it names the next vertical slice it unlocks with independent verification, or advances an explicitly selected reduction program toward a named terminal mechanism-removal state.
-- Each slice defaults to one PR. Several slices are sequential independent PRs, not a stack. If one slice deliberately uses dependent review PRs, load `stack-pull-requests`, keep its scope and terminal obligations fixed, and make every layer a coherent review boundary with current evidence.
+- Each slice defaults to one trunk-based PR. Use independent PRs when slices can merge in any order without blocking or duplicating work, or later work waits for earlier merge. Load `stack-pull-requests` for intra-slice review layers or a cross-slice hard/flow lineage where upper work starts before lower merge; require benefits worth cascading rebase, CI, and approval churn.
 - **Skill routing is mandatory** — behavior-changing and pure preservation paths must list their distinct required skills before code changes begin.
 - **TDD is mandatory for behavior change** — specify fast RED-GREEN-REFACTOR increments, then one accumulated-scope mutation/alternate-evidence gate at PR readiness. Pure preservation specifies a passing baseline and proportionate evidence instead of fabricated RED or structural mutants.
 - **Test behaviour, not implementation** — acceptance criteria and test descriptions must describe observable outcomes (what the user sees, what the API returns), never internal details (what function was called, what query was run)

--- a/claude/.claude/commands/plan.md
+++ b/claude/.claude/commands/plan.md
@@ -5,7 +5,7 @@ allowed-tools: Read, Glob, Grep, Write, Bash(git:*), Bash(gh:*)
 ---
 
 Current branch state:
-!`git log main..HEAD --oneline`
+!`git log --oneline -5`
 
 Current branch:
 !`git branch --show-current`
@@ -15,14 +15,15 @@ Active plans:
 
 Create a vertical-slice plan for the requested work: $ARGUMENTS
 
-1. If on main, create a new feature branch first
+1. Detect the repository's default branch. If currently on it, create a new feature branch first
 2. Explore the codebase to understand the relevant areas
 3. If the request has unresolved product or design decisions, use `grill-me` before writing stories or plans
 4. If the request is still a large story, epic, broad feature idea, or backlog item, use the `story-splitting` skill first to identify independently valuable child stories
-5. If the selected story, acceptance criteria, or mocks are ambiguous, use `find-gaps` to tighten the artifact before finalizing the plan
-6. For a mechanism-reduction program, use `reduce-system-complexity` first to define the conserved contract, ledger, terminal mechanism-removal state, and behavior/mechanism gates
-7. Write the plan to `plans/<feature-name>.md` (create the directory if needed)
-8. Create a PR with the plan for review
+5. Define independently mergeable implementation slices; default each slice to one PR, and use `stack-pull-requests` only when one fixed slice may be too large for effective review
+6. If the selected story, acceptance criteria, or mocks are ambiguous, use `find-gaps` to tighten the artifact before finalizing the plan
+7. For a mechanism-reduction program, use `reduce-system-complexity` first to define the conserved contract, ledger, terminal mechanism-removal state, and behavior/mechanism gates
+8. Write the plan to `plans/<feature-name>.md` (create the directory if needed)
+9. Create a PR with the plan for review
 
 ## Plan File Structure
 
@@ -49,7 +50,7 @@ For a reduction program, define the conserved observable contract, terminal same
 
 ## Slices
 
-Classify every slice as **behavior change**, **pure refactor**, **reduction transition**, or **terminal reduction**. Delivery slices should be the thinnest useful end-to-end behavior. Every reduction transition and terminal reduction loads `reduce-system-complexity` and references the plan-level reduction program. A transition may add a bounded bridge but must keep `mechanism gate: pending — no net-reduction claim`; only the terminal slice may claim net removal after both gates pass and old machinery/expired bridges are gone. Read the project's CLAUDE.md and testing rules before writing slices.
+Classify every slice as **behavior change**, **pure refactor**, **reduction transition**, or **terminal reduction**. Delivery slices should be the thinnest useful end-to-end behavior. Default each slice to one PR; if one slice needs dependent review layers, nest the delivery map from `stack-pull-requests` beneath that slice without expanding its scope or terminal obligations. Every reduction transition and terminal reduction loads `reduce-system-complexity` and references the plan-level reduction program. A transition may add a bounded bridge but must keep `mechanism gate: pending — no net-reduction claim`; only the terminal slice may claim net removal after both gates pass and old machinery/expired bridges are gone. Read the project's CLAUDE.md and testing rules before writing slices.
 
 ## Reduction Program (include only when applicable)
 
@@ -66,7 +67,8 @@ Classify every slice as **behavior change**, **pure refactor**, **reduction tran
 **Value**: Behavior change — actor and observable outcome; pure refactor — preserved consumer surface and maintenance value; reduction transition — why this independently verifiable increment is necessary for the terminal state; terminal reduction — conserved contract plus ownership/mechanism retired.
 **Path**: Behavior change — entry point -> business path -> state/output -> observability; pure refactor — preserved public surface; either reduction class — affected trigger-to-outcome path, program/terminal link, and mechanism scope.
 **Class**: Behavior change / pure refactor / reduction transition / terminal reduction.
-**Required implementation skills**: Changed behavior loads `tdd`, `testing`, and applicable refactoring guidance. A pure refactor loads applicable testing/refactoring skills. Every reduction transition and terminal reduction loads `reduce-system-complexity` plus applicable evidence skills. At PR readiness, load `mutation-testing` for the accumulated slice where meaningful or record the alternate-evidence `N/A`.
+**Delivery**: Single PR (default), or a nested `#### Delivery Shape` map from `stack-pull-requests`.
+**Required implementation skills**: Changed behavior loads `tdd`, `testing`, and applicable refactoring guidance. A pure refactor loads applicable testing/refactoring skills. Every reduction transition and terminal reduction loads `reduce-system-complexity` plus applicable evidence skills. At each PR boundary's readiness, load `mutation-testing` for the focused scope where meaningful or record the alternate-evidence `N/A`.
 **Reduction program**: For either reduction class, reference the plan-level program and terminal slice; otherwise `N/A`.
 **Transition/terminal evidence**: Transition — `behavior gate: pass`, independent verification, bridge owner/removal/bounded-lifetime metadata when a bridge exists (`N/A` otherwise), and `mechanism gate: pending — no net-reduction claim`. Terminal — both gates pass and superseded machinery/expired bridges are removed. Otherwise `N/A`.
 **Acceptance criteria**: Behavior change — observable outcome; pure refactor — conserved surface and evidence; transition — passing behavior gate, independent verification, optional bridge metadata or `N/A`, pending mechanism gate/no net claim; terminal — both gates pass and superseded machinery/expired bridges are gone. Present to the human and get confirmation before writing any code.
@@ -86,6 +88,8 @@ Before each PR:
 3. Typecheck and lint pass
 4. DDD glossary check — if the project uses DDD, verify all domain terms match the canonical glossary
 
+For a stacked slice, nest the exact `#### Delivery Shape` and whole-stack gate from `stack-pull-requests` under that slice. Do not set one delivery mode for the whole plan.
+
 ---
 *Delete this file when the plan is complete. If `plans/` is empty, delete the directory.*
 ```
@@ -97,7 +101,7 @@ Before each PR:
 - Write the plan to a file, never present it inline in chat
 - **Prefer vertical slices** — break work into the smallest independently mergeable units that deliver observable value through the real production path.
 - **Avoid layer-cake plans** — database-only, API-only, UI-only, and "do all plumbing first" work is allowed only when it names the next vertical slice it unlocks with independent verification, or advances an explicitly selected reduction program toward a named terminal mechanism-removal state.
-- Each slice in the plan must be small enough for a single PR. A slice may contain multiple TDD commits, but it must be reviewable and mergeable as one coherent unit.
+- Each slice defaults to one PR. Several slices are sequential independent PRs, not a stack. If one slice deliberately uses dependent review PRs, load `stack-pull-requests`, keep its scope and terminal obligations fixed, and make every layer a coherent review boundary with current evidence.
 - **Skill routing is mandatory** — behavior-changing and pure preservation paths must list their distinct required skills before code changes begin.
 - **TDD is mandatory for behavior change** — specify fast RED-GREEN-REFACTOR increments, then one accumulated-scope mutation/alternate-evidence gate at PR readiness. Pure preservation specifies a passing baseline and proportionate evidence instead of fabricated RED or structural mutants.
 - **Test behaviour, not implementation** — acceptance criteria and test descriptions must describe observable outcomes (what the user sees, what the API returns), never internal details (what function was called, what query was run)

--- a/claude/.claude/commands/pr.md
+++ b/claude/.claude/commands/pr.md
@@ -14,26 +14,27 @@ Recent commits:
 
 If the current branch is the repository's detected default branch, STOP — do not create a PR from it. Ask whether to move the work to a feature branch first.
 
-If an active plan exists, read the current implementation slice's `Delivery` field. With no active plan, default to one PR against the detected default branch unless the user explicitly requests a stack or reliable stack metadata identifies the current branch as a layer.
+If an active plan exists, read the current implementation slice's `Delivery` field. With no active plan, default to one PR against the detected default branch unless the user explicitly requests a stack or reliable stack metadata identifies the current branch as a stacked boundary.
 
 ## Choose The Review Boundary
 
-### Single PR Or Sequential Slice
+### Independent PR
 
 - Target the detected default branch.
 - Review and verify the diff against that branch.
-- A later implementation slice starts from updated trunk after this PR merges; it is not stacked on the open branch.
+- A later independent slice starts from updated trunk after this PR merges. If the approved plan instead puts a dependent slice in flight before merge, use the stack path.
 
-### Stacked PR Layer
+### Stacked PR Boundary
 
 Load `stack-pull-requests` and inspect current `gh stack` help and stack metadata.
 
-- Target the immediately lower layer, or the default branch for the bottom layer.
+- Target the immediately lower boundary, or the default branch for the bottom boundary.
 - Review and verify `git diff <parent>...HEAD`, not the cumulative trunk diff.
-- Confirm required CI runs for the dependent base.
+- Identify whether this is a GitHub-native linked stack. Native stacks evaluate CI and rules against the stack trunk; an unlinked dependent PR retains ordinary immediate-base workflow semantics.
 - Create only the current boundary with `gh pr create --base <parent>` by default.
-- Use `gh stack submit` only when the user intends to create or update the full stack and the exact included branches, PRs, bases, and draft states have been confirmed.
-- Keep unfinished upper layers draft and include the parent, next layer, focused review question, release state, and fixed slice scope in the PR body.
+- Link the boundary into the intended native stack with current `gh stack link` or `gh stack submit` behavior only after the exact affected branches, PRs, bases, and draft states have been confirmed. Until linked, do not assume native stack-trunk CI or rule evaluation.
+- Use `gh stack submit` only when the user intends to create or update the full stack and its whole-stack effects have been confirmed.
+- Keep unfinished upper boundaries draft and include the parent, next boundary, focused review question, release state, owning slice, and declared stack scope in the PR body.
 
 If the plan or explicit intent says stacked but the branch is not in the intended stack, STOP and repair the topology before creating a misleading PR.
 
@@ -41,10 +42,10 @@ If the plan or explicit intent says stacked but the branch is not in the intende
 
 Before creating the PR, verify each of these has been completed:
 
-1. **Implementation skill routing** — Behavior-changing slices or PR layers loaded `tdd`, `testing`, and applicable refactoring guidance; pure refactors loaded applicable testing/refactoring skills; every reduction transition or terminal reduction loaded `reduce-system-complexity` plus applicable evidence skills. Determine whether current mutation or alternate-evidence results cover this PR's actual focused review boundary—changed production scope plus applicable test or evidence changes—independent of the current commit SHA.
+1. **Implementation skill routing** — Behavior-changing slices or PR boundaries loaded `tdd`, `testing`, and applicable refactoring guidance; pure refactors loaded applicable testing/refactoring skills; every reduction transition or terminal reduction loaded `reduce-system-complexity` plus applicable evidence skills. Determine whether current mutation or alternate-evidence results cover this PR's actual focused review boundary—changed production scope plus applicable test or evidence changes—independent of the current commit SHA.
 2. **Change-path evidence** — For changed behavior, RED happened before GREEN. Pure refactors record a passing preservation baseline and proportionate evidence. A reduction transition references its program, conserved contract, and terminal slice; passes the behavior gate and independent verification; records owner/removal/bounded-lifetime metadata for any temporary bridge (`N/A` when none); and states `mechanism gate: pending — no net-reduction claim`. A terminal reduction links the reducer program/report/ledger (or states `N/A — authorized single terminal slice`), passes both gates, discharges transition obligations, and removes the superseded mechanism and expired bridges.
 3. **Implementation phase complete** — Confirm the applicable `refactoring` and/or `reduce-system-complexity` assessment is complete. A transition may leave the mechanism gate pending but cannot claim net reduction; only a terminal reduction may claim it after both gates pass. Record `N/A` when neither assessment applies.
-4. **End-of-phase mutation or alternate-evidence gate** — The target repository's stricter mutation-evidence invalidation rule takes precedence. Only when it has no stricter rule, confirm that a current mutation or alternate-evidence result covers the actual PR boundary using this command's default: treat it as stale only when mutation-relevant production files or applicable tests/evidence changed without being exercised by that result. Documentation- or release-metadata-only commits do not invalidate it, and neither do survivor-fix commits already exercised by the gate's final branch-diff rerun. If the result is missing or stale under the applicable rule, load `mutation-testing` and run it once, scoped to the accumulated branch diff per that skill's **Run and Triage** guidance; for a stacked layer, that branch diff uses the immediate parent rather than trunk. Widen to a full-project run only for that skill's stated triggers. Keep focused survivor reruns and the final boundary-diff rerun inside this gate. If a result is current under the applicable target-repository rule, do not rerun it. Otherwise review the explicit `N/A` rationale and proportionate reachability, configuration, contract, integration, or operational evidence. Do not require or repeat the automated harness for each prior TDD increment or commit.
+4. **End-of-phase mutation or alternate-evidence gate** — The target repository's stricter mutation-evidence invalidation rule takes precedence. Only when it has no stricter rule, confirm that a current mutation or alternate-evidence result covers the actual PR boundary using this command's default: treat it as stale only when mutation-relevant production files or applicable tests/evidence changed without being exercised by that result. Documentation- or release-metadata-only commits do not invalidate it, and neither do survivor-fix commits already exercised by the gate's final branch-diff rerun. If the result is missing or stale under the applicable rule, load `mutation-testing` and run it once, scoped to the accumulated branch diff per that skill's **Run and Triage** guidance; for a stacked boundary, that branch diff uses the immediate parent rather than trunk. Widen to a full-project run only for that skill's stated triggers. Keep focused survivor reruns and the final boundary-diff rerun inside this gate. If a result is current under the applicable target-repository rule, do not rerun it. Otherwise review the explicit `N/A` rationale and proportionate reachability, configuration, contract, integration, or operational evidence. Do not require or repeat the automated harness for each prior TDD increment or commit.
 5. **Project verification passes** — Stop every watcher and verify no watcher process remains. Run the repository-defined complete non-watch test gate against the final tree; in a monorepo this includes every configured project and required integration/E2E suite, not only an affected development subset. Then run the applicable typecheck, lint, and build checks with zero errors; record why any unavailable check is `N/A`. Watch output is not evidence for this gate.
 6. **DDD glossary check** (if project uses DDD) — All new/changed types, functions, and test names conform to the project's DDD glossary.
 

--- a/claude/.claude/commands/pr.md
+++ b/claude/.claude/commands/pr.md
@@ -1,29 +1,50 @@
 ---
 description: Create a pull request following standards
 argument-hint: [optional PR title or focus]
-allowed-tools: Bash(git:*), Bash(gh:*), Bash(npm:*), Bash(pnpm:*), Bash(npx:*), Bash(yarn:*), Bash(bun:*)
+allowed-tools: Read, Glob, Bash(git:*), Bash(gh:*), Bash(npm:*), Bash(pnpm:*), Bash(npx:*), Bash(yarn:*), Bash(bun:*)
 ---
 
-Current branch state:
+Current branch:
 !`git branch --show-current`
 
-!`git log main..HEAD --oneline`
-
-Changes summary:
-!`git diff main...HEAD --stat`
+Recent commits:
+!`git log --oneline -5`
 
 ## Guard
 
-If the current branch is `main` (or the repo's default branch), STOP — do not create a PR from the default branch. Ask whether to move the work to a feature branch first.
+If the current branch is the repository's detected default branch, STOP — do not create a PR from it. Ask whether to move the work to a feature branch first.
+
+If an active plan exists, read the current implementation slice's `Delivery` field. With no active plan, default to one PR against the detected default branch unless the user explicitly requests a stack or reliable stack metadata identifies the current branch as a layer.
+
+## Choose The Review Boundary
+
+### Single PR Or Sequential Slice
+
+- Target the detected default branch.
+- Review and verify the diff against that branch.
+- A later implementation slice starts from updated trunk after this PR merges; it is not stacked on the open branch.
+
+### Stacked PR Layer
+
+Load `stack-pull-requests` and inspect current `gh stack` help and stack metadata.
+
+- Target the immediately lower layer, or the default branch for the bottom layer.
+- Review and verify `git diff <parent>...HEAD`, not the cumulative trunk diff.
+- Confirm required CI runs for the dependent base.
+- Create only the current boundary with `gh pr create --base <parent>` by default.
+- Use `gh stack submit` only when the user intends to create or update the full stack and the exact included branches, PRs, bases, and draft states have been confirmed.
+- Keep unfinished upper layers draft and include the parent, next layer, focused review question, release state, and fixed slice scope in the PR body.
+
+If the plan or explicit intent says stacked but the branch is not in the intended stack, STOP and repair the topology before creating a misleading PR.
 
 ## Pre-PR Quality Gate
 
 Before creating the PR, verify each of these has been completed:
 
-1. **Implementation skill routing** — Behavior-changing slices loaded `tdd`, `testing`, and applicable refactoring guidance; pure refactors loaded applicable testing/refactoring skills; every reduction transition or terminal reduction loaded `reduce-system-complexity` plus applicable evidence skills. Determine whether current mutation or alternate-evidence results already cover the accumulated mutation-relevant diff—changed production scope plus applicable test or evidence changes—independent of the current commit SHA.
+1. **Implementation skill routing** — Behavior-changing slices or PR layers loaded `tdd`, `testing`, and applicable refactoring guidance; pure refactors loaded applicable testing/refactoring skills; every reduction transition or terminal reduction loaded `reduce-system-complexity` plus applicable evidence skills. Determine whether current mutation or alternate-evidence results cover this PR's actual focused review boundary—changed production scope plus applicable test or evidence changes—independent of the current commit SHA.
 2. **Change-path evidence** — For changed behavior, RED happened before GREEN. Pure refactors record a passing preservation baseline and proportionate evidence. A reduction transition references its program, conserved contract, and terminal slice; passes the behavior gate and independent verification; records owner/removal/bounded-lifetime metadata for any temporary bridge (`N/A` when none); and states `mechanism gate: pending — no net-reduction claim`. A terminal reduction links the reducer program/report/ledger (or states `N/A — authorized single terminal slice`), passes both gates, discharges transition obligations, and removes the superseded mechanism and expired bridges.
 3. **Implementation phase complete** — Confirm the applicable `refactoring` and/or `reduce-system-complexity` assessment is complete. A transition may leave the mechanism gate pending but cannot claim net reduction; only a terminal reduction may claim it after both gates pass. Record `N/A` when neither assessment applies.
-4. **End-of-phase mutation or alternate-evidence gate** — The target repository's stricter mutation-evidence invalidation rule takes precedence. Only when it has no stricter rule, confirm that a current mutation or alternate-evidence result covers the accumulated mutation-relevant diff using this command's default: treat it as stale only when mutation-relevant production files or applicable tests/evidence changed without being exercised by that result. Documentation- or release-metadata-only commits do not invalidate it, and neither do survivor-fix commits already exercised by the gate's final branch-diff rerun. If the result is missing or stale under the applicable rule, load `mutation-testing` and run it once, scoped to the accumulated branch diff per that skill's **Run and Triage** guidance; widen to a full-project run only for that skill's stated triggers. Keep focused survivor reruns and the final branch-diff rerun inside this gate. If a result is current under the applicable target-repository rule, do not rerun it. Otherwise review the explicit `N/A` rationale and proportionate reachability, configuration, contract, integration, or operational evidence. Do not require or repeat the automated harness for each prior TDD increment or commit.
+4. **End-of-phase mutation or alternate-evidence gate** — The target repository's stricter mutation-evidence invalidation rule takes precedence. Only when it has no stricter rule, confirm that a current mutation or alternate-evidence result covers the actual PR boundary using this command's default: treat it as stale only when mutation-relevant production files or applicable tests/evidence changed without being exercised by that result. Documentation- or release-metadata-only commits do not invalidate it, and neither do survivor-fix commits already exercised by the gate's final branch-diff rerun. If the result is missing or stale under the applicable rule, load `mutation-testing` and run it once, scoped to the accumulated branch diff per that skill's **Run and Triage** guidance; for a stacked layer, that branch diff uses the immediate parent rather than trunk. Widen to a full-project run only for that skill's stated triggers. Keep focused survivor reruns and the final boundary-diff rerun inside this gate. If a result is current under the applicable target-repository rule, do not rerun it. Otherwise review the explicit `N/A` rationale and proportionate reachability, configuration, contract, integration, or operational evidence. Do not require or repeat the automated harness for each prior TDD increment or commit.
 5. **Project verification passes** — Stop every watcher and verify no watcher process remains. Run the repository-defined complete non-watch test gate against the final tree; in a monorepo this includes every configured project and required integration/E2E suite, not only an affected development subset. Then run the applicable typecheck, lint, and build checks with zero errors; record why any unavailable check is `N/A`. Watch output is not evidence for this gate.
 6. **DDD glossary check** (if project uses DDD) — All new/changed types, functions, and test names conform to the project's DDD glossary.
 
@@ -47,4 +68,4 @@ Include verification notes for exactly one change path:
 - **Reduction transition** — program/terminal-slice link, conserved contract, `behavior gate: pass`, independent verification, owner/removal/bounded-lifetime metadata for any bridge (`N/A` when none), `mechanism gate: pending — no net-reduction claim`, plus mutation results or explicit mutation `N/A` with proportionate alternate evidence
 - **Terminal reduction** — reducer program/report/ledger link (or `N/A — authorized single terminal slice`), passing behavior/mechanism gates, discharged transition obligations, removal of superseded machinery and expired bridges, plus mutation results or explicit mutation `N/A` with proportionate alternate evidence
 
-Use `gh pr create` with appropriate title and body.
+Use `gh pr create` with the appropriate base, title, and body. For a stack, create only the current boundary unless whole-stack submission was explicitly confirmed.

--- a/claude/.claude/commands/setup.md
+++ b/claude/.claude/commands/setup.md
@@ -28,7 +28,7 @@ Set up this project for Claude Code using the global framework. Analyze the proj
 
 1. **Detect tech stack**: language, framework, package manager, test runner, linter, formatter, build tool
 2. **Detect TypeScript strict config**: check for `strict`, `noUncheckedIndexedAccess`, `noImplicitAny` etc.
-3. **Detect CI pipeline**: what CI system, what steps run, what commands, whether PR branch filters allow dependent feature bases, and whether required merge-queue checks handle `merge_group`
+3. **Detect CI pipeline**: what CI system, steps, and commands run; whether stacks will use GitHub-native linking or ordinary dependent PRs; and whether required merge-queue checks handle `merge_group`
 4. **Detect existing config**: check for existing CLAUDE.md, .claude/ directory, hooks, commands
 5. **Check for DDD**: look for glossary files, domain directories, bounded context structure
 6. **Check for hexagonal architecture**: look for ports/, adapters/, domain/ directory structure
@@ -82,8 +82,9 @@ Generate a project-specific PR command that runs the detected quality gates befo
 - Lint command
 - Test command
 - Build command (if applicable)
-- Preserve the global `/pr` topology rules: use the current slice's delivery mode when a plan exists; otherwise default to one PR against the detected default branch unless stack intent or metadata is explicit; target and verify the immediate parent for a stacked layer
-- Confirm required CI runs for dependent feature-branch bases and `merge_group` when the repository uses a merge queue
+- Preserve the global `/pr` topology rules: use the current slice's delivery mode when a plan exists; otherwise default to one PR against the detected default branch unless stack intent or metadata is explicit; target and verify the immediate parent for a stacked boundary
+- Confirm native stacks evaluate CI against the stack trunk; for unlinked dependent PRs, confirm feature-base workflows run; verify `merge_group` when the repository uses a merge queue
+- For intended native stacks, confirm exact affected branches, PRs, bases, and draft states before using current `gh stack link` or `gh stack submit` behavior; stop if the boundary remains unlinked, and never assume native stack semantics before linking
 
 ### 4. Project pr-reviewer agent (`.claude/agents/pr-reviewer.md`)
 

--- a/claude/.claude/commands/setup.md
+++ b/claude/.claude/commands/setup.md
@@ -28,7 +28,7 @@ Set up this project for Claude Code using the global framework. Analyze the proj
 
 1. **Detect tech stack**: language, framework, package manager, test runner, linter, formatter, build tool
 2. **Detect TypeScript strict config**: check for `strict`, `noUncheckedIndexedAccess`, `noImplicitAny` etc.
-3. **Detect CI pipeline**: what CI system, what steps run, what commands
+3. **Detect CI pipeline**: what CI system, what steps run, what commands, whether PR branch filters allow dependent feature bases, and whether required merge-queue checks handle `merge_group`
 4. **Detect existing config**: check for existing CLAUDE.md, .claude/ directory, hooks, commands
 5. **Check for DDD**: look for glossary files, domain directories, bounded context structure
 6. **Check for hexagonal architecture**: look for ports/, adapters/, domain/ directory structure
@@ -82,6 +82,8 @@ Generate a project-specific PR command that runs the detected quality gates befo
 - Lint command
 - Test command
 - Build command (if applicable)
+- Preserve the global `/pr` topology rules: use the current slice's delivery mode when a plan exists; otherwise default to one PR against the detected default branch unless stack intent or metadata is explicit; target and verify the immediate parent for a stacked layer
+- Confirm required CI runs for dependent feature-branch bases and `merge_group` when the repository uses a merge queue
 
 ### 4. Project pr-reviewer agent (`.claude/agents/pr-reviewer.md`)
 

--- a/claude/.claude/skills/mutation-testing/SKILL.md
+++ b/claude/.claude/skills/mutation-testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mutation-testing
-description: Set up and run mutation testing with Stryker, including full-project and diff-against-main runs, then use surviving mutants to strengthen weak or missing tests. Use as the end-of-phase PR-readiness gate after implementation and refactoring are complete, not inside each RED-GREEN increment. Also use when the user explicitly asks for mutation testing, Stryker, mutation score, or surviving-mutant analysis. For writing the tests themselves, see testing.
+description: Set up and run mutation testing with Stryker, including full-project and focused diff runs against the current review base, then use surviving mutants to strengthen weak or missing tests. Use as the end-of-phase PR-readiness gate after implementation and refactoring are complete, not inside each RED-GREEN increment. Also use when the user explicitly asks for mutation testing, Stryker, mutation score, or surviving-mutant analysis. For writing the tests themselves, see testing.
 ---
 
 # Mutation Testing
@@ -75,11 +75,12 @@ At the end-of-phase PR-readiness gate, prove test effectiveness with Stryker whe
 
 ```bash
 rg --files | rg '(^|/)(package.json|stryker\.config\.(mjs|cjs|js|json)|stryker\.conf\.(js|json))$'
-git diff main...HEAD --name-only
+git diff <review-base>...HEAD --name-only
 ```
 
 - Identify the package manager, test runner, affected package(s), and existing Stryker config.
-- If the repo uses a base branch other than `main`, substitute that branch in all diff commands.
+- Use the actual review boundary: the detected default branch for a single PR, or the immediately lower branch for a stacked PR layer.
+- For a stacked slice, mutate the focused layer against its parent. The top also runs the cumulative acceptance and repository gates required by `stack-pull-requests`.
 - In monorepos, start in the smallest affected package, then widen to the repo-level command when the targeted run is healthy.
 - If no Stryker setup exists in a JS/TS project, recommend adding it before doing manual mutation analysis.
 
@@ -107,14 +108,14 @@ Suggest project scripts for full-project, cached, and branch-diff mutation runs:
   "scripts": {
     "mutation": "stryker run",
     "mutation:incremental": "stryker run --incremental",
-    "mutation:diff": "node scripts/stryker-diff.mjs main"
+    "mutation:diff": "node scripts/stryker-diff.mjs <review-base>"
   }
 }
 ```
 
 The `mutation:diff` helper should:
 
-- Read the base branch argument, defaulting to `main`.
+- Read the base branch argument, defaulting to the repository's detected default branch.
 - Collect changed files with `git diff --name-only --diff-filter=ACMRTUXB <base>...HEAD`.
 - Keep changed production files matching the project's source extensions.
 - Exclude test/spec files, fixtures, snapshots, generated files, declaration files, and build output.
@@ -124,7 +125,7 @@ The `mutation:diff` helper should:
 Prefer a small Node helper over dense shell inside `package.json`; quoting `*`, `!`, and command substitution is fragile across shells. For quick local use, this POSIX one-liner is acceptable:
 
 ```bash
-CHANGED=$(git diff --name-only --diff-filter=ACMRTUXB main...HEAD -- '*.ts' '*.tsx' '*.js' '*.jsx' | grep -Ev '(^|/)(__tests__|test|tests|fixtures|generated)/|\.(test|spec|d)\.' | paste -sd, -)
+CHANGED=$(git diff --name-only --diff-filter=ACMRTUXB <review-base>...HEAD -- '*.ts' '*.tsx' '*.js' '*.jsx' | grep -Ev '(^|/)(__tests__|test|tests|fixtures|generated)/|\.(test|spec|d)\.' | paste -sd, -)
 test -n "$CHANGED" && npx stryker run --incremental --force --mutate "$CHANGED"
 ```
 

--- a/claude/.claude/skills/planning/SKILL.md
+++ b/claude/.claude/skills/planning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: planning
-description: Planning work as vertical slices or an explicitly selected mechanism-reduction program in small, known-good increments. Use when starting significant work, turning already-split stories into PR-sized implementation plans, planning PRs, or sequencing complex tasks. For a mechanism-reduction program, use reduce-system-complexity first to define the conserved contract, terminal mechanism-removal state, and behavior/mechanism gates; planning then sequences it. If the input is a broad story, epic, feature idea, or backlog item that still needs product slicing, use story-splitting first.
+description: Planning work as vertical slices or an explicitly selected mechanism-reduction program in small, known-good increments, with a single PR or optional stacked-PR delivery shape for each slice. Use when starting significant work, turning already-split stories into implementation plans, planning PRs, or sequencing complex tasks. For a mechanism-reduction program, use reduce-system-complexity first to define the conserved contract, terminal mechanism-removal state, and behavior/mechanism gates; planning then sequences it. If the input is a broad story, epic, feature idea, or backlog item that still needs product slicing, use story-splitting first; if one planned slice may need dependent review layers, also use stack-pull-requests.
 ---
 
 # Planning in Vertical Slices
@@ -9,13 +9,23 @@ description: Planning work as vertical slices or an explicitly selected mechanis
 
 Horizontal work is allowed only when it explicitly unblocks the next vertical slice and is independently verifiable, or when it belongs to an explicitly selected reduction program whose terminal state retires one complete mechanism while conserving behavior.
 
-Use the `/plan` command to create plans. Use the `/continue` command to resume work after a merged PR.
+Use the `/plan` command to create plans. Use `/continue` after a merged independent PR or to advance and sync an active stack.
 
 ## Relationship To Story Splitting
 
 `story-splitting` decides **what small user-value stories exist**. `planning` decides **how to implement selected stories safely**.
 
-Use `story-splitting` before this skill when the request is still an epic, large story, feature idea, roadmap item, or backlog item with multiple possible customer outcomes. Once a child story or narrow capability has been selected, use this skill to turn it into a `plans/<feature>.md` file with PR-sized slices, acceptance criteria, and TDD execution steps.
+Use `story-splitting` before this skill when the request is still an epic, large story, feature idea, roadmap item, or backlog item with multiple possible customer outcomes. Once a child story or narrow capability has been selected, use this skill to turn it into a `plans/<feature>.md` file with implementation slices, acceptance criteria, evidence routes, and a delivery shape for each slice.
+
+Keep three units distinct:
+
+| Unit | Meaning | Default relationship |
+|---|---|---|
+| Backlog story | Fixed product capability and acceptance scope from `story-splitting` | A plan may advance one selected story |
+| Implementation slice | Smallest independently mergeable and releasable vertical increment, or one explicit reduction transition/terminal state | One PR |
+| PR layer | Dependent review package inside one slice | Exists only when `stack-pull-requests` justifies a stack |
+
+Several implementation slices produce sequential independent PRs, not a stack. After one merges, start the next from trunk. If one slice is difficult to review as a single PR, load `stack-pull-requests`; its layers must not expand the slice's acceptance scope, conserved contract, or reduction obligations.
 
 If a plan starts producing database-only, API-only, UI-only, or "do all plumbing first" slices, pause and return to `story-splitting` unless the horizontal work explicitly unlocks the next vertical slice with independent verification or advances an explicitly selected reduction program toward its named terminal mechanism-removal state.
 
@@ -28,7 +38,8 @@ Before freezing slices that introduce a material generic mechanism or durable ne
 | Fuzzy decision tree | `grill-me` | Resolved decisions or named open questions |
 | Broad requirement with multiple outcomes | `story-splitting` | Child stories |
 | Existing story/plan/AC/mocks with holes | `find-gaps` | Confirmed artifact updates |
-| Selected child story ready for delivery sequencing | `planning` | PR-sized implementation slices |
+| Selected child story ready for delivery sequencing | `planning` | Implementation slices with a delivery shape |
+| One planned slice may need dependent review PRs | `stack-pull-requests` + `planning` | Per-slice single PR or ordered PR stack |
 
 ## Plans Directory
 
@@ -40,15 +51,15 @@ Multiple plans can coexist — each is independent and won't conflict across bra
 
 **When a plan is complete:** delete the plan file. If `plans/` is empty, delete the directory.
 
-## Prefer Multiple Small PRs
+## Prefer Small Reviewable PRs
 
-**Break work into the smallest independently mergeable units.** Each PR should be reviewable in isolation and deliver a coherent slice of value.
+Default to the smallest independently mergeable vertical units, with one PR per slice. Use a stack only as the exception defined by `stack-pull-requests`: dependent layers may package one fixed slice for focused review, while the full stack remains that slice's delivery unit.
 
 **Why this matters:** Small PRs are easier to review, easier to revert, and easier to reason about. When something breaks, the cause is obvious. When a PR sits in review, it doesn't block unrelated work. The goal is to stay as close to main as possible at all times.
 
 **A PR is too big when** the reviewer needs to hold multiple unrelated concepts in their head to understand it, or when you'd struggle to write a clear 1-3 sentence summary of what it does.
 
-There will be exceptions — some changes are inherently coupled and splitting them would create broken intermediate states. Use judgement. But the default should always be to ask "can this be split?"
+There will be exceptions — some changes are inherently coupled and splitting them would create broken intermediate states. Use judgement. First ask whether the work is really several independent slices; only then ask whether one remaining slice needs dependent review layers.
 
 ## What Makes a Vertical Slice
 
@@ -98,11 +109,11 @@ Each slice MUST:
 - Leave all tests passing
 - Be independently deployable
 - Have clear done criteria
-- Fit in a single PR (the smallest independently mergeable unit)
+- Fit in a single PR by default, or have an approved `stack-pull-requests` delivery map
 - Be describable in one sentence
 - Deliver or directly unblock observable behavior, or safely advance an explicitly selected reduction program toward its terminal behavior/mechanism gates
 
-A slice is the unit of planning and review — one PR. Within a behavior-changing slice, fast RED-GREEN-REFACTOR increments may produce multiple commits. Mutation testing or alternate evidence is applied once to the accumulated slice at the end-of-phase PR-readiness gate, not after each increment.
+A slice is the unit of planning and independently mergeable value. By default it is also one review PR. With an approved stack, dependent PR layers become focused review boundaries and the top remains the slice's completion boundary. Within each behavior-changing PR boundary, fast RED-GREEN-REFACTOR increments may produce multiple commits; mutation testing or alternate evidence runs once when that boundary is otherwise PR-ready, not after each increment.
 
 **If you can't describe a slice in one sentence, break it down further.**
 
@@ -127,8 +138,10 @@ A slice is the unit of planning and review — one PR. Within a behavior-changin
 
 **Every behavior-changing slice uses fast RED-GREEN-REFACTOR increments, followed by one end-of-phase mutation or alternate-evidence gate when the slice is otherwise ready for its PR.** Before implementation, load `tdd`, `testing`, and applicable `refactoring` guidance. Use the `mutation-testing` mutator rules for cheap test-design guidance, but defer the automated harness until PR readiness. A true behavior-preserving refactor or `reduce-system-complexity` slice starts from passing proportionate preservation evidence and uses the same end-of-phase gate. Never fabricate a failing mechanism-count test or structural mutant. This section is a routing contract, not a replacement for those skills.
 
+For a stacked slice, apply that cadence to every PR layer against its parent review boundary. Put tests in the earliest layer that owns the behavior, run the mutation-or-alternate-evidence gate once when each layer is PR-ready, and require the top layer to prove the slice's complete acceptance criteria or reduction gates. Do not defer all tests or evidence to the top.
+
 ```
-FOR EACH BEHAVIOR-CHANGING SLICE:
+FOR EACH BEHAVIOR-CHANGING SLICE OR PR LAYER:
     │
     ├─► LOAD: Required implementation skills
     │   - `tdd` for RED-GREEN-REFACTOR
@@ -168,9 +181,9 @@ FOR EACH BEHAVIOR-CHANGING SLICE:
          - Show what was implemented and the ordinary verification
          - Human reviews and approves before commit
 
-WHEN THE SLICE IS OTHERWISE READY FOR ITS PR:
+WHEN THE CURRENT REVIEW BOUNDARY IS OTHERWISE READY FOR ITS PR:
     ├─► LOAD: `mutation-testing`
-    ├─► MUTATE OR ALTERNATE EVIDENCE: Run once for the accumulated slice scope, or record explicit `N/A` plus proportionate alternate evidence
+    ├─► MUTATE OR ALTERNATE EVIDENCE: Run once for the focused boundary scope, or record explicit `N/A` plus proportionate alternate evidence
     ├─► KILL MUTANTS: Address valuable survivors and re-run focused/diff mutations within the same gate
     └─► COMPLETE: Finish the remaining PR checks and present the final report
 ```
@@ -249,7 +262,8 @@ Read the project's CLAUDE.md and testing rules before writing slices.
 **Value**: [Behavior change: actor and observable outcome. Pure refactor: preserved consumer surface and maintenance value. Reduction transition: why this independently verifiable increment is necessary to reach the terminal state. Terminal reduction: conserved contract plus the ownership/mechanism retired.]
 **Path**: [Behavior change: entry point -> business path -> state/output -> observability. Pure refactor: preserved public surface. Either reduction class: affected trigger-to-outcome path, program/terminal link, and mechanism scope.]
 **Class**: Behavior change / pure refactor / reduction transition / terminal reduction.
-**Required implementation skills**: For changed behavior, load `tdd`, `testing`, and applicable refactoring guidance. For a pure refactor, load only applicable testing and refactoring skills. Every reduction transition and terminal reduction loads `reduce-system-complexity` plus applicable evidence skills. At PR readiness, load `mutation-testing` for the accumulated slice where meaningful or record the alternate-evidence `N/A`. Add UI/domain/architecture skills only when relevant.
+**Delivery**: [Single PR (default), or a `#### Delivery Shape` map from `stack-pull-requests` nested under this slice.]
+**Required implementation skills**: For changed behavior, load `tdd`, `testing`, and applicable refactoring guidance. For a pure refactor, load only applicable testing and refactoring skills. Every reduction transition and terminal reduction loads `reduce-system-complexity` plus applicable evidence skills. At each PR boundary's readiness, load `mutation-testing` for the focused scope where meaningful or record the alternate-evidence `N/A`. Add UI/domain/architecture skills only when relevant.
 **Reduction program**: [For either reduction class: reference the plan-level program and terminal slice; otherwise `N/A`.]
 **Transition/terminal evidence**: [Transition: `behavior gate: pass`, independent verification, bridge owner/removal/bounded-lifetime metadata when a bridge exists (`N/A` otherwise), and `mechanism gate: pending — no net-reduction claim`. Terminal: passing behavior gate, like-for-like mechanism gate, and removal of the superseded mechanism/expired bridges. Otherwise `N/A`.]
 **Acceptance criteria**: [Behavior change: specific observable outcome. Pure refactor: conserved surface plus preservation evidence. Transition: passing behavior gate, independent verification, optional bridge metadata or `N/A`, and pending mechanism gate/no net claim. Terminal: both gates pass and superseded machinery/expired bridges are gone. **Present to the human and get confirmation before writing any code.**]
@@ -272,6 +286,8 @@ Before each PR:
 4. DDD glossary check — if the project uses DDD, verify all domain terms match the canonical glossary
 5. Complete tests — stop watchers and run the repository-defined complete non-watch PR test gate; in a monorepo include every configured project and required integration/E2E suite, not only the affected development subset
 6. Evidence freshness — apply the target repository's mutation-evidence rule after later fixes. Use this distribution's `commands/pr.md` model only when the repository has no stricter invalidation policy, and keep project verification current after resulting fixes
+
+For a stacked slice, nest the exact `#### Delivery Shape` and whole-stack gate from `stack-pull-requests` under that slice. Do not set one delivery mode for the whole plan.
 
 ---
 *Delete this file when the plan is complete. If `plans/` is empty, delete the directory.*
@@ -312,8 +328,8 @@ When all slices are complete:
 ❌ **Do all plumbing first**
 - Prefer a walking skeleton that proves the real path, then widen it behavior by behavior
 
-❌ **Slices that span multiple PRs**
-- Break down further until one slice = one PR
+❌ **Slices that span multiple PRs without a delivery decision**
+- Default to one PR. If dependent review layers genuinely help, load `stack-pull-requests`, justify the exception, and keep the slice scope and terminal obligations fixed.
 
 ❌ **Writing changed behavior before its test**
 - RED comes first for behavior change; a true REFACTOR slice records passing preservation evidence instead
@@ -331,13 +347,14 @@ START FEATURE
 │
 ├─► Create plan in plans/ (get approval)
 │
-│   FOR EACH PR-SIZED SLICE:
+│   FOR EACH IMPLEMENTATION SLICE:
 │   │
+│   ├─► DELIVERY: Single PR by default; otherwise nest an approved stack map
 │   ├─► BEHAVIOR CHANGE: LOAD → CONFIRM → RED → GREEN → REFACTOR → REPEAT WITHOUT MUTATION HARNESS
 │   ├─► OR PURE REFACTOR/REDUCTION: PASSING BASELINE → REFACTOR/REDUCE → VERIFY GATES
 │   ├─► **PRESENT WORK, WAIT FOR COMMIT APPROVAL**
-│   ├─► PRE-PR: Run mutation once for the accumulated slice (or alternate evidence), handle survivors within the gate
-│   └─► Verify criteria and create the slice's PR
+│   ├─► PRE-PR: Run mutation once for each current review boundary (or alternate evidence), handle survivors within the gate
+│   └─► Verify focused and top-level criteria; create one PR or the planned stack
 │
 END FEATURE
 │

--- a/claude/.claude/skills/planning/SKILL.md
+++ b/claude/.claude/skills/planning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: planning
-description: Planning work as vertical slices or an explicitly selected mechanism-reduction program in small, known-good increments, with a single PR or optional stacked-PR delivery shape for each slice. Use when starting significant work, turning already-split stories into implementation plans, planning PRs, or sequencing complex tasks. For a mechanism-reduction program, use reduce-system-complexity first to define the conserved contract, terminal mechanism-removal state, and behavior/mechanism gates; planning then sequences it. If the input is a broad story, epic, feature idea, or backlog item that still needs product slicing, use story-splitting first; if one planned slice may need dependent review layers, also use stack-pull-requests.
+description: Planning work as vertical slices or an explicitly selected mechanism-reduction program in small, known-good increments, with independent pull requests or an optional stacked-PR topology across one or more ordered slices. Use when starting significant work, turning already-split stories into implementation plans, planning PRs, or sequencing complex tasks. For a mechanism-reduction program, use reduce-system-complexity first to define the conserved contract, terminal mechanism-removal state, and behavior/mechanism gates; planning then sequences it. If the input is a broad story, epic, feature idea, or backlog item that still needs product slicing, use story-splitting first; if a slice needs review layers or later slices should start on an evolving baseline before lower PRs merge, also use stack-pull-requests.
 ---
 
 # Planning in Vertical Slices
@@ -22,10 +22,10 @@ Keep three units distinct:
 | Unit | Meaning | Default relationship |
 |---|---|---|
 | Backlog story | Fixed product capability and acceptance scope from `story-splitting` | A plan may advance one selected story |
-| Implementation slice | Smallest independently mergeable and releasable vertical increment, or one explicit reduction transition/terminal state | One PR |
-| PR layer | Dependent review package inside one slice | Exists only when `stack-pull-requests` justifies a stack |
+| Implementation slice | Smallest vertical increment or explicit reduction transition/terminal state that can merge and release safely once declared prerequisites land | One PR by default |
+| PR boundary | Review package that owns a whole slice or, exceptionally, a dependent layer inside one slice | Exists independently or inside a deliberate stack |
 
-Several implementation slices produce sequential independent PRs, not a stack. After one merges, start the next from trunk. If one slice is difficult to review as a single PR, load `stack-pull-requests`; its layers must not expand the slice's acceptance scope, conserved contract, or reduction obligations.
+A sequence is work order; a stack is branch topology. Default each slice to a trunk-based PR. Keep slice PRs independent when they can merge in any order without blocking or duplicating work, or when the next branch starts only after its predecessor lands. Load `stack-pull-requests` when one slice needs review layers or when later slices should start on the same evolving baseline before earlier PRs merge. Hard dependency is sufficient but not required; deliberate flow lineage may justify a stack. Speculative backtracking alone does not.
 
 If a plan starts producing database-only, API-only, UI-only, or "do all plumbing first" slices, pause and return to `story-splitting` unless the horizontal work explicitly unlocks the next vertical slice with independent verification or advances an explicitly selected reduction program toward its named terminal mechanism-removal state.
 
@@ -39,7 +39,7 @@ Before freezing slices that introduce a material generic mechanism or durable ne
 | Broad requirement with multiple outcomes | `story-splitting` | Child stories |
 | Existing story/plan/AC/mocks with holes | `find-gaps` | Confirmed artifact updates |
 | Selected child story ready for delivery sequencing | `planning` | Implementation slices with a delivery shape |
-| One planned slice may need dependent review PRs | `stack-pull-requests` + `planning` | Per-slice single PR or ordered PR stack |
+| One slice may need review layers, or later slices may start before lower PRs merge | `stack-pull-requests` + `planning` | Independent PRs or an explicit hard-/flow-lineage stack |
 
 ## Plans Directory
 
@@ -53,13 +53,13 @@ Multiple plans can coexist — each is independent and won't conflict across bra
 
 ## Prefer Small Reviewable PRs
 
-Default to the smallest independently mergeable vertical units, with one PR per slice. Use a stack only as the exception defined by `stack-pull-requests`: dependent layers may package one fixed slice for focused review, while the full stack remains that slice's delivery unit.
+Default to the smallest known-good vertical units, with one trunk-based PR per slice. Use a cross-slice stack when upper slices have hard dependency or deliberate flow lineage, will be in flight before lower merge, and review, lead-time, or correction-routing benefits earn the cascade cost. Use an intra-slice stack when one fixed slice still needs focused dependent review layers.
 
 **Why this matters:** Small PRs are easier to review, easier to revert, and easier to reason about. When something breaks, the cause is obvious. When a PR sits in review, it doesn't block unrelated work. The goal is to stay as close to main as possible at all times.
 
 **A PR is too big when** the reviewer needs to hold multiple unrelated concepts in their head to understand it, or when you'd struggle to write a clear 1-3 sentence summary of what it does.
 
-There will be exceptions — some changes are inherently coupled and splitting them would create broken intermediate states. Use judgement. First ask whether the work is really several independent slices; only then ask whether one remaining slice needs dependent review layers.
+There will be exceptions. Use judgement: first define honest vertical slices, then decide whether they stay independent, share a cross-slice hard/flow stack, or one slice needs intra-slice review layers.
 
 ## What Makes a Vertical Slice
 
@@ -113,7 +113,7 @@ Each slice MUST:
 - Be describable in one sentence
 - Deliver or directly unblock observable behavior, or safely advance an explicitly selected reduction program toward its terminal behavior/mechanism gates
 
-A slice is the unit of planning and independently mergeable value. By default it is also one review PR. With an approved stack, dependent PR layers become focused review boundaries and the top remains the slice's completion boundary. Within each behavior-changing PR boundary, fast RED-GREEN-REFACTOR increments may produce multiple commits; mutation testing or alternate evidence runs once when that boundary is otherwise PR-ready, not after each increment.
+A slice is the unit of planning and known-good value. By default it is also one review PR against trunk. In a cross-slice stack, each PR may own a complete slice and that slice completes when its PR lands bottom-up. In an intra-slice stack, dependent PR layers are focused review boundaries and the slice completes when its top lands. Within each behavior-changing PR boundary, fast RED-GREEN-REFACTOR increments may produce multiple commits; mutation testing or alternate evidence runs once when that boundary is otherwise PR-ready, not after each increment.
 
 **If you can't describe a slice in one sentence, break it down further.**
 
@@ -138,10 +138,10 @@ A slice is the unit of planning and independently mergeable value. By default it
 
 **Every behavior-changing slice uses fast RED-GREEN-REFACTOR increments, followed by one end-of-phase mutation or alternate-evidence gate when the slice is otherwise ready for its PR.** Before implementation, load `tdd`, `testing`, and applicable `refactoring` guidance. Use the `mutation-testing` mutator rules for cheap test-design guidance, but defer the automated harness until PR readiness. A true behavior-preserving refactor or `reduce-system-complexity` slice starts from passing proportionate preservation evidence and uses the same end-of-phase gate. Never fabricate a failing mechanism-count test or structural mutant. This section is a routing contract, not a replacement for those skills.
 
-For a stacked slice, apply that cadence to every PR layer against its parent review boundary. Put tests in the earliest layer that owns the behavior, run the mutation-or-alternate-evidence gate once when each layer is PR-ready, and require the top layer to prove the slice's complete acceptance criteria or reduction gates. Do not defer all tests or evidence to the top.
+For any stack, apply that cadence to every PR against its parent review boundary. Put tests in the PR that first owns the behavior, run the mutation-or-alternate-evidence gate once when each boundary is PR-ready, and require the top to prove every included slice's cumulative acceptance criteria or reduction gates. Do not defer tests or evidence upstack.
 
 ```
-FOR EACH BEHAVIOR-CHANGING SLICE OR PR LAYER:
+FOR EACH BEHAVIOR-CHANGING SLICE OR PR BOUNDARY:
     │
     ├─► LOAD: Required implementation skills
     │   - `tdd` for RED-GREEN-REFACTOR
@@ -206,7 +206,7 @@ After completing an implementation increment:
 2. Verify static analysis passes
 3. Present class-specific evidence: RED/GREEN for behavior change; preserved contract for pure refactor; passing behavior gate plus independent verification and pending mechanism gate/no net claim for a transition; or linked program/ledger, discharged obligations, both passing gates, and retired machinery for a terminal reduction
 
-Do not require a mutation report for every commit. When the complete slice is otherwise ready for its PR, run the end-of-phase mutation gate once and present its final report (or the reviewed alternate-evidence record and `N/A` rationale).
+4. Do not require a mutation report for every commit. When the current PR boundary is otherwise ready, run the end-of-phase mutation gate once and present its final report (or the reviewed alternate-evidence record and `N/A` rationale).
 5. **STOP and ask**: "Ready to commit [description]. Approve?"
 
 Only proceed with commit after explicit approval.
@@ -262,7 +262,7 @@ Read the project's CLAUDE.md and testing rules before writing slices.
 **Value**: [Behavior change: actor and observable outcome. Pure refactor: preserved consumer surface and maintenance value. Reduction transition: why this independently verifiable increment is necessary to reach the terminal state. Terminal reduction: conserved contract plus the ownership/mechanism retired.]
 **Path**: [Behavior change: entry point -> business path -> state/output -> observability. Pure refactor: preserved public surface. Either reduction class: affected trigger-to-outcome path, program/terminal link, and mechanism scope.]
 **Class**: Behavior change / pure refactor / reduction transition / terminal reduction.
-**Delivery**: [Single PR (default), or a `#### Delivery Shape` map from `stack-pull-requests` nested under this slice.]
+**Delivery**: [Independent PR against trunk (default); cross-slice stack member referencing the shared `#### Delivery Shape`; or an intra-slice `#### Delivery Shape` map.]
 **Required implementation skills**: For changed behavior, load `tdd`, `testing`, and applicable refactoring guidance. For a pure refactor, load only applicable testing and refactoring skills. Every reduction transition and terminal reduction loads `reduce-system-complexity` plus applicable evidence skills. At each PR boundary's readiness, load `mutation-testing` for the focused scope where meaningful or record the alternate-evidence `N/A`. Add UI/domain/architecture skills only when relevant.
 **Reduction program**: [For either reduction class: reference the plan-level program and terminal slice; otherwise `N/A`.]
 **Transition/terminal evidence**: [Transition: `behavior gate: pass`, independent verification, bridge owner/removal/bounded-lifetime metadata when a bridge exists (`N/A` otherwise), and `mechanism gate: pending — no net-reduction claim`. Terminal: passing behavior gate, like-for-like mechanism gate, and removal of the superseded mechanism/expired bridges. Otherwise `N/A`.]
@@ -270,8 +270,9 @@ Read the project's CLAUDE.md and testing rules before writing slices.
 **RED or preservation baseline**: For behavior change, what failing behavior test will we write? For a pure refactor/reduction, which passing oracles and proportionate non-test evidence conserve the affected behavior and guarantees? Never assert implementation shape merely to create RED.
 **GREEN or preservation change**: What minimum code makes the new behavior pass, or what smallest mechanism-only change preserves the baseline?
 **REFACTOR**: Assess improvements (only if they add value).
-**PRE-PR MUTATION or alternate evidence**: Once the slice is otherwise ready for its PR, run mutation testing once for the accumulated scope. Address valuable survivors and re-run focused/diff checks inside the same gate. Otherwise mark `N/A` and name reachability, configuration, contract, integration, or operational evidence; never invent structural mutants.
-**Done when**: All acceptance criteria and end-of-phase mutation/alternate-evidence obligations are met. A transition is done when its behavior gate and independent checks pass while the mechanism gate remains truthfully pending with no net claim; a terminal reduction is done only when both gates pass and old machinery/expired bridges are gone. The human approves the commit.
+**PRE-PR MUTATION or alternate evidence**: Once the current review boundary is otherwise PR-ready, run mutation testing once for its accumulated scope. Address valuable survivors and re-run focused/diff checks inside the same gate. Otherwise mark `N/A` and name reachability, configuration, contract, integration, or operational evidence; never invent structural mutants.
+**PR-ready when**: All acceptance criteria owned by the current boundary and its end-of-phase mutation/alternate-evidence obligations are met. A transition's behavior gate and independent checks pass while its mechanism gate remains truthfully pending with no net claim; a terminal reduction passes both gates and removes old machinery/expired bridges. The human approves the commit.
+**Slice complete when**: Its independent or cross-slice owning PR lands, or the top PR lands for an intra-slice stack.
 
 ### Slice 2: [One sentence observable behaviour]
 
@@ -287,7 +288,7 @@ Before each PR:
 5. Complete tests — stop watchers and run the repository-defined complete non-watch PR test gate; in a monorepo include every configured project and required integration/E2E suite, not only the affected development subset
 6. Evidence freshness — apply the target repository's mutation-evidence rule after later fixes. Use this distribution's `commands/pr.md` model only when the repository has no stricter invalidation policy, and keep project verification current after resulting fixes
 
-For a stacked slice, nest the exact `#### Delivery Shape` and whole-stack gate from `stack-pull-requests` under that slice. Do not set one delivery mode for the whole plan.
+For an intra-slice stack, nest the exact `#### Delivery Shape` and whole-stack gate under that slice. For a cross-slice stack, place one shared map before the first included slice and reference it from each included slice. Never stack an entire plan by default.
 
 ---
 *Delete this file when the plan is complete. If `plans/` is empty, delete the directory.*
@@ -305,9 +306,9 @@ Plans are not immutable, but changes must be explicit and approved.
 
 ## End of Feature
 
-When all slices are complete:
+When every slice's owning PR has landed (or the top PR has landed for each intra-slice stack):
 
-1. **Verify completion** — all acceptance criteria met; applicable tests and mutation/alternate evidence pass; any reduction program reaches a terminal slice with both gates passed and old machinery/expired bridges gone
+1. **Verify completion** — all owning PRs landed; all acceptance criteria met; applicable tests and mutation/alternate evidence pass; any reduction program reaches a terminal slice with both gates passed and old machinery/expired bridges gone
 2. **Merge learnings** — if significant insights were gained, use the `learn` agent for CLAUDE.md updates or `adr` agent for architectural decisions
 3. **Delete plan file** — remove from `plans/`, delete `plans/` if empty
 
@@ -329,7 +330,7 @@ When all slices are complete:
 - Prefer a walking skeleton that proves the real path, then widen it behavior by behavior
 
 ❌ **Slices that span multiple PRs without a delivery decision**
-- Default to one PR. If dependent review layers genuinely help, load `stack-pull-requests`, justify the exception, and keep the slice scope and terminal obligations fixed.
+- Default each slice to one trunk-based PR. If a cross-slice flow/hard stack or intra-slice review layers materially help, load `stack-pull-requests`, justify the exact topology, and preserve every slice's scope and terminal obligations.
 
 ❌ **Writing changed behavior before its test**
 - RED comes first for behavior change; a true REFACTOR slice records passing preservation evidence instead
@@ -349,7 +350,7 @@ START FEATURE
 │
 │   FOR EACH IMPLEMENTATION SLICE:
 │   │
-│   ├─► DELIVERY: Single PR by default; otherwise nest an approved stack map
+│   ├─► DELIVERY: Independent trunk-based PR by default; otherwise reference an approved intra- or cross-slice stack map
 │   ├─► BEHAVIOR CHANGE: LOAD → CONFIRM → RED → GREEN → REFACTOR → REPEAT WITHOUT MUTATION HARNESS
 │   ├─► OR PURE REFACTOR/REDUCTION: PASSING BASELINE → REFACTOR/REDUCE → VERIFY GATES
 │   ├─► **PRESENT WORK, WAIT FOR COMMIT APPROVAL**
@@ -358,7 +359,7 @@ START FEATURE
 │
 END FEATURE
 │
-├─► Verify all criteria met
+├─► Verify all owning PRs landed and all criteria met
 ├─► Merge learnings if significant (learn agent, adr agent)
 └─► Delete plan file from plans/
 ```

--- a/claude/.claude/skills/stack-pull-requests/SKILL.md
+++ b/claude/.claude/skills/stack-pull-requests/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: stack-pull-requests
-description: Decide whether a planned vertical implementation slice should ship as one pull request or as a stack of small dependent pull requests, then plan, build, review, update, and merge the stack safely. Use when work is too large for one effective review, when AI-generated code volume needs deliberate review boundaries, when the user mentions stacked PRs, PR stacks, dependent PRs, gh-stack, bottom-up review, or splitting an implementation across branches. Do not use this skill to split epics or invent horizontal backlog stories; use story-splitting first.
+description: Decide whether planned vertical implementation work should ship as independent pull requests or as a stack of small ordered pull requests, then plan, build, review, update, and merge the stack safely. Use when one slice is too large for effective review, when later slices should proceed on the same evolving baseline before earlier pull requests merge, when AI-generated code volume needs deliberate review boundaries, or when the user mentions stacked PRs, PR stacks, dependent PRs, gh-stack, bottom-up review, or splitting an implementation across branches. Do not use this skill to split epics or invent horizontal backlog stories; use story-splitting first.
 ---
 
 # Stack Pull Requests
 
-Use stacked pull requests as an optional **review and integration tactic**, not as a substitute for vertical story splitting.
+Use stacked pull requests as an optional **branch, review, and integration topology**, not as a substitute for vertical story splitting.
 
-Default to one vertical PR. Stack only when smaller dependent diffs materially improve review quality or flow without weakening testing, deployability, or comprehension.
+Default each vertical implementation slice to one PR against trunk. Stack only when ordered branches materially improve review quality or let work continue on the same evolving baseline before lower reviews merge, without weakening testing, deployability, or comprehension.
 
 GitHub's stacked PR support is in public preview. Load `references/source-notes.md` when exact GitHub behavior, command provenance, or the rationale behind these rules matters. Verify current official docs and `gh stack --help` before relying on preview-specific commands.
 
@@ -16,45 +16,59 @@ GitHub's stacked PR support is in public preview. Load `references/source-notes.
 | Unit | Question | Owner | Rule |
 |---|---|---|---|
 | Backlog story | What bounded capability delivers value or learning? | `story-splitting` | Keep it vertical and fix its acceptance scope before delivery planning |
-| Implementation slice | What smallest vertical increment advances that story and leaves a known-good state? | `planning` | Merge and release it independently; use one PR by default |
-| PR layer | How should one implementation slice be packaged for review? | This skill | Use only inside a deliberate stack; it may be technical and dependent |
+| Implementation slice | What smallest vertical increment advances that story and leaves a known-good state? | `planning` | Merge and release it safely once declared prerequisites land; use one PR by default |
+| PR boundary | How should planned implementation work be packaged for review? | This skill | Usually owns one whole slice; may instead be a dependent layer within one slice |
 
-A plan may contain several implementation slices. Those are sequential independent vertical PRs, not a stack: after one merges, the next starts from trunk. Apply the single-PR-versus-stack decision to **each slice**, never to the plan as a whole.
+A sequence describes work order; a stack describes branch dependency. A lower PR in a stack may be independently mergeable, while every upper PR targets the branch below it. Several vertical slices are therefore not automatically independent PRs and not automatically a stack.
 
-A PR layer is not a child story or implementation slice. It must not add acceptance scope. The selected slice remains the fixed end-to-end unit delivered by the full stack.
+Use independent PRs when each slice can target trunk and merge in any safe order without blocking or duplicating work, or when the next branch starts only after its predecessor merges. Use a cross-slice stack for either **hard lineage** (an upper slice requires a lower slice) or **flow lineage** (slices remain separately complete, but upper work starts before lower review and merge on the same evolving baseline, and fixed lower-first landing is acceptable). Use an intra-slice stack when one fixed slice is too large for one effective review.
+
+Backtracking is a real stack benefit: a lower-branch correction stays with its owning PR and stack tooling propagates it upward. It is not free insurance. Every changed upper branch must be rebased, pushed, rechecked, and may conflict or lose stale approvals. Treat likely lower-boundary iteration while dependent upper work is already in flight as a benefit; do not manufacture a branch dependency solely because an earlier decision might someday change.
+
+An intra-slice PR layer is not a child story or implementation slice and must not add acceptance scope. A cross-slice stack member may own a complete planned slice and its acceptance criteria; it must not invent scope outside the approved slices.
 
 Use this order:
 
 1. Load `story-splitting` if the request still contains multiple customer outcomes, paths, roles, or quality levels.
 2. Select one vertical child story.
-3. Load `planning` to define its vertical implementation slices, classes, evidence, and terminal obligations.
-4. For each slice, use this skill only if its single-PR diff would be hard to review.
-5. Use `find-gaps` if acceptance criteria, release constraints, or intermediate safety remain unclear.
+3. Load `planning` to define its vertical implementation slices, dependencies, classes, evidence, and terminal obligations.
+4. Use this skill when one slice needs review layers or when a contiguous run of hard- or flow-lineage slices should be in flight together.
+5. Keep slices as independent trunk-based PRs when no review, lead-time, or correction-routing benefit earns fixed order and cascade cost.
+6. Use `find-gaps` if acceptance criteria, release constraints, or intermediate safety remain unclear.
 
 Do not turn `database → API → UI → tests` into backlog stories. If those boundaries help review one selected implementation slice, describe them as dependent PR layers and keep their release state explicit.
 
-## Decide: One PR Or A Stack
+## Decide: Independent PRs Or A Stack
 
-Choose a stack for one implementation slice only when all of these hold:
+Choose a stack only when all of these hold:
 
-- The slice has fixed acceptance scope inside one cohesive vertical story or a fixed conserved contract inside an approved reduction program.
-- The slice's combined diff would be slow, risky, or cognitively expensive to review.
-- The work has a real one-way dependency order.
-- Each proposed layer is one coherent change that can be understood from its own diff plus the layers below.
-- Each layer can leave its cumulative branch known-good: buildable, verified, and safe to deploy or explicitly dormant.
-- The expected cascade/rebase cost is lower than the review benefit of smaller diffs.
-- The repository and team can support dependent branches, rebases, and bottom-up merging.
-- CI and repository rules can run the required checks on PRs whose base is another feature branch.
+- Its scope is one fixed slice or a contiguous deliberately ordered sequence of already planned vertical slices or reduction transitions.
+- At least one benefit is concrete: the combined change needs focused diffs, or later ordered work should proceed before lower review and merge complete.
+- The branches have deliberate one-way lineage: a hard dependency, or deliberate flow lineage where upper work actually begins before lower merge on the same evolving baseline and fixed lower-first landing is acceptable.
+- Each PR owns one whole slice where practical, or one coherent intra-slice layer that can be understood from its own diff plus the layers below.
+- Each PR boundary can leave its cumulative branch known-good: buildable, verified, and safe to deploy or explicitly dormant.
+- Every lower slice remains useful and safe to merge if all upper work is abandoned.
+- The expected cascade/rebase cost is lower than the focused-review, lead-time, and correction-ownership benefit.
+- The repository and team can support dependent branches, cascading rebases, and native prefix/group merge or manual bottom-up merge.
+- The intended stack mechanism can apply the required CI and repository rules to every PR.
 
-Prefer one vertical PR when any of these hold:
+Prefer independent trunk-based PRs when any of these hold:
 
 - The whole change is already a quick, coherent review.
+- The proposed slice PRs can target trunk and merge, reorder, or be dropped independently without blocking or duplicating work.
+- The next dependent slice can wait until its prerequisite merges without blocking useful work or feedback.
 - Splitting would separate tests or evidence from the behavior or contract they protect.
 - Reviewers must understand the full stack to judge every layer.
 - Intermediate merges would expose an unsafe schema, contract, bridge, or half-feature.
 - The change is cross-cutting enough that every layer would repeatedly touch the same code.
 - The only proposed boundaries are files, architectural tiers, work phases, or team ownership.
+- The only proposed benefit is speculative convenience if an earlier decision changes.
 - Rebase and CI churn would cost more than the smaller diffs save.
+
+### Run Two Counterfactuals
+
+1. **Trunk counterfactual:** Could every proposed PR start from current trunk and merge, reorder, or be dropped without incorporating a sibling? If no, use a hard-lineage stack when the other gates pass.
+2. **Flow counterfactual:** If yes, will upper work actually start before the lower PR lands on the same evolving path, is fixed lower-first landing acceptable, and will saved wait time or lower-owned correction routing outweigh restacking and re-review? If yes, a flow-lineage stack is valid. Otherwise use independent PRs.
 
 Do not stack by reflex. Record the decision in one sentence:
 
@@ -69,83 +83,89 @@ Delivery: 3-PR stack — the dormant migration, tested repository adapter, and
 fixed sign-in slice form one-way dependencies with meaningful verification.
 ```
 
+or:
+
+```text
+Delivery: 3-PR flow-lineage stack — each vertical slice is known-good in order,
+upper work starts now on the same evolving path, and lower-first landing is acceptable.
+```
+
 ## Design The Stack Before Writing Code
 
-### 1. Fix The Story And Slice Scope
+### 1. Fix The Story And Stack Scope
 
-Write the selected story's actor and outcome, then the selected implementation slice's:
+Write the selected story's actor and outcome, then record:
 
-- trigger
-- observable outcome or conserved contract
-- production path: entry point → domain behavior → state/external effects → output → observability
-- acceptance examples or preservation evidence
-- class and any reduction-program/terminal obligations from `planning`
-- release constraint
+- whether the stack is inside one slice or spans a contiguous sequence of slices
+- every included slice, its trigger, observable outcome or conserved contract, production path, acceptance evidence, class, and release constraint
+- the fixed union of approved scope covered by the stack
 
-If the story still describes more than one customer capability, return to `story-splitting`. If the slice contains several independently mergeable vertical outcomes or reduction transitions, keep them as sequential slices in `planning`. Freeze the selected slice's scope before drawing PR layers.
+If the story still describes more than one customer capability, return to `story-splitting`. Keep every vertical outcome or reduction transition as a distinct slice in `planning`, even when several slices share a stack. For a cross-slice stack, each PR may add its own approved acceptance case in dependency order. For an intra-slice stack, freeze the selected slice's scope before drawing PR layers.
 
-For a reduction slice, PR layers do not replace its ledger or gates. A lower layer cannot claim net reduction while superseded machinery or an added bridge remains; only the top of a terminal-reduction slice may satisfy the mechanism gate and claim the fixed terminal state.
+For reduction work, stack membership does not replace the ledger or gates. A transition cannot claim net reduction while superseded machinery or an added bridge remains; only the terminal-reduction slice may satisfy the mechanism gate and claim the fixed terminal state.
 
-### 2. Draw The Dependency Graph
+### 2. Draw The Lineage Graph
 
-Identify what genuinely must exist before something else. Separate logical dependency from habitual build order. "We usually build the backend first" is not evidence.
+Identify hard dependencies and deliberate flow lineage. Separate both from habitual build order. "We usually build the backend first" is not evidence; "the next approved slice starts now on this evolving baseline while review is open" can be.
 
 Prefer boundaries in this order:
 
-1. **Testable path increments** — each PR advances the same fixed slice without adding a new acceptance case that belongs in another slice.
-2. **Behavior-preserving preparation** — a focused refactor or safety characterization that makes the later change reviewable.
-3. **Backward-compatible enablement** — a migration, contract, or infrastructure change that is verified, dormant, and directly used by the next PR.
-4. **Risk isolation** — a security-, data-, or performance-sensitive change that deserves focused expert review.
-5. **Reviewer expertise** — a subsystem boundary, only when the PR still makes sense without an essay about the rest of the stack.
+1. **Whole vertical slices** — each PR owns one approved known-good slice; upper work has hard or deliberate flow lineage and overlaps lower review.
+2. **Testable path increments** — each PR advances the same fixed slice without adding an acceptance case that belongs in another slice.
+3. **Behavior-preserving preparation** — a focused refactor or safety characterization that makes the later change reviewable.
+4. **Backward-compatible enablement** — a migration, contract, or infrastructure change that is verified, dormant, and directly used by the next PR.
+5. **Risk isolation** — a security-, data-, or performance-sensitive change that deserves focused expert review.
+6. **Reviewer expertise** — a subsystem boundary, only when the PR still makes sense without an essay about the rest of the stack.
 
 Avoid:
 
 - all tests in the top PR
 - speculative foundations or abstractions
-- layers whose only claim is "files in the same folder"
-- a lower layer that requires an upper layer to compile, migrate safely, pass CI, or discharge an unowned bridge
-- duplicate fixups in upper layers instead of fixing the owning lower layer
+- boundaries whose only claim is "files in the same folder"
+- a lower boundary that requires an upper boundary to compile, migrate safely, pass CI, or discharge an unowned bridge
+- duplicate fixups in upper boundaries instead of fixing the owning lower boundary
 - a long stack where cascade and review overhead dominate
 
-There is no universal layer count or line limit. Keep the smallest stack whose PRs are quick reads with one concept each. If two adjacent layers need the same explanation or evidence, fold them together.
+There is no universal boundary count or line limit. Keep the smallest stack whose PRs are quick reads with one concept each. If two adjacent boundaries need the same explanation or evidence, fold them together.
 
-### 3. Route Verification By Layer Type
+### 3. Route Verification By Boundary Type
 
 GitHub's tutorial illustrates tests as a final layer; do not copy that ordering into this workflow.
 
-For a behavior-changing production layer:
+For a behavior-changing production boundary:
 
 - Load `tdd`, `testing`, and applicable `refactoring` guidance before code changes.
-- Follow fast RED-GREEN-REFACTOR increments for the behavior owned by that layer.
-- Put contract, migration, unit, integration, or UI tests in the earliest layer that owns the behavior.
-- When the layer is otherwise PR-ready, load `mutation-testing` and run its accumulated-scope gate once against the layer's parent where meaningful, or record its proportionate alternate-evidence `N/A`.
+- Follow fast RED-GREEN-REFACTOR increments for the behavior owned by that boundary.
+- Put contract, migration, unit, integration, or UI tests in the earliest boundary that owns the behavior.
+- When the boundary is otherwise PR-ready, load `mutation-testing` and run its accumulated-scope gate once against its parent where meaningful, or record its proportionate alternate-evidence `N/A`.
 
-For a behavior-preserving layer:
+For a behavior-preserving production boundary:
 
 - Load applicable testing and `refactoring` guidance; if protection is inadequate, load `finding-seams` and `characterisation-tests`.
 - Establish passing preservation evidence for the touched consumer paths.
 - Refactor without changing behavior, keeping the applicable focused/affected tests green.
-- At PR readiness, run the same once-per-layer mutation-or-alternate-evidence gate; do not fabricate structural mutants.
+- At PR readiness, run the same once-per-boundary mutation-or-alternate-evidence gate; do not fabricate structural mutants.
 
-For reduction-transition or terminal-reduction layers, also preserve the selected slice's `reduce-system-complexity` ledger, conserved contract, bridge ownership/removal obligations, and behavior/mechanism gate status.
+For reduction-transition or terminal-reduction boundaries, also preserve the selected slice's `reduce-system-complexity` ledger, conserved contract, bridge ownership/removal obligations, and behavior/mechanism gate status.
 
-For documentation, release metadata, configuration, or non-production mechanical changes, use the smallest executable verification that can fail if the layer is wrong and record mutation `N/A` when appropriate.
+For documentation, release metadata, configuration, or non-production mechanical changes, use the smallest executable verification that can fail if the boundary is wrong and record mutation `N/A` when appropriate.
 
-For every layer, run the repository's required build, lint, type, security, and complete non-watch test checks and verify the cumulative branch, because an upstack PR contains every lower layer.
+For every PR boundary, run the repository's required build, lint, type, security, and complete non-watch test checks and verify the cumulative branch, because an upstack PR contains every lower boundary.
 
-The top layer must prove the selected slice's acceptance examples or terminal gates. It may add stack-level tests, but it must not be the first place lower-layer behavior is tested.
+The top boundary must prove the cumulative acceptance examples or terminal gates for every included slice. It may add stack-level tests, but a behavior's first test belongs in the PR that introduces that behavior, not a later stack member.
 
 ### 4. Verify CI Topology Before Stacking
 
-Inspect the repository's workflows, rulesets, required status contexts, and merge queue:
+Identify whether the PRs will be linked as a GitHub-native stack or merely form an unlinked dependent branch chain, then inspect workflows, rulesets, required status contexts, and the merge queue:
 
-- Confirm `pull_request` workflows run when an upper PR targets a lower feature branch. Branch filters evaluate the PR's base branch; a `main`-only filter can skip every upper layer.
-- Confirm every required status is produced for every layer that needs it.
+- For a GitHub-native linked stack, GitHub evaluates Actions, branch protection, required checks, reviews, CODEOWNERS, and code scanning against the stack trunk. A `pull_request` workflow filtered to that trunk runs for every stack PR; do not require a workflow change merely because an upper PR directly targets a feature branch.
+- For unlinked dependent PRs or tooling without equivalent stack metadata, ordinary immediate-base semantics apply. Confirm feature-base PRs trigger the required workflows before relying on them.
+- Confirm every required status is produced for every PR boundary that needs it.
 - If the repository uses a merge queue, confirm required workflows handle `merge_group`.
-- Decide which focused checks run per layer and which cumulative or end-to-end checks run at the top; do not weaken required merge checks to make stacking convenient.
+- Decide which focused checks run per boundary and which cumulative or end-to-end checks run at the top; do not weaken required merge checks to make stacking convenient.
 - Account for rebase-triggered reruns and existing affected-test or cache behavior.
 
-Prefer one PR when the repository cannot give dependent PRs trustworthy required checks without risky CI changes.
+Prefer one PR when the chosen stack mechanism cannot give every boundary trustworthy required checks without risky CI changes.
 
 ### 5. Make Intermediate States Safe
 
@@ -162,36 +182,37 @@ Never merge an intermediate state that breaks callers, requires an unavailable s
 
 ## Write The Delivery Plan
 
-Add this section under the selected implementation slice, not at plan level:
+For an intra-slice stack, add this section under the selected implementation slice. For a cross-slice stack, place one shared map immediately before the first included slice and reference it from every included slice:
 
 ```markdown
 #### Delivery Shape
 
 **Mode**: Single PR | Stacked PRs
+**Stack scope**: Intra-slice | Cross-slice
 **Reason**: [Why this shape improves review without weakening delivery]
-**Story scope**: [Fixed parent story; PR layers must not expand it]
-**Slice class**: [Class from planning]
-**Slice done when**: [Fixed observable outcome, conserved contract, or terminal gates]
+**Story scope**: [Fixed parent story; PR boundaries must not expand it]
+**Included slices**: [One fixed slice, or the exact contiguous slice sequence]
+**Done when**: [Acceptance criteria or terminal gates for all included slices]
 
-| # | PR layer | Base | Owns | Depends on | Verification | Release state |
-|---|---|---|---|---|---|---|
-| 1 | [focused title] | [repository default branch] | [one coherent change] | — | [tests/evidence/checks] | [deployable/dormant/etc.] |
-| 2 | [focused title] | layer 1 | [one coherent change] | [specific contract] | [tests/evidence/checks] | [...] |
+| # | Ownership unit | PR boundary | Base | Owns | Depends on | Verification | Release state |
+|---|---|---|---|---|---|---|---|
+| 1 | [whole slice or intra-slice layer] | [focused title] | [repository default branch] | [one coherent change] | — | [tests/evidence/checks] | [deployable/dormant/etc.] |
+| 2 | [whole slice or intra-slice layer] | [focused title] | [boundary 1 branch] | [one coherent change] | [specific contract or deliberate flow lineage] | [tests/evidence/checks] | [...] |
 
 ### Whole-stack gate
 
-- [ ] Slice acceptance examples, conserved contract, and applicable terminal gates pass at the top
-- [ ] Every layer's focused and cumulative checks pass
-- [ ] No behavior waits until a later PR for its first test
-- [ ] Every PR-ready layer has current mutation or alternate evidence for its focused review boundary
+- [ ] Every included slice's acceptance examples, conserved contract, and applicable terminal gates pass cumulatively at the top
+- [ ] Every PR boundary's focused and cumulative checks pass
+- [ ] No behavior waits beyond its owning PR for its first test
+- [ ] Every PR-ready boundary has current mutation or alternate evidence for its focused review scope
 - [ ] Intermediate merge and release states are explicit and safe
 - [ ] Reduction ledger, bridge, and mechanism-gate obligations remain accurate when applicable
-- [ ] CI runs required statuses for dependent-base PRs and `merge_group` when applicable
-- [ ] Review sequence is bottom-up for dependency-sensitive layers; independent specialist reviews may run in parallel
-- [ ] Merge order is bottom to top
+- [ ] Native stack-trunk or unlinked immediate-base CI semantics are identified; required statuses and `merge_group` run where applicable
+- [ ] Review sequence is bottom-up for lineage-sensitive boundaries; independent specialist reviews may run in parallel
+- [ ] Merge includes every required lower PR: native all-or-nothing prefix/group, or manual bottom-up order
 ```
 
-For each layer, also record:
+For each PR boundary, also record:
 
 - focused review question
 - included and excluded scope
@@ -203,24 +224,24 @@ Use repository branch naming conventions. Do not create branches, commit, push, 
 
 ## Build Bottom To Top
 
-For each layer:
+For each PR boundary:
 
-1. Start from the topmost completed branch.
-2. Confirm the layer's acceptance criteria or conserved contract with the user before code.
+1. Start from the topmost committed, known-good branch.
+2. Confirm the boundary's acceptance criteria or conserved contract with the user before code.
 3. Complete the applicable implementation route and keep focused/affected checks green.
-4. When the layer is otherwise PR-ready, complete its mutation-or-alternate-evidence gate and repository checks.
+4. When the boundary is otherwise PR-ready, complete its mutation-or-alternate-evidence gate and repository checks.
 5. Self-review the diff against its parent, not against trunk.
 6. Remove work that belongs upstack.
 7. Present the focused diff and verification evidence.
 8. Wait for commit approval.
-9. Create the next branch only after the current layer is committed and known-good; review approval is not required to extend the stack.
+9. Create the next branch only after the current boundary is committed and known-good; review approval is not required to extend the stack.
 
 Prefer the official `gh stack` command when it is available and matches current repository policy. Use current help rather than memorized preview syntax. If it is unavailable, either manage dependent branches and PR bases with existing Git/GitHub tooling or ask before installing anything.
 
-Open unfinished upper layers as drafts. Give each PR a focused title and concise description containing:
+Open unfinished upper boundaries as drafts. Give each PR a focused title and concise description containing:
 
-- selected story, fixed implementation slice, and this layer's purpose
-- parent/base PR and next layer, when known
+- selected story, included implementation slice(s), and this PR's purpose
+- parent/base PR and next boundary, when known
 - what to review in this diff
 - verification performed
 - release state
@@ -228,11 +249,11 @@ Open unfinished upper layers as drafts. Give each PR a focused title and concise
 
 ## Review And Revise
 
-Self-review every layer before requesting review. Check function, intent, code quality, dependencies, AI-specific mistakes, and test integrity.
+Self-review every PR boundary before requesting review. Check function, intent, code quality, dependencies, AI-specific mistakes, and test integrity.
 
-Request review from the bottom upward when later layers depend strongly on earlier decisions. Different specialists may review and approve layers in parallel when each focused diff is understandable. Merge readiness and merge order still flow bottom to top.
+Request review from the bottom upward when later boundaries depend strongly on earlier decisions. Different specialists may review and approve boundaries in parallel when each focused diff is understandable. Merge readiness and merge order still flow bottom to top.
 
-When feedback changes a lower layer:
+When feedback changes a lower boundary:
 
 1. Move to the branch that owns the change.
 2. Fix and test it there.
@@ -243,23 +264,32 @@ When feedback changes a lower layer:
 
 Do not add an upstack workaround for a downstack defect.
 
-Reshape the stack when evidence changes. Fold adjacent PRs that cannot be reviewed separately; split a layer that acquired a second concept; reorder only when dependencies allow it. A clean working tree and recoverable rebase path are prerequisites for structural changes.
+Put a discovery in the boundary that owns it:
+
+- If it repairs behavior or a contract promised by a lower slice, fix that lower branch and restack.
+- If it adds acceptance scope owned only by an upper slice, keep it upstack.
+- If the owning lower PR already merged, use a focused trunk-based fix; after it lands, sync or rebase and recheck the remaining upper stack before continuing.
+- If it invalidates the planned boundaries, reshape the stack and plan instead of smuggling scope downstack.
+
+Reshape the stack when evidence changes. Fold adjacent PRs that cannot be reviewed separately; split a boundary that acquired a second concept; reorder only when dependencies allow it. A clean working tree and recoverable rebase path are prerequisites for structural changes.
 
 ## Merge And Finish
 
 Before merge:
 
-- require passing checks and required approvals for the layer and every layer below it
+- require passing checks and required approvals for the boundary and every boundary below it
 - require linear stack history
-- verify the top branch still satisfies the fixed slice acceptance criteria or terminal gates
+- verify the top branch satisfies the complete declared stack scope and cumulative acceptance criteria or terminal gates
 - verify any partially merged state remains safe
 - resolve documentation conflicts using current GitHub guidance because stacked PR behavior is preview
 
-Merge from the bottom upward, individually or as a contiguous group supported by the repository. Never treat a mid-stack PR as independently mergeable when it depends on unmerged layers below.
+For a GitHub-native linked stack, merge an approved prefix or the full stack with `gh stack merge`; the selected PR and every PR below it land as one all-or-nothing operation unless a merge queue splits processing into groups. For an unlinked dependent chain or other tooling, merge bottom-up and restack after lower merges. Never merge an upper PR without every dependency below it.
 
-After lower layers merge, sync or rebase the remaining stack, rerun affected checks, and verify each PR still shows only its intended focused diff. Mark the implementation slice complete only when its top lands. Delete the plan when every selected implementation slice lands, following `planning`.
+After lower boundaries merge, sync or rebase the remaining stack, rerun affected checks, and verify each PR still shows only its intended focused diff. Mark a cross-slice stack's slice complete when its owning PR lands; mark an intra-slice stack's slice complete only when its top lands. The whole stack completes when its top lands. Delete the plan when every selected implementation slice lands, following `planning`.
 
-## Example: Preserve The Vertical Slice
+## Examples
+
+### Use Layers Inside One Vertical Slice
 
 Selected story and fixed implementation slice:
 
@@ -276,3 +306,13 @@ If it is too large, a responsible stack could be:
 3. Add the valid-credential path through the real entry point, domain behavior, storage, response, and observability, with its behavior tests.
 
 The story and slice remain vertical and their scope does not grow. Layers 1 and 2 are enabling tasks, not user stories or implementation slices. Use separate "all endpoints" or "all middleware" PRs only when concrete repository constraints make that safer and every layer still satisfies this skill's gates. Never defer all tests to a final PR.
+
+### Stack Several Vertical Slices
+
+A plan may instead define these approved slices:
+
+1. A registered customer can sign in with valid credentials.
+2. A customer with invalid credentials sees a safe rejection.
+3. Repeated invalid attempts temporarily lock the account.
+
+Keep them as three implementation slices. If each can target trunk and merge in any order without blocking or duplicating work, use independent PRs. Use a three-PR cross-slice stack if slices 2 and 3 require the lower behavior, or if their work starts before lower reviews merge on the same evolving baseline and fixed lower-first landing is worth the cascade cost. Fix lower-owned feedback in the lower slice and propagate it upward; keep new upper-slice scope upstack.

--- a/claude/.claude/skills/stack-pull-requests/SKILL.md
+++ b/claude/.claude/skills/stack-pull-requests/SKILL.md
@@ -1,0 +1,278 @@
+---
+name: stack-pull-requests
+description: Decide whether a planned vertical implementation slice should ship as one pull request or as a stack of small dependent pull requests, then plan, build, review, update, and merge the stack safely. Use when work is too large for one effective review, when AI-generated code volume needs deliberate review boundaries, when the user mentions stacked PRs, PR stacks, dependent PRs, gh-stack, bottom-up review, or splitting an implementation across branches. Do not use this skill to split epics or invent horizontal backlog stories; use story-splitting first.
+---
+
+# Stack Pull Requests
+
+Use stacked pull requests as an optional **review and integration tactic**, not as a substitute for vertical story splitting.
+
+Default to one vertical PR. Stack only when smaller dependent diffs materially improve review quality or flow without weakening testing, deployability, or comprehension.
+
+GitHub's stacked PR support is in public preview. Load `references/source-notes.md` when exact GitHub behavior, command provenance, or the rationale behind these rules matters. Verify current official docs and `gh stack --help` before relying on preview-specific commands.
+
+## Keep The Three Units Separate
+
+| Unit | Question | Owner | Rule |
+|---|---|---|---|
+| Backlog story | What bounded capability delivers value or learning? | `story-splitting` | Keep it vertical and fix its acceptance scope before delivery planning |
+| Implementation slice | What smallest vertical increment advances that story and leaves a known-good state? | `planning` | Merge and release it independently; use one PR by default |
+| PR layer | How should one implementation slice be packaged for review? | This skill | Use only inside a deliberate stack; it may be technical and dependent |
+
+A plan may contain several implementation slices. Those are sequential independent vertical PRs, not a stack: after one merges, the next starts from trunk. Apply the single-PR-versus-stack decision to **each slice**, never to the plan as a whole.
+
+A PR layer is not a child story or implementation slice. It must not add acceptance scope. The selected slice remains the fixed end-to-end unit delivered by the full stack.
+
+Use this order:
+
+1. Load `story-splitting` if the request still contains multiple customer outcomes, paths, roles, or quality levels.
+2. Select one vertical child story.
+3. Load `planning` to define its vertical implementation slices, classes, evidence, and terminal obligations.
+4. For each slice, use this skill only if its single-PR diff would be hard to review.
+5. Use `find-gaps` if acceptance criteria, release constraints, or intermediate safety remain unclear.
+
+Do not turn `database → API → UI → tests` into backlog stories. If those boundaries help review one selected implementation slice, describe them as dependent PR layers and keep their release state explicit.
+
+## Decide: One PR Or A Stack
+
+Choose a stack for one implementation slice only when all of these hold:
+
+- The slice has fixed acceptance scope inside one cohesive vertical story or a fixed conserved contract inside an approved reduction program.
+- The slice's combined diff would be slow, risky, or cognitively expensive to review.
+- The work has a real one-way dependency order.
+- Each proposed layer is one coherent change that can be understood from its own diff plus the layers below.
+- Each layer can leave its cumulative branch known-good: buildable, verified, and safe to deploy or explicitly dormant.
+- The expected cascade/rebase cost is lower than the review benefit of smaller diffs.
+- The repository and team can support dependent branches, rebases, and bottom-up merging.
+- CI and repository rules can run the required checks on PRs whose base is another feature branch.
+
+Prefer one vertical PR when any of these hold:
+
+- The whole change is already a quick, coherent review.
+- Splitting would separate tests or evidence from the behavior or contract they protect.
+- Reviewers must understand the full stack to judge every layer.
+- Intermediate merges would expose an unsafe schema, contract, bridge, or half-feature.
+- The change is cross-cutting enough that every layer would repeatedly touch the same code.
+- The only proposed boundaries are files, architectural tiers, work phases, or team ownership.
+- Rebase and CI churn would cost more than the smaller diffs save.
+
+Do not stack by reflex. Record the decision in one sentence:
+
+```text
+Delivery: single PR — the end-to-end change is already one focused review.
+```
+
+or:
+
+```text
+Delivery: 3-PR stack — the dormant migration, tested repository adapter, and
+fixed sign-in slice form one-way dependencies with meaningful verification.
+```
+
+## Design The Stack Before Writing Code
+
+### 1. Fix The Story And Slice Scope
+
+Write the selected story's actor and outcome, then the selected implementation slice's:
+
+- trigger
+- observable outcome or conserved contract
+- production path: entry point → domain behavior → state/external effects → output → observability
+- acceptance examples or preservation evidence
+- class and any reduction-program/terminal obligations from `planning`
+- release constraint
+
+If the story still describes more than one customer capability, return to `story-splitting`. If the slice contains several independently mergeable vertical outcomes or reduction transitions, keep them as sequential slices in `planning`. Freeze the selected slice's scope before drawing PR layers.
+
+For a reduction slice, PR layers do not replace its ledger or gates. A lower layer cannot claim net reduction while superseded machinery or an added bridge remains; only the top of a terminal-reduction slice may satisfy the mechanism gate and claim the fixed terminal state.
+
+### 2. Draw The Dependency Graph
+
+Identify what genuinely must exist before something else. Separate logical dependency from habitual build order. "We usually build the backend first" is not evidence.
+
+Prefer boundaries in this order:
+
+1. **Testable path increments** — each PR advances the same fixed slice without adding a new acceptance case that belongs in another slice.
+2. **Behavior-preserving preparation** — a focused refactor or safety characterization that makes the later change reviewable.
+3. **Backward-compatible enablement** — a migration, contract, or infrastructure change that is verified, dormant, and directly used by the next PR.
+4. **Risk isolation** — a security-, data-, or performance-sensitive change that deserves focused expert review.
+5. **Reviewer expertise** — a subsystem boundary, only when the PR still makes sense without an essay about the rest of the stack.
+
+Avoid:
+
+- all tests in the top PR
+- speculative foundations or abstractions
+- layers whose only claim is "files in the same folder"
+- a lower layer that requires an upper layer to compile, migrate safely, pass CI, or discharge an unowned bridge
+- duplicate fixups in upper layers instead of fixing the owning lower layer
+- a long stack where cascade and review overhead dominate
+
+There is no universal layer count or line limit. Keep the smallest stack whose PRs are quick reads with one concept each. If two adjacent layers need the same explanation or evidence, fold them together.
+
+### 3. Route Verification By Layer Type
+
+GitHub's tutorial illustrates tests as a final layer; do not copy that ordering into this workflow.
+
+For a behavior-changing production layer:
+
+- Load `tdd`, `testing`, and applicable `refactoring` guidance before code changes.
+- Follow fast RED-GREEN-REFACTOR increments for the behavior owned by that layer.
+- Put contract, migration, unit, integration, or UI tests in the earliest layer that owns the behavior.
+- When the layer is otherwise PR-ready, load `mutation-testing` and run its accumulated-scope gate once against the layer's parent where meaningful, or record its proportionate alternate-evidence `N/A`.
+
+For a behavior-preserving layer:
+
+- Load applicable testing and `refactoring` guidance; if protection is inadequate, load `finding-seams` and `characterisation-tests`.
+- Establish passing preservation evidence for the touched consumer paths.
+- Refactor without changing behavior, keeping the applicable focused/affected tests green.
+- At PR readiness, run the same once-per-layer mutation-or-alternate-evidence gate; do not fabricate structural mutants.
+
+For reduction-transition or terminal-reduction layers, also preserve the selected slice's `reduce-system-complexity` ledger, conserved contract, bridge ownership/removal obligations, and behavior/mechanism gate status.
+
+For documentation, release metadata, configuration, or non-production mechanical changes, use the smallest executable verification that can fail if the layer is wrong and record mutation `N/A` when appropriate.
+
+For every layer, run the repository's required build, lint, type, security, and complete non-watch test checks and verify the cumulative branch, because an upstack PR contains every lower layer.
+
+The top layer must prove the selected slice's acceptance examples or terminal gates. It may add stack-level tests, but it must not be the first place lower-layer behavior is tested.
+
+### 4. Verify CI Topology Before Stacking
+
+Inspect the repository's workflows, rulesets, required status contexts, and merge queue:
+
+- Confirm `pull_request` workflows run when an upper PR targets a lower feature branch. Branch filters evaluate the PR's base branch; a `main`-only filter can skip every upper layer.
+- Confirm every required status is produced for every layer that needs it.
+- If the repository uses a merge queue, confirm required workflows handle `merge_group`.
+- Decide which focused checks run per layer and which cumulative or end-to-end checks run at the top; do not weaken required merge checks to make stacking convenient.
+- Account for rebase-triggered reruns and existing affected-test or cache behavior.
+
+Prefer one PR when the repository cannot give dependent PRs trustworthy required checks without risky CI changes.
+
+### 5. Make Intermediate States Safe
+
+Every lower PR must be one of:
+
+- independently deployable and useful
+- behavior-preserving
+- backward-compatible and dormant
+- hidden behind a flag
+- an independently verifiable reduction transition with owned, bounded bridges and no premature net-reduction claim
+- intended to merge only as part of a contiguous approved group, with the reason stated
+
+Never merge an intermediate state that breaks callers, requires an unavailable schema, weakens security, or exposes incomplete behavior. Backward-compatible expand/contract changes usually belong in separate stacks because cleanup must wait until all consumers have moved.
+
+## Write The Delivery Plan
+
+Add this section under the selected implementation slice, not at plan level:
+
+```markdown
+#### Delivery Shape
+
+**Mode**: Single PR | Stacked PRs
+**Reason**: [Why this shape improves review without weakening delivery]
+**Story scope**: [Fixed parent story; PR layers must not expand it]
+**Slice class**: [Class from planning]
+**Slice done when**: [Fixed observable outcome, conserved contract, or terminal gates]
+
+| # | PR layer | Base | Owns | Depends on | Verification | Release state |
+|---|---|---|---|---|---|---|
+| 1 | [focused title] | [repository default branch] | [one coherent change] | — | [tests/evidence/checks] | [deployable/dormant/etc.] |
+| 2 | [focused title] | layer 1 | [one coherent change] | [specific contract] | [tests/evidence/checks] | [...] |
+
+### Whole-stack gate
+
+- [ ] Slice acceptance examples, conserved contract, and applicable terminal gates pass at the top
+- [ ] Every layer's focused and cumulative checks pass
+- [ ] No behavior waits until a later PR for its first test
+- [ ] Every PR-ready layer has current mutation or alternate evidence for its focused review boundary
+- [ ] Intermediate merge and release states are explicit and safe
+- [ ] Reduction ledger, bridge, and mechanism-gate obligations remain accurate when applicable
+- [ ] CI runs required statuses for dependent-base PRs and `merge_group` when applicable
+- [ ] Review sequence is bottom-up for dependency-sensitive layers; independent specialist reviews may run in parallel
+- [ ] Merge order is bottom to top
+```
+
+For each layer, also record:
+
+- focused review question
+- included and excluded scope
+- likely files or subsystem, without prescribing unnecessary implementation
+- required specialist reviewer, if any
+- acceptance criteria and verification route for the behavior, conserved contract, or mechanical change it owns
+
+Use repository branch naming conventions. Do not create branches, commit, push, submit PRs, rebase shared branches, or merge unless the user has authorized that action.
+
+## Build Bottom To Top
+
+For each layer:
+
+1. Start from the topmost completed branch.
+2. Confirm the layer's acceptance criteria or conserved contract with the user before code.
+3. Complete the applicable implementation route and keep focused/affected checks green.
+4. When the layer is otherwise PR-ready, complete its mutation-or-alternate-evidence gate and repository checks.
+5. Self-review the diff against its parent, not against trunk.
+6. Remove work that belongs upstack.
+7. Present the focused diff and verification evidence.
+8. Wait for commit approval.
+9. Create the next branch only after the current layer is committed and known-good; review approval is not required to extend the stack.
+
+Prefer the official `gh stack` command when it is available and matches current repository policy. Use current help rather than memorized preview syntax. If it is unavailable, either manage dependent branches and PR bases with existing Git/GitHub tooling or ask before installing anything.
+
+Open unfinished upper layers as drafts. Give each PR a focused title and concise description containing:
+
+- selected story, fixed implementation slice, and this layer's purpose
+- parent/base PR and next layer, when known
+- what to review in this diff
+- verification performed
+- release state
+- intentional deferrals
+
+## Review And Revise
+
+Self-review every layer before requesting review. Check function, intent, code quality, dependencies, AI-specific mistakes, and test integrity.
+
+Request review from the bottom upward when later layers depend strongly on earlier decisions. Different specialists may review and approve layers in parallel when each focused diff is understandable. Merge readiness and merge order still flow bottom to top.
+
+When feedback changes a lower layer:
+
+1. Move to the branch that owns the change.
+2. Fix and test it there.
+3. Rebase or restack every branch above it.
+4. Re-evaluate whether existing mutation/alternate evidence remains current under repository policy, then rerun affected focused and cumulative checks as required.
+5. Re-review upstack diffs for accidental duplication or semantic drift.
+6. Push only with safe lease protection and authorization.
+
+Do not add an upstack workaround for a downstack defect.
+
+Reshape the stack when evidence changes. Fold adjacent PRs that cannot be reviewed separately; split a layer that acquired a second concept; reorder only when dependencies allow it. A clean working tree and recoverable rebase path are prerequisites for structural changes.
+
+## Merge And Finish
+
+Before merge:
+
+- require passing checks and required approvals for the layer and every layer below it
+- require linear stack history
+- verify the top branch still satisfies the fixed slice acceptance criteria or terminal gates
+- verify any partially merged state remains safe
+- resolve documentation conflicts using current GitHub guidance because stacked PR behavior is preview
+
+Merge from the bottom upward, individually or as a contiguous group supported by the repository. Never treat a mid-stack PR as independently mergeable when it depends on unmerged layers below.
+
+After lower layers merge, sync or rebase the remaining stack, rerun affected checks, and verify each PR still shows only its intended focused diff. Mark the implementation slice complete only when its top lands. Delete the plan when every selected implementation slice lands, following `planning`.
+
+## Example: Preserve The Vertical Slice
+
+Selected story and fixed implementation slice:
+
+```text
+A registered customer can sign in with valid credentials and reach their account.
+```
+
+If the end-to-end diff is already reviewable, use one PR containing storage, authentication behavior, entry point, response, and tests.
+
+If it is too large, a responsible stack could be:
+
+1. Add a backward-compatible, dormant credential-storage migration with migration and rollback verification.
+2. Add the credential repository adapter behind the existing boundary with contract tests.
+3. Add the valid-credential path through the real entry point, domain behavior, storage, response, and observability, with its behavior tests.
+
+The story and slice remain vertical and their scope does not grow. Layers 1 and 2 are enabling tasks, not user stories or implementation slices. Use separate "all endpoints" or "all middleware" PRs only when concrete repository constraints make that safer and every layer still satisfies this skill's gates. Never defer all tests to a final PR.

--- a/claude/.claude/skills/stack-pull-requests/agents/openai.yaml
+++ b/claude/.claude/skills/stack-pull-requests/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Stack Pull Requests"
   short_description: "Plan and deliver optional stacked pull requests"
-  default_prompt: "Use $stack-pull-requests to decide whether this planned vertical slice needs one PR or a reviewable PR stack."
+  default_prompt: "Use $stack-pull-requests to decide whether this planned vertical work needs independent PRs or a reviewable hard- or flow-lineage stack."

--- a/claude/.claude/skills/stack-pull-requests/agents/openai.yaml
+++ b/claude/.claude/skills/stack-pull-requests/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Stack Pull Requests"
+  short_description: "Plan and deliver optional stacked pull requests"
+  default_prompt: "Use $stack-pull-requests to decide whether this planned vertical slice needs one PR or a reviewable PR stack."

--- a/claude/.claude/skills/stack-pull-requests/references/source-notes.md
+++ b/claude/.claude/skills/stack-pull-requests/references/source-notes.md
@@ -8,14 +8,15 @@ Load this resource for source provenance, teaching, or updating preview-specific
 |---|---|
 | [Stack AI-generated code in pull requests](https://docs.github.com/en/copilot/tutorials/stack-ai-generated-code-in-pull-requests) | Design the stack before code generation; use small coherent dependency-ordered layers; build and self-review bottom first; keep fixes in the owning layer; rebase upward; review and merge bottom-up |
 | [Review AI-generated code](https://docs.github.com/en/copilot/tutorials/review-ai-generated-code) | Run automated checks; verify context and intent; assess maintainability and dependencies; look for hallucinated APIs, ignored constraints, deleted tests, and plausible-looking wrong logic; combine human and automated review |
-| [Managing stacked pull requests](https://docs.github.com/en/pull-requests/how-tos/create-pull-requests/managing-stacked-pull-requests) | Make lower-layer changes on their owning branch; cascade rebases; preserve a linear history; restructure stacks deliberately; sync after merges |
+| [Managing stacked pull requests](https://docs.github.com/en/pull-requests/how-tos/create-pull-requests/managing-stacked-pull-requests) | Make lower-boundary changes on their owning branch; cascade rebases; preserve a linear history; restructure stacks deliberately; sync after merges |
 | [Reviewing stacked pull requests](https://docs.github.com/en/pull-requests/how-tos/review-pull-requests/reviewing-stacked-pull-requests) | Review each layer's focused diff; update the owning branch; rebase and retest upstack |
-| [Merging stacked pull requests](https://docs.github.com/en/pull-requests/how-tos/merge-and-close-pull-requests/merging-stacked-pull-requests) | Merge bottom-up; only merge contiguous groups from the lowest unmerged PR; require lower approvals/checks and linear history |
-| [Stacked pull requests CLI commands](https://docs.github.com/en/pull-requests/reference/stacked-prs-cli-commands) | Current `gh stack` command model, safe lease pushes, stack modification prerequisites, draft submission behavior, and cumulative rebase/sync semantics |
-| [Events that trigger workflows](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows) | `pull_request.branches` filters match the PR base, so main-only filters can skip upstack PRs; merge queues need `merge_group` triggers for required checks |
+| [Stacked pull requests](https://docs.github.com/en/pull-requests/reference/stacked-pull-requests) | Native stack rules, checks, reviews, CODEOWNERS, code scanning, and Actions evaluate against the stack trunk; selected lower prefixes merge atomically; merge queues preserve dependency order |
+| [Stacked pull requests CLI commands](https://docs.github.com/en/pull-requests/reference/stacked-prs-cli-commands) | Current `gh stack` command model, native linking, safe-lease but non-atomic pushes, all-or-nothing prefix merges, stack modification prerequisites, draft submission behavior, and cumulative rebase/sync semantics |
+| [Events that trigger workflows](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows) | Ordinary unlinked PR branch filters use the immediate base; merge queues need `merge_group` triggers for required checks |
 | [Graphite: How to structure a stack](https://graphite.com/docs/how-to-structure-your-stacks) | Useful candidate boundaries: functional components, iterative improvements, refactor-then-change, risk isolation, and dependency-aware ordering |
 | [Graphite: Best practices for reviewing stacks](https://graphite.com/docs/best-practices-for-reviewing-stacks) | Make each PR atomic enough to understand, submit ready layers early, mark work-in-progress layers draft, choose focused reviewers, and review bottom-up |
 | [Graphite: CI optimizations](https://graphite.com/docs/stacking-and-ci) | Stacks multiply CI and rebase runs; use existing caching or affected-test mechanisms when scale justifies it, without weakening required merge checks |
+| [Sapling: Stacks of commits](https://sapling-scm.com/docs/overview/stacks/) | `absorb` and targeted amend demonstrate assigning a newly discovered correction to its lower owning change and rewriting descendants |
 
 ## Reconciliation With This Skill Set
 
@@ -23,20 +24,22 @@ GitHub's tutorial uses an authentication example ordered as data model, CRUD end
 
 This skill therefore makes these synthesis decisions:
 
-- Keep backlog stories vertical and valuable. Treat PR layers as delivery boundaries, not child stories.
+- Keep backlog stories vertical and valuable. Treat PR boundaries as delivery boundaries, not child stories.
 - Default to one vertical PR. Stacking is optional and must earn its coordination cost.
-- Prefer testable path increments within a fixed vertical slice; do not add acceptance scope by calling a new behavior a PR layer.
+- Prefer whole vertical slices as stack members when they have hard dependency or deliberate flow lineage; otherwise prefer testable path increments within a fixed slice and do not add acceptance scope by calling a new behavior an intra-slice PR layer.
 - Permit a horizontal lower layer only when it is coherent, directly required, independently verified, and safe or dormant.
 - Keep tests with the earliest behavior they protect. Never create a final "all tests" layer.
 - Use the repository's fast RED-GREEN-REFACTOR loop inside a layer and its mutation-or-alternate-evidence gate once when that layer is PR-ready.
-- Require the top branch to prove the complete selected implementation slice without expanding its story scope.
+- Require the top branch to prove the cumulative criteria for every included slice without expanding the approved story scope.
 - Distinguish independently reviewable from independently mergeable or releasable.
-- Treat a backlog story, vertical implementation slice, and dependent PR layer as three different units; choose delivery per slice, not once per plan.
-- Require a CI-topology check before stacking because an apparently valid stack is unsafe when required workflows never run on dependent bases.
+- Treat a backlog story, vertical implementation slice, and dependent PR boundary as different units; choose the exact stack scope rather than stacking a whole plan by default.
+- Treat a stack as branch topology, not a semantic work category. A stack may contain one slice's review layers or several complete vertical slices with hard dependency or deliberate flow lineage while work overlaps review.
+- Prefer independent trunk-based PRs when slices can merge in any order. Correcting a lower stacked branch and cascading the fix upward is a real workflow benefit, but it also rebases every affected branch and re-triggers CI, so it is a supporting factor rather than sufficient justification by itself.
+- Distinguish GitHub-native linked stacks, whose CI and rules evaluate against the stack trunk, from unlinked dependent PRs, which retain ordinary immediate-base workflow semantics.
 
 ## Preview Caveat
 
-GitHub labels stacked pull requests and `gh stack` as public preview. The tutorial currently recommends auto-merge or a merge queue, while the dedicated merging page says auto-merge is not supported for stacked pull requests. Treat the dedicated current management/reference pages and live CLI help as operational authority, and verify rather than encoding either statement as permanent behavior.
+GitHub labels stacked pull requests and `gh stack` as public preview. Treat the current stack reference, management pages, CLI reference, and live help as operational authority; re-check Actions, merge, and queue behavior instead of assuming ordinary dependent-PR semantics.
 
 Do not hardcode a minimum GitHub CLI version in the main skill. The tutorial and command reference currently state different minimum versions. Verify the installed extension and current official prerequisites when execution matters.
 

--- a/claude/.claude/skills/stack-pull-requests/references/source-notes.md
+++ b/claude/.claude/skills/stack-pull-requests/references/source-notes.md
@@ -1,0 +1,50 @@
+# Stack Pull Requests Source Notes
+
+Load this resource for source provenance, teaching, or updating preview-specific guidance. Do not load it for ordinary stack decisions.
+
+## Primary Source Map
+
+| Source | Guidance used |
+|---|---|
+| [Stack AI-generated code in pull requests](https://docs.github.com/en/copilot/tutorials/stack-ai-generated-code-in-pull-requests) | Design the stack before code generation; use small coherent dependency-ordered layers; build and self-review bottom first; keep fixes in the owning layer; rebase upward; review and merge bottom-up |
+| [Review AI-generated code](https://docs.github.com/en/copilot/tutorials/review-ai-generated-code) | Run automated checks; verify context and intent; assess maintainability and dependencies; look for hallucinated APIs, ignored constraints, deleted tests, and plausible-looking wrong logic; combine human and automated review |
+| [Managing stacked pull requests](https://docs.github.com/en/pull-requests/how-tos/create-pull-requests/managing-stacked-pull-requests) | Make lower-layer changes on their owning branch; cascade rebases; preserve a linear history; restructure stacks deliberately; sync after merges |
+| [Reviewing stacked pull requests](https://docs.github.com/en/pull-requests/how-tos/review-pull-requests/reviewing-stacked-pull-requests) | Review each layer's focused diff; update the owning branch; rebase and retest upstack |
+| [Merging stacked pull requests](https://docs.github.com/en/pull-requests/how-tos/merge-and-close-pull-requests/merging-stacked-pull-requests) | Merge bottom-up; only merge contiguous groups from the lowest unmerged PR; require lower approvals/checks and linear history |
+| [Stacked pull requests CLI commands](https://docs.github.com/en/pull-requests/reference/stacked-prs-cli-commands) | Current `gh stack` command model, safe lease pushes, stack modification prerequisites, draft submission behavior, and cumulative rebase/sync semantics |
+| [Events that trigger workflows](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows) | `pull_request.branches` filters match the PR base, so main-only filters can skip upstack PRs; merge queues need `merge_group` triggers for required checks |
+| [Graphite: How to structure a stack](https://graphite.com/docs/how-to-structure-your-stacks) | Useful candidate boundaries: functional components, iterative improvements, refactor-then-change, risk isolation, and dependency-aware ordering |
+| [Graphite: Best practices for reviewing stacks](https://graphite.com/docs/best-practices-for-reviewing-stacks) | Make each PR atomic enough to understand, submit ready layers early, mark work-in-progress layers draft, choose focused reviewers, and review bottom-up |
+| [Graphite: CI optimizations](https://graphite.com/docs/stacking-and-ci) | Stacks multiply CI and rebase runs; use existing caching or affected-test mechanisms when scale justifies it, without weakening required merge checks |
+
+## Reconciliation With This Skill Set
+
+GitHub's tutorial uses an authentication example ordered as data model, CRUD endpoints, JWT middleware, then integration and unit tests. That illustrates dependency-ordered review layers, but copying it literally would conflict with this repository's `story-splitting`, `planning`, `tdd`, and `testing` contracts.
+
+This skill therefore makes these synthesis decisions:
+
+- Keep backlog stories vertical and valuable. Treat PR layers as delivery boundaries, not child stories.
+- Default to one vertical PR. Stacking is optional and must earn its coordination cost.
+- Prefer testable path increments within a fixed vertical slice; do not add acceptance scope by calling a new behavior a PR layer.
+- Permit a horizontal lower layer only when it is coherent, directly required, independently verified, and safe or dormant.
+- Keep tests with the earliest behavior they protect. Never create a final "all tests" layer.
+- Use the repository's fast RED-GREEN-REFACTOR loop inside a layer and its mutation-or-alternate-evidence gate once when that layer is PR-ready.
+- Require the top branch to prove the complete selected implementation slice without expanding its story scope.
+- Distinguish independently reviewable from independently mergeable or releasable.
+- Treat a backlog story, vertical implementation slice, and dependent PR layer as three different units; choose delivery per slice, not once per plan.
+- Require a CI-topology check before stacking because an apparently valid stack is unsafe when required workflows never run on dependent bases.
+
+## Preview Caveat
+
+GitHub labels stacked pull requests and `gh stack` as public preview. The tutorial currently recommends auto-merge or a merge queue, while the dedicated merging page says auto-merge is not supported for stacked pull requests. Treat the dedicated current management/reference pages and live CLI help as operational authority, and verify rather than encoding either statement as permanent behavior.
+
+Do not hardcode a minimum GitHub CLI version in the main skill. The tutorial and command reference currently state different minimum versions. Verify the installed extension and current official prerequisites when execution matters.
+
+## Updating The Skill
+
+When GitHub changes the preview:
+
+1. Re-read the official tutorial, management, review, merge, and CLI reference pages.
+2. Check live `gh stack --help`.
+3. Update operational wording, not the durable story/PR distinction.
+4. Preserve the local verification cadence and vertical-slice contracts even if external examples defer tests or split strictly by components.

--- a/claude/.claude/skills/story-splitting/SKILL.md
+++ b/claude/.claude/skills/story-splitting/SKILL.md
@@ -22,7 +22,9 @@ This skill is based on Tim Ottinger's [Splitting Stories - A Resource Listicle](
 
 ## How This Fits With Other Skills
 
-Use `story-splitting` **before** `planning` when the input is a large story, epic, feature idea, roadmap item, or backlog item. This skill discovers small valuable child stories. The `planning` skill then sequences one selected child story into PR-sized implementation slices with TDD execution details.
+Use `story-splitting` **before** `planning` when the input is a large story, epic, feature idea, roadmap item, or backlog item. This skill discovers small valuable child stories. The `planning` skill then sequences one selected child story into implementation slices with evidence and delivery details.
+
+Keep story boundaries vertical whether delivery uses one PR or an optional PR stack. Several independently mergeable implementation slices are sequential PRs, not a stack. If one planned slice is too large for effective review, load `stack-pull-requests` to decide whether dependent PR layers would help. Those layers are delivery boundaries, not child stories or implementation slices; never put database, API, UI, and tests into the backlog as separate customer outcomes.
 
 Use `find-gaps` **after** a split or plan exists when you need to tighten missing states, acceptance criteria, edge cases, or unverifiable language. If `find-gaps` discovers that the plan is still horizontal or too large, return here and split again.
 
@@ -30,7 +32,7 @@ Use `grill-me` when the issue is unresolved product or design decision-making ra
 
 Use `storyboard` when the work spans multiple UX surfaces or mock states; the storyboard can reveal missing screens and flow gaps that become child stories. Use design skills such as `shape`, `critique`, and `polish` to improve the mocks themselves, not to replace product slicing.
 
-This skill must not drive implementation directly. When a selected child story is ready to implement, load `planning` first. Planning must turn that child story into implementation slices/stages. Within each slice, use fast RED-GREEN-REFACTOR increments without running the automated mutation harness after every increment. When the complete slice is otherwise ready for its PR, load `mutation-testing`, run it once for the accumulated scope, and handle valuable survivors normally within that gate. Treat this as a per-slice mandatory handoff, not a one-time feature reminder. Use `finding-seams` and `characterisation-tests` when a slice touches legacy code that cannot yet be tested safely. Use domain and architecture skills (`domain-driven-design`, `hexagonal-architecture`, `api-design`, `cli-design`, `twelve-factor`, `production-parity-skill-builder`) to keep each slice coherent; do not split stories by those technical layers.
+This skill must not drive implementation directly. When a selected child story is ready to implement, load `planning` first and load `stack-pull-requests` only for a planned slice that may need dependent review layers. Planning must turn that child story into implementation slices/stages. Within each behavior-changing slice or PR layer, use fast RED-GREEN-REFACTOR increments without running the automated mutation harness after every increment. When each review boundary is otherwise PR-ready, load `mutation-testing`, run it once for the accumulated focused scope, and handle valuable survivors within that gate. Pure refactor and reduction boundaries use their passing preservation evidence and applicable gates instead of fabricated RED or structural mutants. Treat this as a per-boundary handoff, not a one-time feature reminder. Use `finding-seams` and `characterisation-tests` when legacy code cannot yet be tested safely. Use domain and architecture skills (`domain-driven-design`, `hexagonal-architecture`, `api-design`, `cli-design`, `twelve-factor`, `production-parity-skill-builder`) to keep each slice coherent; do not split stories by those technical layers.
 
 ## Requirement Refinement Pipeline
 
@@ -41,7 +43,8 @@ Use the earliest skill that matches the uncertainty:
 | "We don't know which decision branch is right." | `grill-me` | A resolved decision tree or a named open decision |
 | "This requirement is too broad or solution-shaped." | `story-splitting` | Independently valuable child stories |
 | "This story/spec/plan/mock has holes." | `find-gaps` | Confirmed artifact updates with testable wording |
-| "We selected a child story and need to build it." | `planning` | PR-sized implementation slices |
+| "We selected a child story and need to build it." | `planning` | Implementation slices with per-slice delivery shapes |
+| "One planned vertical slice may be too large for one review." | `stack-pull-requests` + `planning` | A justified single PR or dependent PR stack |
 
 Do not use `story-splitting` to interrogate every product decision from scratch; use `grill-me` when the decision tree is the real work. Do not use `story-splitting` to produce implementation tasks; use `planning` after a child story is selected. Do not use `find-gaps` before there is an artifact to inspect; use it to harden a split, plan, AC set, or mock spec.
 
@@ -242,7 +245,7 @@ Why this first: [value, risk, learning, or bargain]
 [Component splits, unsafe deferrals, unclear ownership, or missing examples]
 
 ## Next Step
-[Usually: load `planning` for the selected first slice, run `find-gaps` on the split, or ask one decision question. If implementing, every planned implementation slice/stage must explicitly require `tdd`, `testing`, and applicable `refactoring` guidance before code changes; use RED-GREEN-REFACTOR increments, then run `mutation-testing` once for the accumulated scope when the slice is otherwise ready for its PR.]
+[Usually: load `planning` for the selected first slice, optionally load `stack-pull-requests` if one slice may need dependent review layers, run `find-gaps` on the split, or ask one decision question. If implementing, follow the class-specific evidence route for each slice or PR layer and run `mutation-testing` once when each review boundary is otherwise PR-ready where meaningful.]
 ```
 
 If the user wants an interactive refinement session, ask one high-value question at a time rather than dumping a questionnaire. Start with the question that most changes the split: usually actor, outcome, release constraint, highest-value customer segment, or biggest risk.

--- a/claude/.claude/skills/story-splitting/SKILL.md
+++ b/claude/.claude/skills/story-splitting/SKILL.md
@@ -24,7 +24,7 @@ This skill is based on Tim Ottinger's [Splitting Stories - A Resource Listicle](
 
 Use `story-splitting` **before** `planning` when the input is a large story, epic, feature idea, roadmap item, or backlog item. This skill discovers small valuable child stories. The `planning` skill then sequences one selected child story into implementation slices with evidence and delivery details.
 
-Keep story boundaries vertical whether delivery uses one PR or an optional PR stack. Several independently mergeable implementation slices are sequential PRs, not a stack. If one planned slice is too large for effective review, load `stack-pull-requests` to decide whether dependent PR layers would help. Those layers are delivery boundaries, not child stories or implementation slices; never put database, API, UI, and tests into the backlog as separate customer outcomes.
+Keep story boundaries vertical regardless of PR topology. Several implementation slices are not automatically independent PRs and not automatically a stack: use trunk-based PRs when they can merge in any order without blocking or duplicating work, or when later work waits for earlier merge. Consider a cross-slice stack for hard dependency or deliberate flow lineage when upper work starts on the same evolving baseline before lower reviews merge and fixed lower-first landing is acceptable. A stack may also use review layers inside one oversized slice. Load `stack-pull-requests` after planning to make that choice; never turn database, API, UI, and tests into separate backlog outcomes.
 
 Use `find-gaps` **after** a split or plan exists when you need to tighten missing states, acceptance criteria, edge cases, or unverifiable language. If `find-gaps` discovers that the plan is still horizontal or too large, return here and split again.
 
@@ -32,7 +32,7 @@ Use `grill-me` when the issue is unresolved product or design decision-making ra
 
 Use `storyboard` when the work spans multiple UX surfaces or mock states; the storyboard can reveal missing screens and flow gaps that become child stories. Use design skills such as `shape`, `critique`, and `polish` to improve the mocks themselves, not to replace product slicing.
 
-This skill must not drive implementation directly. When a selected child story is ready to implement, load `planning` first and load `stack-pull-requests` only for a planned slice that may need dependent review layers. Planning must turn that child story into implementation slices/stages. Within each behavior-changing slice or PR layer, use fast RED-GREEN-REFACTOR increments without running the automated mutation harness after every increment. When each review boundary is otherwise PR-ready, load `mutation-testing`, run it once for the accumulated focused scope, and handle valuable survivors within that gate. Pure refactor and reduction boundaries use their passing preservation evidence and applicable gates instead of fabricated RED or structural mutants. Treat this as a per-boundary handoff, not a one-time feature reminder. Use `finding-seams` and `characterisation-tests` when legacy code cannot yet be tested safely. Use domain and architecture skills (`domain-driven-design`, `hexagonal-architecture`, `api-design`, `cli-design`, `twelve-factor`, `production-parity-skill-builder`) to keep each slice coherent; do not split stories by those technical layers.
+This skill must not drive implementation directly. When a selected child story is ready to implement, load `planning` first and load `stack-pull-requests` when one slice may need review layers or later slices may start on the same evolving baseline before lower PRs merge. Planning must turn that child story into implementation slices/stages. Within each behavior-changing slice or PR boundary, use fast RED-GREEN-REFACTOR increments without running the automated mutation harness after every increment. When each review boundary is otherwise PR-ready, load `mutation-testing`, run it once for the accumulated focused scope, and handle valuable survivors within that gate. Pure refactor and reduction boundaries use their passing preservation evidence and applicable gates instead of fabricated RED or structural mutants. Treat this as a per-boundary handoff, not a one-time feature reminder. Use `finding-seams` and `characterisation-tests` when legacy code cannot yet be tested safely. Use domain and architecture skills (`domain-driven-design`, `hexagonal-architecture`, `api-design`, `cli-design`, `twelve-factor`, `production-parity-skill-builder`) to keep each slice coherent; do not split stories by those technical layers.
 
 ## Requirement Refinement Pipeline
 
@@ -44,7 +44,7 @@ Use the earliest skill that matches the uncertainty:
 | "This requirement is too broad or solution-shaped." | `story-splitting` | Independently valuable child stories |
 | "This story/spec/plan/mock has holes." | `find-gaps` | Confirmed artifact updates with testable wording |
 | "We selected a child story and need to build it." | `planning` | Implementation slices with per-slice delivery shapes |
-| "One planned vertical slice may be too large for one review." | `stack-pull-requests` + `planning` | A justified single PR or dependent PR stack |
+| "One slice is too large, or later slices should start before lower PRs merge." | `stack-pull-requests` + `planning` | Justified independent PRs or a hard-/flow-lineage stack |
 
 Do not use `story-splitting` to interrogate every product decision from scratch; use `grill-me` when the decision tree is the real work. Do not use `story-splitting` to produce implementation tasks; use `planning` after a child story is selected. Do not use `find-gaps` before there is an artifact to inspect; use it to harden a split, plan, AC set, or mock spec.
 
@@ -245,7 +245,7 @@ Why this first: [value, risk, learning, or bargain]
 [Component splits, unsafe deferrals, unclear ownership, or missing examples]
 
 ## Next Step
-[Usually: load `planning` for the selected first slice, optionally load `stack-pull-requests` if one slice may need dependent review layers, run `find-gaps` on the split, or ask one decision question. If implementing, follow the class-specific evidence route for each slice or PR layer and run `mutation-testing` once when each review boundary is otherwise PR-ready where meaningful.]
+[Usually: load `planning` for the selected first slice, optionally load `stack-pull-requests` if one slice may need review layers or later slices may start before lower PRs merge, run `find-gaps` on the split, or ask one decision question. If implementing, follow the class-specific evidence route for each slice or PR boundary and run `mutation-testing` once when each review boundary is otherwise PR-ready where meaningful.]
 ```
 
 If the user wants an interactive refinement session, ask one high-value question at a time rather than dumping a questionnaire. Start with the question that most changes the split: usually actor, outcome, release constraint, highest-value customer segment, or biggest risk.

--- a/test/mutation-workflow.sh
+++ b/test/mutation-workflow.sh
@@ -135,7 +135,7 @@ require_text \
 
 require_text \
   "$CLAUDE_ROOT/commands/generate-pr-review.md" \
-  "Once the completed phase is otherwise PR-ready" \
+  "Once the current review boundary is otherwise PR-ready" \
   "review generation: defers mutation until PR readiness"
 
 require_text \


### PR DESCRIPTION
## Summary

- add a `stack-pull-requests` skill that preserves vertical story splitting while choosing between independent trunk PRs, hard-lineage stacks, and deliberate flow-lineage stacks
- treat stacked PRs as optional delivery topology: whole vertical slices may be stacked when upper work genuinely overlaps lower review on the same evolving baseline, while oversized single slices may use focused intra-slice review layers
- integrate correction ownership, linked-native versus unlinked CI semantics, safe restacking, PR-readiness versus landed completion, and current GitHub stack submission/merge behavior across planning and delivery workflows

## Verification

- `quick_validate.py` passed for `stack-pull-requests`, `planning`, and `story-splitting`
- `./test/run.sh`
- `pnpm changeset status --since origin/main`
- `git diff --check`

Mutation evidence: `N/A` — documentation, skill, command, test-contract, and release-metadata changes only; executable skill validators and repository workflow tests provide proportionate evidence.
