### PR TITLE
fix(herdr): stow the herdr package from install.sh with a backup guard

### DIFF
--- a/.changeset/herdr-stow-install.md
+++ b/.changeset/herdr-stow-install.md
@@ -1,0 +1,15 @@
+---
+"@citypaul/dotfiles": patch
+---
+
+Stow the herdr package from install.sh, backing up any existing config first
+
+The `herdr` package was added to the repo but `install.sh` never stowed it, so
+the standalone install path silently skipped it while the Ansible path picked it
+up. Add it to the stow list.
+
+It also needs the same `move_with_backup` treatment as `.zshrc`, the ghostty
+config, and the opencode config. GNU stow refuses to overwrite a real file and
+aborts the entire invocation rather than skipping the one package, so a
+pre-existing `~/.config/herdr/config.toml` would have stopped every other package
+from stowing too.

--- a/install.sh
+++ b/install.sh
@@ -26,5 +26,6 @@ move_with_backup ~/.zshrc
 
 move_with_backup "$HOME/Library/Application Support/com.mitchellh.ghostty/config"
 move_with_backup "$HOME/.config/opencode/opencode.json"
+move_with_backup "$HOME/.config/herdr/config.toml"
 
-stow zsh tmux gnupg alacritty zellij .oh-my-zsh karabiner ghostty claude opencode
+stow zsh tmux gnupg alacritty zellij .oh-my-zsh karabiner ghostty claude opencode herdr


### PR DESCRIPTION
## Two problems, both latent

#220 added the `herdr` stow package, but `install.sh` was never updated.

**It never stowed the package.** The stow list in `install.sh` is hardcoded, so the standalone install path silently skipped `herdr` while the Ansible path in mac-dev-machine-setup (which reads `dotfiles_stow_packages`) picked it up. Anyone installing these dotfiles directly got the package on disk but no symlink.

**It would have aborted the whole stow anyway.** GNU stow refuses to overwrite a real file, and it aborts the entire invocation rather than skipping the offending package:

```
WARNING! stowing herdr would cause conflicts:
  * cannot stow ../repo/herdr/.config/herdr/config.toml over existing target
    .config/herdr/config.toml since neither a link nor a directory and
    --adopt not specified
All operations aborted.
```

Since `install.sh` stows everything in one call, a pre-existing `~/.config/herdr/config.toml` would have stopped `zsh`, `tmux`, `gnupg`, `alacritty`, `zellij`, `.oh-my-zsh`, `karabiner`, `ghostty`, `claude` and `opencode` from stowing too.

## The fix

Add `herdr` to the stow list, and give it the same `move_with_backup` treatment already applied to `.zshrc`, the ghostty config and the opencode config.

## Verification

`bash -n install.sh` passes and the full test suite is green (8/8 suites).

The stow behaviour was verified separately against GNU Stow 2.4.1 in a throwaway tree: the conflict was reproduced with a real file present (confirming a non-conflicting package was left unlinked), the backup-then-stow sequence then linked both packages, and an immediate re-run was clean.

## Related

The equivalent fix for the Ansible path is citypaul/mac-dev-machine-setup#91. That one is the path that runs on my machine; this one keeps the repo's own installer consistent with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)