### PR TITLE
fix: make repeat skill installs frictionless

### DIFF
--- a/.changeset/frictionless-skill-reinstall.md
+++ b/.changeset/frictionless-skill-reinstall.md
@@ -1,0 +1,6 @@
+---
+"@citypaul/dotfiles": patch
+---
+
+Make repeat skill installs frictionless by backing up selected destinations
+before the pinned Skills CLI refreshes them.

--- a/README.md
+++ b/README.md
@@ -1577,7 +1577,7 @@ Agents are invoked implicitly (Claude detects when to use them) or explicitly:
 - ✅ No per-project configuration needed
 - ✅ Skills install via [skills.sh](https://skills.sh) — works with Claude Code, Cursor, Codex, Copilot, OpenCode, Gemini CLI, and 40+ other agents
 - ✅ Modular structure loads details on-demand
-- ✅ Explicit maintenance: inspect with `npx skills@1.5.22 list -g`; back up and verify destination ownership before any reviewed replacement, and use `git pull` for the rest
+- ✅ Explicit maintenance: inspect with `npx skills@1.5.22 list -g`; reviewed installer reruns back up selected skills before replacement, and `git pull` updates the checkout
 
 **Install from an inspected, immutable checkout:**
 
@@ -1628,12 +1628,10 @@ depends on the selected agents:
 
 All three layouts expose the same complete bundle. Include `--agent codex` when Codex should discover and use the skill (the installer targets Claude Code only by default).
 
-**Existing skill directories are preserved.** The CLI lock does not record
-per-destination ownership, so a matching lock name cannot prove that a target
-copy is disposable. Before any skill install, the installer resolves every
-selected agent's pinned global target and stops if any target contains
-content. Back up and explicitly clear the target, or use a separately reviewed
-CLI update workflow.
+**Repeat installs are recoverable.** Before invoking the CLI, the installer
+copies every existing selected skill to an adjacent
+`skills.before-install.<random>/` directory. The pinned CLI can then refresh
+those reviewed names without unrelated skills or files blocking the install.
 
 **What gets installed:**
 - ✅ `~/.claude/CLAUDE.md` (~160 lines - lean core principles)
@@ -1654,7 +1652,7 @@ npx skills@1.5.22 list -g              # List installed skills
 npx skills@1.5.22 find <query>         # Discover more skills on skills.sh
 ```
 
-The CLI's `update` and `remove` commands mutate destinations without this installer's ownership preflight. Do not run them as routine maintenance: first back up the exact targets, prove they are CLI-owned, and review the resolved source bytes. The conservative path is a clean, reviewed replacement. To update a pinned source, review its diff, change the exact commit in this repository, and run the installer tests before release.
+The CLI's `update` and `remove` commands mutate destinations without this installer's automatic selected-skill backup. Do not run them as routine maintenance: first back up the exact targets, prove they are CLI-owned, and review the resolved source bytes. The conservative path is a reviewed installer rerun. To update a pinned source, review its diff, change the exact commit in this repository, and run the installer tests before release.
 
 > **Requires Node.js** for skills install (so `npx` is available). Use `--claude-only` or `--agents-only` if you don't have Node installed.
 
@@ -1665,7 +1663,7 @@ The installer used to `curl` every `SKILL.md` straight from this repo into `~/.c
 
 1. **Multi-agent portability.** The same skills are now installable against [40+ coding agents](https://github.com/vercel-labs/skills) — Claude Code, Cursor, Codex, GitHub Copilot, OpenCode, Gemini CLI, Cline, Continue, Windsurf, and more — via the `-a <agent>` flag. Using these skills from a non-Claude tool no longer requires a Claude-specific copy step. `--with-opencode` is now just an extra `-a opencode` on the existing install instead of a second duplicated tree.
 
-2. **Inspection and discovery commands.** `npx skills@1.5.22 list -g` records what the shared lock knows, and `find <query>` surfaces skills beyond this repo. Mutating `update`/`remove` commands bypass this installer's destination-ownership preflight, so they require an explicit backup, ownership check, and source review rather than being advertised as safe routine lifecycle operations.
+2. **Inspection and discovery commands.** `npx skills@1.5.22 list -g` records what the shared lock knows, and `find <query>` surfaces skills beyond this repo. Mutating `update`/`remove` commands bypass this installer's automatic backup, so they require an explicit backup, ownership check, and source review rather than being advertised as safe routine lifecycle operations.
 
 3. **Explicit target copies.** The installer passes `--copy`, so installation
    writes only the selected agents' resolved global targets. The shared lock
@@ -1673,10 +1671,9 @@ The installer used to `curl` every `SKILL.md` straight from this repo into `~/.c
 
 4. **Installer doesn't grow with the skill list.** Three `curl` loops with hard-coded file lists (including every `resources/*.md` and `references/*.md`) collapsed to a small set of pinned CLI calls. Adding a new skill to `claude/.claude/skills/` no longer requires a matching installer edit — the CLI discovers it.
 
-5. **Safe destination preflight.** Before invoking the installer, setup checks
-   every selected agent target and refuses to overwrite existing content.
-   Custom, stale-lock, and prior-install directories remain untouched until
-   the user explicitly backs up and resolves them.
+5. **Recoverable repeat installs.** Setup copies existing selected skill names
+   to an adjacent backup before replacement. Unselected content stays untouched,
+   and a failed CLI install leaves the previous copy available for recovery.
 
 **Trade-offs:**
 - Requires Node.js for `npx`. `--claude-only` and `--agents-only` still work without it.

--- a/install-claude.sh
+++ b/install-claude.sh
@@ -371,8 +371,7 @@ download_filtered_file() {
 
 # Global destination map from the pinned skills@1.5.22 agent registry. This
 # installer passes --copy explicitly, so only the resolved selected destinations
-# can be replaced. The CLI lock records no per-destination ownership, so a
-# matching name never proves a target disposable.
+# can be replaced.
 global_skills_dir_for_agent() {
   local agent="$1"
   local config_home="${XDG_CONFIG_HOME:-$HOME/.config}"
@@ -444,17 +443,8 @@ global_skills_dir_for_agent() {
   esac
 }
 
-skill_dir_has_entries() {
-  local dir="$1" entry
-  [[ -d "$dir" ]] || return 1
-  for entry in "$dir"/* "$dir"/.[!.]* "$dir"/..?*; do
-    [[ -e "$entry" || -L "$entry" ]] && return 0
-  done
-  return 1
-}
-
-guard_selected_skill_dirs() {
-  local agent dir entry blocked=false
+backup_selected_skills() {
+  local skills=("$@") agent dir skill backup
   local checked_dirs=()
 
   for agent in "${SKILL_AGENTS[@]}"; do
@@ -466,21 +456,18 @@ guard_selected_skill_dirs() {
   done
 
   for dir in "${checked_dirs[@]}"; do
-    if skill_dir_has_entries "$dir"; then
-      blocked=true
-      echo -e "${RED}✗${NC} Existing skill content found in $dir:"
-      for entry in "$dir"/* "$dir"/.[!.]* "$dir"/..?*; do
-        [[ -e "$entry" || -L "$entry" ]] || continue
-        echo -e "      • $(basename "$entry")"
-      done
-    fi
-  done
+    local existing=()
+    for skill in "${skills[@]}"; do
+      [[ -e "$dir/$skill" || -L "$dir/$skill" ]] && existing+=("$skill")
+    done
+    [[ ${#existing[@]} -gt 0 ]] || continue
 
-  if [[ "$blocked" == true ]]; then
-    echo -e "    Skill installation stopped before skills@$SKILLS_CLI_VERSION could replace a destination."
-    echo -e "    Back up and explicitly clear the listed target, or use a separately reviewed CLI update workflow."
-    return 1
-  fi
+    backup="$(mktemp -d "$dir.before-install.XXXXXXXX")"
+    echo -e "${YELLOW}→${NC} Backing up ${#existing[@]} existing selected skill(s) from $dir to $backup"
+    for skill in "${existing[@]}"; do
+      cp -a "$dir/$skill" "$backup/"
+    done
+  done
 }
 
 # Optional (community) skill sources that failed to install. Collected so a
@@ -608,9 +595,7 @@ if [[ "$INSTALL_SKILLS" == true ]]; then
     exit 1
   fi
 
-  if ! guard_selected_skill_dirs; then
-    exit 1
-  fi
+  backup_selected_skills "${install_manifest[@]}"
 
   install_skills_from "$OWN_SKILLS_REPO" "own skills (citypaul/.dotfiles)" "${FIRST_PARTY_SKILLS[@]}"
 
@@ -637,8 +622,7 @@ if [[ "$INSTALL_SKILLS" == true ]]; then
       echo -e "      • $src"
     done
     echo -e "    These are third-party community sources; setup continued without them."
-    echo -e "    Review the failed source on skills.sh. Before retrying, back up and explicitly clear the selected targets,"
-    echo -e "    or use a separately reviewed ownership-safe workflow; successful installs make an automatic rerun stop by design."
+    echo -e "    Review the failed source on skills.sh, then rerun; existing selected skills were backed up before replacement."
   fi
   echo ""
 fi
@@ -782,7 +766,7 @@ echo -e "${BLUE}Inspecting skills:${NC}"
 echo ""
 echo -e "  ${YELLOW}npx skills@$SKILLS_CLI_VERSION list -g${NC}              List installed skills"
 echo -e "  ${YELLOW}npx skills@$SKILLS_CLI_VERSION find <query>${NC}         Search skills.sh for more skills"
-echo -e "  Mutating update/remove commands bypass this installer's ownership preflight; back up and verify exact targets first."
+echo -e "  Mutating update/remove commands bypass this installer's automatic backups; back up and verify exact targets first."
 echo ""
 echo -e "${BLUE}Next steps:${NC}"
 echo ""

--- a/test/install-claude-skill-layout.sh
+++ b/test/install-claude-skill-layout.sh
@@ -1,12 +1,7 @@
 #!/usr/bin/env bash
 #
-# Verify the installer refuses to invoke the pinned installer while any target
-# it may replace already contains skills. The v3 lock has no per-destination
-# ownership, so neither an absent nor a present name proves a target disposable.
-#
-# skills@1.5.22 recursively replaces same-named destinations. The wrapper passes
-# --copy explicitly, so the preflight must cover every selected resolved target
-# and must not block on an unrelated canonical directory.
+# Verify repeat installs back up selected existing skills, then let the pinned
+# CLI replace them without touching unrelated content.
 #
 
 set -e
@@ -38,8 +33,8 @@ AGENTS_DIR="$HOME_DIR/.agents"
 
 mkdir -p "$TMPDIR/bin" "$SKILLS_DIR" "$AGENTS_DIR/skills/linked-skill"
 
-# Stub npx so no real install happens. If invoked, it simulates copy mode
-# replacing the colliding directory; a correct preflight never calls it.
+# Stub npx so no real install happens. If requested, it simulates copy mode
+# replacing one selected skill directory.
 cat > "$TMPDIR/bin/npx" <<'STUB'
 #!/usr/bin/env bash
 touch "$NPX_MARKER"
@@ -48,6 +43,8 @@ if [[ -n "${NPX_ARGS:-}" ]]; then
 fi
 if [[ -d "$SIMULATED_DESTINATION" ]]; then
   mv "$SIMULATED_DESTINATION" "${SIMULATED_DESTINATION}.overwritten"
+  mkdir -p "$SIMULATED_DESTINATION"
+  echo "# installed" > "$SIMULATED_DESTINATION/SKILL.md"
 fi
 exit 0
 STUB
@@ -94,32 +91,33 @@ OUTPUT=$(HOME="$HOME_DIR" PATH="$TMPDIR/bin:$PATH" \
 STATUS=$?
 set -e
 
-if [[ $STATUS -ne 0 ]]; then
-  pass "installer refuses an existing Claude skill target"
+if [[ $STATUS -eq 0 ]]; then
+  pass "repeat install replaces a selected Claude skill"
 else
-  fail "installer must stop before a colliding unmanaged skill can be replaced"
+  fail "existing selected Claude skill should not block installation"
 fi
 
-if [[ ! -e "$TMPDIR/npx-called" ]]; then
-  pass "skills CLI is not invoked before the ownership conflict is resolved"
+if [[ -e "$TMPDIR/npx-called" ]]; then
+  pass "skills CLI is invoked after backup"
 else
-  fail "preflight must run before npx"
+  fail "skills CLI should run after backing up existing selected skills"
 fi
 
-# The custom directory stays untouched.
-if [[ -f "$SKILLS_DIR/tdd/SKILL.md" ]] && grep -q '# custom tdd' "$SKILLS_DIR/tdd/SKILL.md"; then
-  pass "colliding unmanaged skill directory is left untouched"
+# The previous content remains recoverable.
+if compgen -G "$HOME_DIR/.claude/skills.before-install.*/tdd/SKILL.md" > /dev/null &&
+   grep -q '# custom tdd' "$HOME_DIR"/.claude/skills.before-install.*/tdd/SKILL.md; then
+  pass "replaced Claude skill is backed up"
 else
-  fail "installer must preserve the colliding unmanaged skill"
+  fail "installer must back up a selected Claude skill before replacement"
 fi
 
-if printf '%s' "$OUTPUT" | grep -q "tdd"; then
-  pass "installer identifies the Claude collision"
+if grep -q '# installed' "$SKILLS_DIR/tdd/SKILL.md"; then
+  pass "selected Claude skill is refreshed"
 else
-  fail "installer should report the unmanaged directory before stopping"
+  fail "selected Claude skill should be replaced after backup"
 fi
 
-# A lock entry does not bypass the destination preflight.
+# An unrelated lock-managed skill stays put.
 if [[ -d "$SKILLS_DIR/managed-skill" && -f "$SKILLS_DIR/managed-skill/SKILL.md" ]]; then
   pass "stale or ambiguous lock-managed directory is left in place"
 else
@@ -141,14 +139,14 @@ else
   fail "symlinked skill must be left untouched"
 fi
 
-if printf '%s' "$OUTPUT" | grep -q "managed-skill"; then
-  pass "lock name is not treated as destination ownership evidence"
+if ! printf '%s' "$OUTPUT" | grep -q "managed-skill"; then
+  pass "unselected lock-managed skill is ignored"
 else
-  fail "preflight should list every existing destination entry"
+  fail "installer should not inspect unrelated skill names"
 fi
 
 # Universal agents use the canonical ~/.agents/skills target. A Codex-only
-# install must protect it without being blocked by an unrelated Claude target.
+# install refreshes selected names there without being blocked by Claude.
 mkdir -p "$AGENTS_DIR/skills/tdd"
 echo "# custom codex tdd" > "$AGENTS_DIR/skills/tdd/SKILL.md"
 
@@ -159,17 +157,19 @@ CODEX_OUTPUT=$(HOME="$HOME_DIR" PATH="$TMPDIR/bin:$PATH" \
 CODEX_STATUS=$?
 set -e
 
-if [[ $CODEX_STATUS -ne 0 ]] && [[ ! -e "$TMPDIR/npx-called-codex" ]]; then
-  pass "Codex-only install is stopped before the canonical target can be replaced"
+if [[ $CODEX_STATUS -eq 0 ]] && [[ -e "$TMPDIR/npx-called-codex" ]] &&
+   printf '%s' "$CODEX_OUTPUT" | grep -q 'Backing up'; then
+  pass "Codex-only repeat install refreshes the canonical target"
 else
-  fail "Codex canonical preflight must run before npx"
+  fail "existing Codex skill should not block installation"
 fi
 
-if grep -q '# custom codex tdd' "$AGENTS_DIR/skills/tdd/SKILL.md" &&
-   printf '%s' "$CODEX_OUTPUT" | grep -q "tdd"; then
-  pass "Codex collision is reported and preserved"
+if compgen -G "$AGENTS_DIR/skills.before-install.*/tdd/SKILL.md" > /dev/null &&
+   grep -q '# custom codex tdd' "$AGENTS_DIR"/skills.before-install.*/tdd/SKILL.md &&
+   grep -q '# installed' "$AGENTS_DIR/skills/tdd/SKILL.md"; then
+  pass "Codex skill is backed up and refreshed"
 else
-  fail "Codex collision must remain recoverable"
+  fail "Codex replacement must remain recoverable"
 fi
 
 # Two per-agent clients with the same registry layout key still resolve to
@@ -196,7 +196,7 @@ else
   fail "skills CLI invocation must include --copy"
 fi
 
-if grep -q '# custom codex tdd' "$AGENTS_DIR/skills/tdd/SKILL.md" &&
+if grep -q '# installed' "$AGENTS_DIR/skills/tdd/SKILL.md" &&
    printf '%s' "$PAIR_OUTPUT" | grep -q 'installed'; then
   pass "unselected canonical skill content remains untouched"
 else


### PR DESCRIPTION
## Summary

- back up existing selected skills before the pinned Skills CLI refreshes them
- leave unrelated skills and files in each destination untouched
- document repeat-install recovery and add a patch changeset

## Why

The destination-wide safety guard treated successful previous installs and
unrelated files such as `.DS_Store` as conflicts. Every installer rerun
therefore stopped before the pinned CLI could refresh the reviewed skill names.

The installer now copies only colliding selected names to an adjacent
`skills.before-install.<random>/` backup, then continues with the existing
pinned, explicit-copy install.

## User impact

Existing Claude Code and Codex skill installs can be refreshed by rerunning the
installer. Previous selected content remains recoverable, while unrelated
destination content no longer blocks or gets copied.

## Validation

- `shellcheck install-claude.sh test/install-claude-skill-layout.sh`
- `./test/run.sh`
