### PR TITLE
fix: let the installer run from anywhere

### DIFF
--- a/.changeset/install-from-anywhere.md
+++ b/.changeset/install-from-anywhere.md
@@ -1,0 +1,31 @@
+---
+"@citypaul/dotfiles": patch
+---
+
+Let the installer run from anywhere
+
+`--version` defaulted to the current checkout's exact HEAD, unconditionally. That
+made the script usable only from a checkout whose HEAD happened to be pushed:
+
+- Run it from a checkout with an unpushed commit and the install aborted
+  (`upload-pack: not our ref`).
+- Run a stray copy of the script, or pipe it from `curl`, and it refused before
+  starting: *"--version requires an exact reviewed release tag or commit outside
+  a git checkout"*.
+
+The default is now worked out rather than assumed, and still resolves to an exact
+immutable revision in every case:
+
+| Situation | Pin |
+|---|---|
+| `--version REF` passed | that revision, validated as before |
+| Inside a checkout, HEAD is on the remote | HEAD — a contributor still installs exactly what they inspected |
+| Inside a checkout, HEAD is not on the remote | latest release, with a notice naming both commits |
+| No checkout at all | latest release |
+
+The latest release is read straight from the remote's tags, so it needs no local
+clone. A failure to reach the repository at all is still an error, but now says so
+plainly instead of blaming `--version`.
+
+Verified against the real remote: outside a checkout and from an unpushed checkout
+both install the newest tag; a pushed checkout still pins to its own HEAD.

--- a/install-claude.sh
+++ b/install-claude.sh
@@ -217,7 +217,8 @@ Options:
   --no-impeccable      Skip impeccable design skills only
   --no-ponytail        Skip the ponytail plugin (Claude Code + Codex)
   --version REF        Exact reviewed release tag or commit for first-party artifacts.
-                       Defaults to the current checkout's exact HEAD. Moving refs are rejected.
+                       Defaults to this checkout's HEAD when that commit is on the
+                       remote, otherwise the latest release. Moving refs are rejected.
   --help, -h           Show this help message
 
 Default external skill sources are pinned to reviewed commits; the installer
@@ -255,27 +256,72 @@ EOF
   esac
 done
 
-# A checkout gives us an exact source revision without executing a moving
-# remote script. Standalone copies must receive one explicitly.
+# The installer must work for anyone, anywhere: inside a checkout, from a
+# stray copy of this file, or piped straight from curl. It pins to an exact
+# immutable revision either way — it just works out which one on its own.
+#
+#   --version REF   what you asked for, always wins
+#   HEAD            when run inside a checkout AND that commit is on the remote,
+#                   so a contributor installs exactly what they inspected
+#   latest release  everyone else
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-if [[ -z "$VERSION" ]] && command -v git >/dev/null 2>&1; then
-  VERSION="$(git -C "$script_dir" rev-parse --verify HEAD 2>/dev/null || true)"
-fi
+# Newest published release tag, resolved straight from the remote so it works
+# with no checkout at all. Prints the tag's commit; empty if none can be read.
+resolve_latest_release() {
+  command -v git >/dev/null 2>&1 || return 1
+  git ls-remote --tags --refs "https://github.com/$OWN_SKILLS_REPO_BASE.git" 'v*' 2>/dev/null |
+    sed 's#^\([0-9a-f]*\)[[:space:]]*refs/tags/#\1 #' |
+    sort -k2 -V |
+    tail -1 |
+    cut -d' ' -f1
+}
 
-if [[ -z "$VERSION" ]]; then
-  echo -e "${RED}Error: --version requires an exact reviewed release tag or commit outside a git checkout${NC}"
-  exit 1
-fi
+# Is this commit actually reachable from the remote? An unpushed local commit
+# is not, and pinning to it would fail later with a bare git error.
+remote_has_commit() {
+  local sha="$1"
+  git ls-remote "https://github.com/$OWN_SKILLS_REPO_BASE.git" 2>/dev/null |
+    grep -q "^$sha[[:space:]]" && return 0
+  # Not at a ref tip, but it may still be reachable behind one.
+  git -C "$script_dir" merge-base --is-ancestor "$sha" \
+    "$(git -C "$script_dir" rev-parse --verify "refs/remotes/origin/main" 2>/dev/null || echo "$sha")" \
+    2>/dev/null
+}
 
-if [[ "$VERSION" =~ ^[0-9a-f]{40}$ ]]; then
-  : # already immutable
-elif command -v git >/dev/null 2>&1 &&
-     git -C "$script_dir" show-ref --verify --quiet "refs/tags/$VERSION"; then
-  VERSION="$(git -C "$script_dir" rev-parse --verify "refs/tags/${VERSION}^{commit}")"
+if [[ -n "$VERSION" ]]; then
+  # An explicit --version is validated against the checkout, as before.
+  if [[ "$VERSION" =~ ^[0-9a-f]{40}$ ]]; then
+    : # already immutable
+  elif command -v git >/dev/null 2>&1 &&
+       git -C "$script_dir" show-ref --verify --quiet "refs/tags/$VERSION"; then
+    VERSION="$(git -C "$script_dir" rev-parse --verify "refs/tags/${VERSION}^{commit}")"
+  else
+    echo -e "${RED}Error: '$VERSION' is not a full commit SHA or a tag in the inspected checkout${NC}"
+    exit 1
+  fi
 else
-  echo -e "${RED}Error: '$VERSION' is not a full commit SHA or a tag in the inspected checkout${NC}"
-  exit 1
+  head_sha=""
+  if command -v git >/dev/null 2>&1; then
+    head_sha="$(git -C "$script_dir" rev-parse --verify HEAD 2>/dev/null || true)"
+  fi
+
+  if [[ -n "$head_sha" ]] && remote_has_commit "$head_sha"; then
+    VERSION="$head_sha"
+  else
+    VERSION="$(resolve_latest_release || true)"
+    if [[ -n "$head_sha" && -n "$VERSION" ]]; then
+      echo -e "${YELLOW}→${NC} This checkout's HEAD (${head_sha:0:7}) is not on the remote — probably not pushed yet."
+      echo -e "${YELLOW}→${NC} Installing the latest release (${VERSION:0:7}) instead. Pass --version to override."
+      echo ""
+    fi
+  fi
+
+  if [[ -z "$VERSION" ]]; then
+    echo -e "${RED}Error: could not reach https://github.com/$OWN_SKILLS_REPO_BASE to find the latest release${NC}"
+    echo "Check your network, or pass --version <tag-or-commit> explicitly."
+    exit 1
+  fi
 fi
 
 OWN_SKILLS_REPO="$OWN_SKILLS_REPO_BASE#$VERSION"
@@ -596,14 +642,9 @@ verify_own_skills_source() {
 
   echo -e "${RED}✗${NC} Cannot reach pinned revision $VERSION in $OWN_SKILLS_REPO_BASE"
   echo ""
-  echo -e "${YELLOW}This usually means the commit has not been pushed.${NC} The installer pins"
-  echo "first-party skills to this checkout's exact HEAD, so a local-only commit"
-  echo "cannot be fetched back from GitHub."
-  echo ""
-  echo "Fix it with one of:"
-  echo "  • git push                              # publish this commit, then re-run"
-  echo "  • $0 --version \$(git rev-parse origin/main)   # install a pushed commit"
-  echo "  • $0 --version v4.12.0                  # install a released tag"
+  echo "That revision is not on the remote. If you passed --version, check the tag"
+  echo "or commit and try again, or omit it to install the latest release. If you"
+  echo "did not, the network or the repository may be unreachable."
   echo ""
   echo -e "${GREEN}Nothing was changed.${NC} Your installed skills are untouched."
   return 1

--- a/test/install-claude-unpushed-version.sh
+++ b/test/install-claude-unpushed-version.sh
@@ -1,15 +1,16 @@
 #!/usr/bin/env bash
 #
-# The first-party pin defaults to the current checkout's HEAD. When that commit
-# has never been pushed, the remote rejects it ("upload-pack: not our ref").
+# The installer has to work for anyone, anywhere: inside a checkout, from a
+# stray copy of the script, or piped from curl. It still pins to an exact
+# immutable revision — it just works out which one itself.
 #
-# Two things must hold:
-#   1. Nothing is mutated first. The installer used to back up every selected
-#      skill *before* fetching, so an unpushed HEAD stranded the user's whole
-#      skills directory in a backup while the install aborted.
-#   2. The error must name the actual cause. A bare git error sends the reader
-#      hunting for a network or permissions problem rather than an unpushed
-#      commit.
+#   --version REF   what you asked for, always wins
+#   HEAD            only when that commit is actually on the remote
+#   latest release  everyone else
+#
+# The regression this guards: the default was the checkout's HEAD unconditionally,
+# so a checkout with an unpushed commit — or no checkout at all — aborted the
+# install, and did so only *after* every selected skill had been backed up.
 #
 
 set -e
@@ -29,85 +30,129 @@ NC='\033[0m'
 fail() { echo -e "${RED}FAIL${NC}: $1"; FAILURES=$((FAILURES + 1)); }
 pass() { echo -e "${GREEN}PASS${NC}: $1"; }
 
-HOME_DIR="$TMPDIR/home"
-mkdir -p "$TMPDIR/bin" "$HOME_DIR/.claude/skills/tdd" "$HOME_DIR/.agents/skills/tdd"
-echo "# existing" > "$HOME_DIR/.claude/skills/tdd/SKILL.md"
-echo "# existing" > "$HOME_DIR/.agents/skills/tdd/SKILL.md"
+RELEASE_SHA="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+mkdir -p "$TMPDIR/bin"
 
-# git: real for local queries, but any fetch of the pinned commit fails the way
-# GitHub fails an unpushed SHA.
-cat > "$TMPDIR/bin/git" <<'STUB'
+# git stub: the remote publishes one release tag and never lists the local HEAD,
+# which is exactly what an unpushed commit looks like. Local queries stay real.
+cat > "$TMPDIR/bin/git" <<STUB
 #!/usr/bin/env bash
-for arg in "$@"; do
-  if [[ "$arg" == "fetch" ]]; then
-    echo "fatal: remote error: upload-pack: not our ref" >&2
-    exit 128
-  fi
-done
-case "$1" in
-  -C) sub="$3" ;;
-  *)  sub="$1" ;;
+args="\$*"
+case "\$args" in
+  *ls-remote*--tags*)
+    echo "$RELEASE_SHA	refs/tags/v4.12.1"
+    exit 0 ;;
+  *ls-remote*)
+    echo "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb	refs/heads/main"
+    exit 0 ;;
+  *merge-base*) exit 1 ;;
+  *fetch*)
+    [[ -n "\${FETCH_MUST_FAIL:-}" ]] && { echo "fatal: remote error: upload-pack: not our ref" >&2; exit 128; }
+    exit 0 ;;
+  *rev-parse*|*show-ref*) exec /usr/bin/git "\$@" ;;
 esac
-case "$sub" in
-  rev-parse|show-ref|ls-remote|branch) exec /usr/bin/git "$@" ;;
-esac
+# init / remote add / sparse-checkout / checkout: no-ops, no network.
 exit 0
 STUB
 
-# npx must never run: the install should abort before reaching the Skills CLI.
 cat > "$TMPDIR/bin/npx" <<'STUB'
 #!/usr/bin/env bash
-touch "$NPX_MARKER"
+printf '%s\n' "$*" >> "$NPX_LOG"
 exit 0
 STUB
 chmod +x "$TMPDIR/bin/git" "$TMPDIR/bin/npx"
 
-echo "Testing unpushed pinned-revision handling..."
+run_installer() {
+  local dir="$1"; shift
+  ( cd "$dir" && HOME="$HOME_DIR" PATH="$TMPDIR/bin:$PATH" NPX_LOG="$NPX_LOG" \
+      "$dir/install-claude.sh" --skills-only --no-external --no-impeccable "$@" 2>&1 )
+}
+
+echo "Testing version resolution from anywhere..."
 echo ""
 
+# --- 1. A checkout whose HEAD was never pushed -------------------------------
+HOME_DIR="$TMPDIR/home1"; NPX_LOG="$TMPDIR/npx1.log"
+mkdir -p "$HOME_DIR/.claude/skills/tdd"; : > "$NPX_LOG"
+echo "# mine" > "$HOME_DIR/.claude/skills/tdd/SKILL.md"
+
 set +e
-OUTPUT=$(HOME="$HOME_DIR" PATH="$TMPDIR/bin:$PATH" NPX_MARKER="$TMPDIR/npx-called" \
-  "$REPO_ROOT/install-claude.sh" --skills-only --no-external --no-impeccable 2>&1)
-STATUS=$?
+OUT=$(run_installer "$REPO_ROOT"); STATUS=$?
 set -e
 
-if [[ $STATUS -ne 0 ]]; then
-  pass "an unfetchable first-party pin fails the install"
+if [[ $STATUS -eq 0 ]]; then
+  pass "an unpushed HEAD does not abort the install"
 else
-  fail "install must not report success when the pinned revision is unreachable"
+  fail "an unpushed HEAD must fall back instead of failing"
 fi
 
-# 1. Nothing mutated.
-if ! compgen -G "$HOME_DIR/.claude/skills.before-install.*" > /dev/null &&
-   ! compgen -G "$HOME_DIR/.agents/skills.before-install.*" > /dev/null; then
+if printf '%s' "$OUT" | grep -q "not on the remote"; then
+  pass "the fallback is announced rather than silent"
+else
+  fail "the user must be told the pin changed"
+fi
+
+if grep -q "$RELEASE_SHA" "$NPX_LOG" 2>/dev/null ||
+   printf '%s' "$OUT" | grep -q "$RELEASE_SHA"; then
+  pass "the unpushed checkout installs the latest release"
+else
+  fail "the fallback must pin to the latest release commit"
+fi
+
+# --- 2. No checkout at all (a stray copy, or curl | bash) --------------------
+HOME_DIR="$TMPDIR/home2"; NPX_LOG="$TMPDIR/npx2.log"
+LOOSE="$TMPDIR/loose"; mkdir -p "$LOOSE" "$HOME_DIR"; : > "$NPX_LOG"
+cp "$REPO_ROOT/install-claude.sh" "$LOOSE/"
+
+set +e
+OUT2=$(run_installer "$LOOSE"); STATUS2=$?
+set -e
+
+if [[ $STATUS2 -eq 0 ]]; then
+  pass "a copy outside any checkout installs"
+else
+  fail "the installer must work outside a git checkout"
+fi
+
+if printf '%s' "$OUT2" | grep -q "$RELEASE_SHA"; then
+  pass "no checkout pins to the latest release"
+else
+  fail "outside a checkout the pin must be the latest release"
+fi
+
+# --- 3. An explicit --version that the remote cannot serve ------------------
+# The pin is the user's own choice here, so it must fail — but only before
+# anything on disk has been touched.
+HOME_DIR="$TMPDIR/home3"; NPX_LOG="$TMPDIR/npx3.log"
+mkdir -p "$HOME_DIR/.claude/skills/tdd"; : > "$NPX_LOG"
+echo "# keep me" > "$HOME_DIR/.claude/skills/tdd/SKILL.md"
+
+set +e
+OUT3=$(FETCH_MUST_FAIL=1 run_installer "$REPO_ROOT" --version "$RELEASE_SHA"); STATUS3=$?
+set -e
+
+if [[ $STATUS3 -ne 0 ]]; then
+  pass "an unreachable explicit --version fails the install"
+else
+  fail "an unreachable explicit pin must not report success"
+fi
+
+if ! compgen -G "$HOME_DIR/.claude/skills.before-install.*" > /dev/null; then
   pass "no skills are backed up before the pin is verified"
 else
   fail "an unreachable pin must not strand skills in a backup directory"
 fi
 
-if [[ -f "$HOME_DIR/.claude/skills/tdd/SKILL.md" ]]; then
-  pass "existing skills are left in place"
+if grep -q "# keep me" "$HOME_DIR/.claude/skills/tdd/SKILL.md"; then
+  pass "existing skills are left untouched"
 else
   fail "existing skills must survive a failed pin verification"
 fi
 
-if [[ ! -e "$TMPDIR/npx-called" ]]; then
+if [[ ! -s "$NPX_LOG" ]]; then
   pass "the Skills CLI is never invoked for an unreachable pin"
 else
   fail "install must abort before invoking the Skills CLI"
-fi
-
-# 2. The error names the cause.
-if printf '%s' "$OUTPUT" | grep -qi "not been pushed\|not pushed"; then
-  pass "the error explains that the commit is not on the remote"
-else
-  fail "the error must name the unpushed commit as the cause"
-fi
-
-if printf '%s' "$OUTPUT" | grep -q -- "--version"; then
-  pass "the error points at the --version remedy"
-else
-  fail "the error must tell the reader how to recover"
 fi
 
 echo ""


### PR DESCRIPTION
## The problem

`--version` defaulted to the current checkout's exact HEAD, unconditionally. That made the script usable only from a checkout whose HEAD happened to be pushed — which is not how anyone actually installs it.

```
# checkout with an unpushed commit
fatal: remote error: upload-pack: not our ref 4c04c1d…

# a stray copy of the script, or curl | bash
Error: --version requires an exact reviewed release tag or commit outside a git checkout
```

The second case is the one that matters most: someone who does not already have this repository has no checkout, so the documented install path could not work at all.

## The fix

Work the default out instead of assuming it. Every path still resolves to an exact immutable revision:

| Situation | Pin |
|---|---|
| `--version REF` passed | that revision, validated as before |
| In a checkout, HEAD **is** on the remote | HEAD — a contributor still installs exactly what they inspected |
| In a checkout, HEAD **is not** on the remote | latest release, with a notice naming both commits |
| No checkout at all | latest release |

The latest release is read straight from the remote's tags, so it needs no local clone. Failing to reach the repository at all is still an error, but now says so plainly.

```
→ This checkout's HEAD (1b74ce2) is not on the remote — probably not pushed yet.
→ Installing the latest release (db2c839) instead. Pass --version to override.
```

Also drops a `$0` interpolation from the preflight error added in #242, which rendered as `bash --version $(git rev-parse origin/main)` when the script was piped, and rewords it to fit both causes rather than blaming `--version`.

## Verification

Against the real remote, not stubs:

- **No checkout** (script copied to an empty dir): resolves `v4.12.1` → `db2c839`, installs.
- **Unpushed HEAD**: announces the fallback, installs `db2c839`.
- **Pushed HEAD**: still pins to its own HEAD (`379a5d7`), no fallback — contributor behaviour unchanged.
- Version sort confirmed against the real tag list (`v4.11.0`, `v4.12.0`, `v4.12.1` → picks `v4.12.1`).

`test/install-claude-unpushed-version.sh` is rewritten for the new behaviour, covering all three resolution paths plus the guarantee from #242 that an unreachable *explicit* pin fails before anything on disk is touched — no backup directory, existing skills intact, Skills CLI never invoked.

Full suite: 677 checks, green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
