### PR TITLE
fix: raise Skills CLI download cap for large pinned sources

### DIFF
--- a/.changeset/skills-download-cap.md
+++ b/.changeset/skills-download-cap.md
@@ -1,0 +1,11 @@
+---
+"@citypaul/dotfiles": patch
+---
+
+Raise the Skills CLI download cap so large pinned sources install
+
+The Skills CLI refuses source downloads larger than 10MB, and several pinned
+community skill sources (impeccable, herdr, next-skills) ship archives above
+that, failing the install. The installer now sets
+`SKILLS_DOWNLOAD_MAX_BYTES=104857600` (100MB) for its Skills CLI invocations,
+while an explicit caller-provided cap still wins.

--- a/install-claude.sh
+++ b/install-claude.sh
@@ -41,6 +41,13 @@ INSTALL_PONYTAIL=true
 BASE_URL="https://raw.githubusercontent.com/citypaul/.dotfiles"
 SKILLS_CLI_VERSION="1.5.22" # https://github.com/vercel-labs/skills/tree/v1.5.22
 
+# The Skills CLI refuses source downloads larger than 10MB unless
+# SKILLS_DOWNLOAD_MAX_BYTES raises the cap. Several pinned community repos
+# (impeccable, herdr, next-skills) ship archives above that, so raise it to
+# 100MB while letting an explicit caller-provided cap win.
+SKILLS_DOWNLOAD_MAX_BYTES="${SKILLS_DOWNLOAD_MAX_BYTES:-104857600}"
+export SKILLS_DOWNLOAD_MAX_BYTES
+
 # Reviewed immutable source revisions. Every source is pinned to a commit and
 # every selected name is declared before mutation. The Skills CLI clones
 # `repo#<ref>` sources with `git clone --branch`, which only accepts branch or


### PR DESCRIPTION
## Why

The Skills CLI refuses source downloads larger than 10MB. Several pinned community skill sources — impeccable, herdr, next-skills — ship archives above that limit, so `install-claude.sh` fails to install them.

## What changed

`install-claude.sh` exports `SKILLS_DOWNLOAD_MAX_BYTES=104857600` (100MB) before invoking the Skills CLI, while letting an explicit caller-provided cap win (`${SKILLS_DOWNLOAD_MAX_BYTES:-104857600}`). Includes a patch changeset.

Note: this change was recovered from a work-in-progress stash (`users-skills-download-cap-wip`); a companion test asserting the cap reaches the Skills CLI environment (`DOWNLOAD_CAP_LOG` in `test/install-claude-next-skills.sh`) was seen in an earlier working tree but is not part of this PR — worth adding if that WIP still exists elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)