### PR TITLE
fix: install commit-pinned skill sources via GitHub archive URLs

### DIFF
--- a/.changeset/fix-commit-pinned-skill-install.md
+++ b/.changeset/fix-commit-pinned-skill-install.md
@@ -1,0 +1,11 @@
+---
+"@citypaul/dotfiles": patch
+---
+
+Fix skill installation failing with "Remote branch <sha> not found in upstream
+origin". The pinned Skills CLI clones `repo#<ref>` sources with
+`git clone --branch`, which only accepts branch or tag names, so every
+commit-pinned source added by the install hardening could never clone. The
+installer now rewrites commit pins to GitHub commit-archive tarball URLs,
+which the CLI downloads and installs without cloning while keeping the same
+immutable revision.

--- a/README.md
+++ b/README.md
@@ -1677,7 +1677,7 @@ The installer used to `curl` every `SKILL.md` straight from this repo into `~/.c
 
 **Trade-offs:**
 - Requires Node.js for `npx`. `--claude-only` and `--agents-only` still work without it.
-- The executable CLI is pinned to [`skills@1.5.22`](https://github.com/vercel-labs/skills/tree/v1.5.22). Every repository source uses the CLI's `#<git-ref>` syntax, and every selected skill name is declared before installation; source changes require an explicit pin update and re-audit. `--version` pins first-party skills, `CLAUDE.md`, commands, and agents to the same reviewed release/commit.
+- The executable CLI is pinned to [`skills@1.5.22`](https://github.com/vercel-labs/skills/tree/v1.5.22). Every repository source is pinned to a commit, and the installer hands each pin to the CLI as a GitHub commit-archive URL (the CLI's `#<git-ref>` syntax clones with `git clone --branch`, which rejects commit SHAs). Every selected skill name is declared before installation; source changes require an explicit pin update and re-audit. `--version` pins first-party skills, `CLAUDE.md`, commands, and agents to the same reviewed release/commit.
 - Skills used to ship at the same `v3.x` tag as everything else in this repo; now they roll independently. Use `npx skills@1.5.22 list -g --json` if you want to snapshot what's installed.
 
 `CLAUDE.md`, slash commands, and Claude-Code agents are still `curl`ed directly from this repo — they aren't skills and aren't part of the skills.sh ecosystem.

--- a/install-claude.sh
+++ b/install-claude.sh
@@ -41,8 +41,11 @@ INSTALL_PONYTAIL=true
 BASE_URL="https://raw.githubusercontent.com/citypaul/.dotfiles"
 SKILLS_CLI_VERSION="1.5.22" # https://github.com/vercel-labs/skills/tree/v1.5.22
 
-# Reviewed immutable source revisions. The Skills CLI supports `#<git-ref>`;
-# every source is pinned and every selected name is declared before mutation.
+# Reviewed immutable source revisions. Every source is pinned to a commit and
+# every selected name is declared before mutation. The Skills CLI clones
+# `repo#<ref>` sources with `git clone --branch`, which only accepts branch or
+# tag names, so commit pins are rewritten to GitHub commit-archive URLs before
+# install (see resolve_pinned_source).
 OWN_SKILLS_REPO_BASE="citypaul/.dotfiles"
 WEB_QUALITY_SKILLS_REPO="addyosmani/web-quality-skills#95d6e255afe1596b557d7a8498517884438f5b3a"
 NEXT_SKILLS_REPO="vercel-labs/next-skills#b76d687cf3e026eac3b1032f610f06b47a56377c"
@@ -487,12 +490,42 @@ validate_unique_skill_names() {
   done
 }
 
+# The pinned Skills CLI fetches `repo#<ref>` sources with
+# `git clone --branch <ref>`, and git only accepts branch or tag names there —
+# a commit-SHA pin always dies with "Remote branch <sha> not found in upstream
+# origin". GitHub's commit-archive endpoint serves the same immutable revision
+# as a tarball, and the CLI installs archive URLs without cloning, so
+# commit-pinned GitHub sources are rewritten to that form. Anything else
+# (branch/tag refs, non-GitHub URLs) passes through untouched.
+resolve_pinned_source() {
+  local source="$1"
+  local repo="${source%%#*}"
+  local ref="${source##*#}"
+
+  if [[ "$source" != *"#"* ]] || ! [[ "$ref" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "$source"
+    return 0
+  fi
+
+  case "$repo" in
+    https://github.com/*) repo="${repo#https://github.com/}" ;;
+    *://*|git@*)
+      echo "$source"
+      return 0
+      ;;
+  esac
+
+  echo "https://github.com/${repo%.git}/archive/$ref.tar.gz"
+}
+
 # Install skills from a skills.sh source for the selected agents
 install_skills_from() {
   local source="$1"
   local label="$2"
   shift 2
   local skills=("$@")
+  local install_source
+  install_source="$(resolve_pinned_source "$source")"
 
   if [[ ${#skills[@]} -eq 0 ]]; then
     echo -e "${RED}✗${NC} No reviewed skill names declared for $source"
@@ -510,7 +543,7 @@ install_skills_from() {
   # -g: install globally (per-agent paths managed by the skills CLI)
   # -s: install only the reviewed names declared above
   # -y: skip prompts
-  if npx --yes "skills@$SKILLS_CLI_VERSION" add "$source" -g "${agent_args[@]}" -s "${skills[@]}" --copy -y; then
+  if npx --yes "skills@$SKILLS_CLI_VERSION" add "$install_source" -g "${agent_args[@]}" -s "${skills[@]}" --copy -y; then
     echo -e "${GREEN}✓${NC} $label installed"
   else
     echo -e "${RED}✗${NC} Failed to install $label from $source"

--- a/test/install-claude-herdr-skill.sh
+++ b/test/install-claude-herdr-skill.sh
@@ -63,7 +63,7 @@ HOME="$TMPDIR/home" \
 PATH="$TMPDIR/bin:/usr/bin:/bin" \
   "$REPO_ROOT/install-claude.sh" --no-agents > "$TMPDIR/output"
 
-if grep -Fq -- "skills@1.5.22 add herdrdev/herdr#1777e9bba32b953ed1ad203b4a16d01105539000 -g -a claude-code -s herdr --copy -y" "$NPX_LOG"; then
+if grep -Fq -- "skills@1.5.22 add https://github.com/herdrdev/herdr/archive/1777e9bba32b953ed1ad203b4a16d01105539000.tar.gz -g -a claude-code -s herdr --copy -y" "$NPX_LOG"; then
   pass "installs the herdr skill for claude-code"
 else
   fail "missing herdr skill install for claude-code"
@@ -79,7 +79,7 @@ HOME="$TMPDIR/home" \
 PATH="$TMPDIR/bin:/usr/bin:/bin" \
   "$REPO_ROOT/install-claude.sh" --no-agents --agent codex > "$TMPDIR/output-codex"
 
-if grep -Fq -- "skills@1.5.22 add herdrdev/herdr#1777e9bba32b953ed1ad203b4a16d01105539000 -g -a claude-code -a codex -s herdr --copy -y" "$NPX_LOG"; then
+if grep -Fq -- "skills@1.5.22 add https://github.com/herdrdev/herdr/archive/1777e9bba32b953ed1ad203b4a16d01105539000.tar.gz -g -a claude-code -a codex -s herdr --copy -y" "$NPX_LOG"; then
   pass "installs the herdr skill for claude-code and codex"
 else
   fail "herdr skill did not target both agents"

--- a/test/install-claude-next-skills.sh
+++ b/test/install-claude-next-skills.sh
@@ -102,16 +102,22 @@ assert_output() {
   fi
 }
 
-assert_npx_call "--yes skills@1.5.22 add vercel-labs/next-skills#b76d687cf3e026eac3b1032f610f06b47a56377c -g -a codex -s next-best-practices next-cache-components next-upgrade --copy -y"
+assert_npx_call "--yes skills@1.5.22 add https://github.com/vercel-labs/next-skills/archive/b76d687cf3e026eac3b1032f610f06b47a56377c.tar.gz -g -a codex -s next-best-practices next-cache-components next-upgrade --copy -y"
 assert_output "vercel-labs/next-skills"
 
-if grep -Eq 'add (addyosmani/web-quality-skills|vercel-labs/next-skills|pbakaus/impeccable|https://github.com/mattpocock/skills|coreyhaines31/marketingskills|herdrdev/herdr)[^ ]* .* -s \* ' "$NPX_LOG"; then
+if grep -Eq 'add [^ ]*(addyosmani/web-quality-skills|vercel-labs/next-skills|pbakaus/impeccable|mattpocock/skills|coreyhaines31/marketingskills|herdrdev/herdr)[^ ]* .* -s \* ' "$NPX_LOG"; then
   fail "external sources must never install an undeclared wildcard set"
 else
   pass "external sources install only reviewed names"
 fi
 
-FIRST_PARTY_CALL=$(grep 'add citypaul/.dotfiles#' "$NPX_LOG" || true)
+if grep -Eq 'add [^ ]*#[0-9a-f]{40}( |$)' "$NPX_LOG"; then
+  fail "commit-pinned sources must reach the skills CLI as archive URLs (git clone --branch rejects SHAs)"
+else
+  pass "no source is passed as a repo#sha ref the skills CLI cannot clone"
+fi
+
+FIRST_PARTY_CALL=$(grep 'add https://github.com/citypaul/.dotfiles/archive/' "$NPX_LOG" || true)
 while IFS= read -r skill_file; do
   skill_name=$(basename "$(dirname "$skill_file")")
   if [[ " $FIRST_PARTY_CALL " != *" $skill_name "* ]]; then
@@ -119,7 +125,7 @@ while IFS= read -r skill_file; do
   fi
 done < <(find "$REPO_ROOT/claude/.claude/skills" -mindepth 2 -maxdepth 2 -name SKILL.md -print)
 
-if [[ "$FIRST_PARTY_CALL" == *"#"* ]] && [[ "$FIRST_PARTY_CALL" != *" -s * "* ]]; then
+if [[ "$FIRST_PARTY_CALL" == *"archive/$EXACT_COMMIT.tar.gz"* ]] && [[ "$FIRST_PARTY_CALL" != *" -s * "* ]]; then
   pass "first-party source revision and complete name set are explicit"
 else
   fail "first-party install must use a pinned source and declared names"


### PR DESCRIPTION
## Summary

- Skill installation has been broken since #229 for every fresh run: the pinned Skills CLI (`skills@1.5.22`, still the latest release) fetches `repo#<ref>` sources with `git clone --depth 1 --branch <ref>`, and git's `--branch` only accepts branch/tag names — so every commit-SHA pin died with `Remote branch <sha> not found in upstream origin` (the CLI's no-clone fast path is allowlisted to vercel/vercel-labs/heygen-com repos only).
- `install-claude.sh` now rewrites commit-pinned GitHub sources to commit-archive tarball URLs (`https://github.com/<owner>/<repo>/archive/<sha>.tar.gz`) via a new `resolve_pinned_source` helper before invoking the CLI. GitHub serves the exact pinned commit as a tarball and the CLI installs archive URLs through its download path with no clone — same immutable revision, no `git clone --branch` failure. Branch/tag refs and non-GitHub URLs pass through unchanged.
- Updated the installer tests to assert the archive-URL form, added a regression guard that fails if any `repo#<sha>` source ever reaches the CLI again, and corrected the README's description of the pinning mechanism.

## Verification (behavior change)

- **RED → GREEN**: test expectations in `test/install-claude-next-skills.sh` and `test/install-claude-herdr-skill.sh` were updated first and failed against the unfixed script (48 + 2 failures), then passed after the `resolve_pinned_source` change.
- **Mutation testing**: N/A — bash installer script, no Stryker-mutable TypeScript in scope. Proportionate alternate evidence:
  - Live end-to-end check: `npx skills@1.5.22 add https://github.com/citypaul/.dotfiles/archive/956a9f9….tar.gz -s tdd --copy -y` downloads the pinned commit, discovers the nested `claude/.claude/skills/*` layout, and installs correctly.
  - `curl -IL` confirms GitHub serves `archive/<sha>.tar.gz` (302 → codeload → 200) for the pinned revisions.
  - New regression guard test scans the full npx invocation log, covering both slug-form (`owner/repo#sha`) and URL-form (`https://github.com/mattpocock/skills#sha`) pins.
- **Full gate**: `./test/run.sh` — all 8 test files pass on the final tree. Lint: shellcheck unavailable locally — N/A (`bash -n` clean).
- Changeset included (`.changeset/fix-commit-pinned-skill-install.md`, patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)