### PR TITLE
xstate: machines model lifecycles, not entity kinds

### DIFF
--- a/.changeset/install-from-anywhere.md
+++ b/.changeset/install-from-anywhere.md
@@ -9,9 +9,13 @@ made the script usable only from a checkout whose HEAD happened to be pushed:
 
 - Run it from a checkout with an unpushed commit and the install aborted
   (`upload-pack: not our ref`).
-- Run a stray copy of the script, or pipe it from `curl`, and it refused before
-  starting: *"--version requires an exact reviewed release tag or commit outside
-  a git checkout"*.
+- Run a stray copy of the script and it refused before starting: *"--version
+  requires an exact reviewed release tag or commit outside a git checkout"*.
+- Worst of all, a piped install (`... | bash`) leaves `BASH_SOURCE` unset, so
+  `dirname ""` resolved to `.` — the directory the user happened to be standing
+  in. Running the one-liner from inside *any* other repository pinned the
+  install to **that** repository's HEAD, producing
+  `upload-pack: not our ref <sha>` for a commit that was never in this project.
 
 The default is now worked out rather than assumed, and still resolves to an exact
 immutable revision in every case:
@@ -19,7 +23,7 @@ immutable revision in every case:
 | Situation | Pin |
 |---|---|
 | `--version REF` passed | that revision, validated as before |
-| Inside a checkout, HEAD is on the remote | HEAD — a contributor still installs exactly what they inspected |
+| Inside a checkout **of this repository**, HEAD is on the remote | HEAD — a contributor still installs exactly what they inspected |
 | Inside a checkout, HEAD is not on the remote | latest release, with a notice naming both commits |
 | No checkout at all | latest release |
 
@@ -27,5 +31,12 @@ The latest release is read straight from the remote's tags, so it needs no local
 clone. A failure to reach the repository at all is still an error, but now says so
 plainly instead of blaming `--version`.
 
-Verified against the real remote: outside a checkout and from an unpushed checkout
-both install the newest tag; a pushed checkout still pins to its own HEAD.
+The script's own location now counts only when it is a real file inside a real
+checkout of this repository, so an unrelated repo — or the current directory of a
+piped install — can never become the version source. `--version <tag>` also
+resolves against the remote, so it works with no checkout at all.
+
+Verified against the real remote: piped from inside an unrelated repository, piped
+from a plain directory, and run from an unpushed checkout all install the newest
+release; a pushed checkout of this repository still pins to its own HEAD; and
+`--version v4.12.0` resolves to that tag's commit without a checkout.

--- a/claude/.claude/skills/xstate/SKILL.md
+++ b/claude/.claude/skills/xstate/SKILL.md
@@ -99,7 +99,9 @@ Before adding flow state to a component, search the feature for an existing mach
 
 When a new machine *is* justified, the boundary is **a distinct unit of functionality with its own inputs and outputs** — typically its own connection, resource, or authority. In a real actor-based front end that produced one machine per SSE stream, one for canvas interaction, one for the workshop's node-adding rules, and one for media-connection management: each owns a different external edge, so each fails and reconnects independently.
 
-The question to answer explicitly, and out loud, is not "does this deserve a machine?" but **"why does this not belong to the machine that already owns this edge?"** A small new machine sitting beside a larger one that shares its inputs and outputs is usually a state that should have been added to the larger one. Where the answer is genuinely close, ask rather than guess.
+**Machines model lifecycles, not entity kinds.** Before the edge question, run the shape question: does an actor already model this same lifecycle for a *sibling kind of thing*? Adding, editing, and deleting are usually the same states for every kind a surface manages — compose, submit, wait for the authoritative answer, settle or refuse. When flows differ only in the kind of thing they operate on, that is one machine with the kind carried as context or input, not a machine per kind. A per-kind copy is the plural form of the escaped-state bug: the finite states get duplicated instead of shared, every copy drifts and is tested separately, and the design hides that the lifecycle was the invariant all along. Found a sibling-kind machine? Generalize it — promote the kind to data — rather than cloning it.
+
+The question to answer explicitly, and out loud, is not "does this deserve a machine?" but **"why does this not belong to the machine that already owns this edge — or to the one that already models this lifecycle for a sibling kind?"** A small new machine sitting beside a larger one that shares its inputs and outputs is usually a state that should have been added to the larger one; a new machine that repeats a sibling's states for a different kind is usually that machine, ungeneralized. Where the answer is genuinely close, ask rather than guess.
 
 ### Sweeping for the same violation elsewhere
 
@@ -114,7 +116,7 @@ Once one hand-rolled statechart is found, the same pattern is usually repeated a
 5. **Name everything in `setup()`.** Named actions, guards, actors, and delays make string references type-checked, the chart readable, and `machine.provide()` the universal test seam.
 6. **All v5 transitions are internal by default.** Targetless self-transitions for "update and stay"; `reenter: true` only when you truly want exit/entry re-run and invocations restarted.
 7. **Machines complete like functions.** Flows that end declare final states and `output`; parents consume `onDone`/`onError`. Error paths are modeled states, not console noise.
-8. **One machine per flow — and one owner per lifecycle.** Cross-flow coordination is an actor system (parent machines, `systemId`), never a god machine. Equally, a lifecycle already owned by an actor does not get a second copy of itself in a component's `useState`.
+8. **One machine per flow — and one owner per lifecycle.** Cross-flow coordination is an actor system (parent machines, `systemId`), never a god machine. Equally, a lifecycle already owned by an actor does not get a second copy of itself in a component's `useState` — and flows that differ only in the kind of thing they manage are one flow: the kind is context, not a reason for another machine.
 9. **Test the machine headlessly, the component through the DOM.** The snapshot is the machine's contract; it is implementation detail one level up. Never assert machine state from a component test.
 10. **Validate at the trust boundary.** Events from outside the process (sockets, storage, URLs) are schema-parsed before `send`; persisted snapshots are restored only with a versioning story.
 
@@ -167,6 +169,7 @@ stateDiagram-v2
 **Modeling done wrong:**
 
 - Boolean flags accumulating in context, gating behavior through guards — hidden finite states.
+- A machine per entity kind whose states are the same chart over and over — adding, editing, and deleting one kind of thing at a time. The lifecycle is the invariant; the kind belongs in context or input, and the copies belong merged.
 - Form field *values* mirrored into machine context on every keystroke — the machine owns the submission lifecycle, the form layer owns the current text. (Note the split: `values` stay local, `submitting` does not.)
 - `sendParent` coupling children to parent shapes — pass the parent ref via `input` and use `sendTo`.
 - Spawned actors never stopped; `stopChild` without clearing the context ref.

--- a/claude/.claude/skills/xstate/references/machine-design.md
+++ b/claude/.claude/skills/xstate/references/machine-design.md
@@ -78,6 +78,7 @@ Pure, synchronous, boolean, side-effect-free. Named in `setup({ guards })`, comb
 | Smell | Diagnosis | Fix |
 |-------|-----------|-----|
 | God machine modeling the whole app | Flows forced into one chart | One machine per flow; actor system for coordination |
+| Machine per entity kind | The same add/edit/delete states copied for every type of thing | One machine; the kind is context or input — states are the invariant |
 | Context as dumping ground, 1–2 states | Machine-as-reducer (Pocock's tell: every event does the same thing in every state) | Demote to `@xstate/store` |
 | Boolean flags accumulating in context, gating behavior via guards | Hidden finite states | Promote to explicit states |
 | One event, five guarded transitions on the same field | Same as above | Promote the field to states |

--- a/claude/.claude/skills/xstate/references/when-to-model.md
+++ b/claude/.claude/skills/xstate/references/when-to-model.md
@@ -46,6 +46,8 @@ A submission flag sitting beside a machine that already dispatches the command, 
 
 Search the feature for an existing machine, actor, or `createActorContext` provider before adding flow state to a component.
 
+The same override applies across entity kinds. If a machine already models this lifecycle for a *sibling kind of thing* — the add/edit/delete shape is usually identical for every kind a surface manages — the answer is to generalize that machine so the kind becomes context or input, not to author a per-kind copy whose states repeat it. Copied states drift apart exactly the way split state does; the machine that already exists is the owner, ungeneralized.
+
 ## The Complexity Ladder
 
 Stop at the first rung that genuinely holds — but apply both overrides above first, and read the signals table below; flow logic almost always climbs past rung 2.
@@ -104,4 +106,4 @@ The reverse tell — a machine that should be demoted — is one where the state
 
 **Check the repository before applying any default here.** Architecture or boundary tests, import/lint rules, an established `machine`/`actor` directory convention, `CLAUDE.md`, or the project's own layout guidance all outrank this section — a correct machine in a layer the repository forbids still fails the build, and finding that out from CI costs a round trip. `structure-codebase` owns the general question of which layer owns what.
 
-Absent a repository rule, colocate the machine with the feature it drives: `feature/checkoutMachine.ts` beside the components that render it — a machine *is* feature logic. Large machines may become a folder (`checkout/machine/` with the `setup()` assembly plus actions/actors/guards modules). Avoid a global `machines/` dumping ground for the same reason a global `utils/` fails — it hides feature boundaries. One machine per *flow* (checkout, auth, upload), never per component and never one app-god-machine; cross-flow coordination is an actor-system concern (`references/actors-and-systems.md`).
+Absent a repository rule, colocate the machine with the feature it drives: `feature/checkoutMachine.ts` beside the components that render it — a machine *is* feature logic. Large machines may become a folder (`checkout/machine/` with the `setup()` assembly plus actions/actors/guards modules). Avoid a global `machines/` dumping ground for the same reason a global `utils/` fails — it hides feature boundaries. One machine per *flow* (checkout, auth, upload), never per component, never per entity kind when the flows differ only in the kind of thing they manage, and never one app-god-machine; cross-flow coordination is an actor-system concern (`references/actors-and-systems.md`).

--- a/install-claude.sh
+++ b/install-claude.sh
@@ -257,14 +257,33 @@ EOF
 done
 
 # The installer must work for anyone, anywhere: inside a checkout, from a
-# stray copy of this file, or piped straight from curl. It pins to an exact
+# stray copy of this file, or piped straight from a download. It pins to an exact
 # immutable revision either way — it just works out which one on its own.
 #
 #   --version REF   what you asked for, always wins
-#   HEAD            when run inside a checkout AND that commit is on the remote,
-#                   so a contributor installs exactly what they inspected
+#   HEAD            only when run inside a checkout OF THIS REPOSITORY and that
+#                   commit is on the remote, so a contributor installs exactly
+#                   what they inspected
 #   latest release  everyone else
-script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+#
+# A piped install leaves BASH_SOURCE unset, and `dirname ""` resolves to `.` —
+# the directory the user happens to be standing in. Inferring a checkout from
+# that once pinned an install to an unrelated private repository's HEAD, so the
+# script's own location only counts when it is a real file inside a real
+# checkout of this repository.
+script_dir=""
+if [[ -n "${BASH_SOURCE[0]:-}" && -f "${BASH_SOURCE[0]}" ]]; then
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+fi
+
+# True only for a git checkout of this repository. Any other repo — including
+# whatever directory a piped install was launched from — is not a version source.
+own_checkout() {
+  [[ -n "$script_dir" ]] || return 1
+  command -v git >/dev/null 2>&1 || return 1
+  git -C "$script_dir" rev-parse --git-dir >/dev/null 2>&1 || return 1
+  git -C "$script_dir" remote -v 2>/dev/null | grep -qF "$OWN_SKILLS_REPO_BASE"
+}
 
 # Newest published release tag, resolved straight from the remote so it works
 # with no checkout at all. Prints the tag's commit; empty if none can be read.
@@ -277,32 +296,42 @@ resolve_latest_release() {
     cut -d' ' -f1
 }
 
-# Is this commit actually reachable from the remote? An unpushed local commit
-# is not, and pinning to it would fail later with a bare git error.
+# Resolve a tag name to its commit on the remote, so `--version v4.12.1` works
+# without a checkout.
+resolve_remote_tag() {
+  command -v git >/dev/null 2>&1 || return 1
+  git ls-remote --tags --refs "https://github.com/$OWN_SKILLS_REPO_BASE.git" \
+    "refs/tags/$1" 2>/dev/null | cut -f1
+}
+
+# Is this commit actually on this repository's remote? An unpushed local commit
+# is not, and neither is a commit belonging to some other repository entirely.
 remote_has_commit() {
   local sha="$1"
   git ls-remote "https://github.com/$OWN_SKILLS_REPO_BASE.git" 2>/dev/null |
     grep -q "^$sha[[:space:]]" && return 0
-  # Not at a ref tip, but it may still be reachable behind one.
+  # Not at a ref tip, but a checkout of THIS repository can prove reachability.
+  own_checkout || return 1
   git -C "$script_dir" merge-base --is-ancestor "$sha" \
     "$(git -C "$script_dir" rev-parse --verify "refs/remotes/origin/main" 2>/dev/null || echo "$sha")" \
     2>/dev/null
 }
 
 if [[ -n "$VERSION" ]]; then
-  # An explicit --version is validated against the checkout, as before.
   if [[ "$VERSION" =~ ^[0-9a-f]{40}$ ]]; then
     : # already immutable
-  elif command -v git >/dev/null 2>&1 &&
+  elif own_checkout &&
        git -C "$script_dir" show-ref --verify --quiet "refs/tags/$VERSION"; then
     VERSION="$(git -C "$script_dir" rev-parse --verify "refs/tags/${VERSION}^{commit}")"
+  elif tag_sha="$(resolve_remote_tag "$VERSION")" && [[ -n "$tag_sha" ]]; then
+    VERSION="$tag_sha"
   else
-    echo -e "${RED}Error: '$VERSION' is not a full commit SHA or a tag in the inspected checkout${NC}"
+    echo -e "${RED}Error: '$VERSION' is not a full commit SHA or a tag in this repository${NC}"
     exit 1
   fi
 else
   head_sha=""
-  if command -v git >/dev/null 2>&1; then
+  if own_checkout; then
     head_sha="$(git -C "$script_dir" rev-parse --verify HEAD 2>/dev/null || true)"
   fi
 

--- a/test/install-claude-herdr-skill.sh
+++ b/test/install-claude-herdr-skill.sh
@@ -59,6 +59,14 @@ STUB
 # read-only queries (version resolution) still reach the real git.
 cat > "$TMPDIR/bin/git" <<'STUB'
 #!/usr/bin/env bash
+# The installer resolves the latest release from the remote when it cannot use
+# a checkout HEAD, so the stub has to publish one tag.
+case "$*" in
+  *ls-remote*--tags*)
+    printf '%s\n' "$*" >> "$GIT_LOG"
+    echo "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa	refs/tags/v4.12.1"
+    exit 0 ;;
+esac
 for arg in "$@"; do
   case "$arg" in
     rev-parse|show-ref) exec /usr/bin/git "$@" ;;

--- a/test/install-claude-ponytail.sh
+++ b/test/install-claude-ponytail.sh
@@ -58,6 +58,14 @@ STUB
 # queries (version resolution) still reach the real git.
 cat > "$TMPDIR/bin/git" <<'STUB'
 #!/usr/bin/env bash
+# The installer resolves the latest release from the remote when it cannot use
+# a checkout HEAD, so the stub has to publish one tag. Everything else stays a
+# no-op; local read-only queries reach the real git.
+case "$*" in
+  *ls-remote*--tags*)
+    echo "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa	refs/tags/v4.12.1"
+    exit 0 ;;
+esac
 for arg in "$@"; do
   case "$arg" in
     rev-parse|show-ref) exec /usr/bin/git "$@" ;;

--- a/test/install-claude-skill-layout.sh
+++ b/test/install-claude-skill-layout.sh
@@ -54,6 +54,14 @@ chmod +x "$TMPDIR/bin/npx"
 # queries (version resolution) still reach the real git.
 cat > "$TMPDIR/bin/git" <<'STUB'
 #!/usr/bin/env bash
+# The installer resolves the latest release from the remote when it cannot use
+# a checkout HEAD, so the stub has to publish one tag. Everything else stays a
+# no-op; local read-only queries reach the real git.
+case "$*" in
+  *ls-remote*--tags*)
+    echo "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa	refs/tags/v4.12.1"
+    exit 0 ;;
+esac
 for arg in "$@"; do
   case "$arg" in
     rev-parse|show-ref) exec /usr/bin/git "$@" ;;

--- a/test/install-claude-unpushed-version.sh
+++ b/test/install-claude-unpushed-version.sh
@@ -45,6 +45,7 @@ case "\$args" in
   *ls-remote*)
     echo "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb	refs/heads/main"
     exit 0 ;;
+  *"remote -v"*) exec /usr/bin/git "\$@" ;;
   *merge-base*) exit 1 ;;
   *fetch*)
     [[ -n "\${FETCH_MUST_FAIL:-}" ]] && { echo "fatal: remote error: upload-pack: not our ref" >&2; exit 128; }
@@ -153,6 +154,43 @@ if [[ ! -s "$NPX_LOG" ]]; then
   pass "the Skills CLI is never invoked for an unreachable pin"
 else
   fail "install must abort before invoking the Skills CLI"
+fi
+
+# --- 4. Piped from curl while standing inside some other repository ---------
+# A piped install leaves BASH_SOURCE unset. `dirname ""` resolves to `.`, so the
+# script once treated the user's current directory as its own checkout and
+# pinned the install to an unrelated repository's HEAD.
+HOME_DIR="$TMPDIR/home4"; NPX_LOG="$TMPDIR/npx4.log"
+FOREIGN="$TMPDIR/foreign"; mkdir -p "$FOREIGN" "$HOME_DIR"; : > "$NPX_LOG"
+/usr/bin/git -C "$FOREIGN" init --quiet
+/usr/bin/git -C "$FOREIGN" remote add origin "https://example.invalid/someone/other-repo.git"
+echo hi > "$FOREIGN/f"
+/usr/bin/git -C "$FOREIGN" add f
+/usr/bin/git -C "$FOREIGN" -c user.email=t@t -c user.name=t commit --quiet -m "foreign commit"
+FOREIGN_SHA="$(/usr/bin/git -C "$FOREIGN" rev-parse HEAD)"
+
+set +e
+OUT4=$( cd "$FOREIGN" && HOME="$HOME_DIR" PATH="$TMPDIR/bin:$PATH" NPX_LOG="$NPX_LOG" \
+  bash -s -- --skills-only --no-external --no-impeccable < "$REPO_ROOT/install-claude.sh" 2>&1 )
+STATUS4=$?
+set -e
+
+if ! printf '%s' "$OUT4" | grep -q "$FOREIGN_SHA"; then
+  pass "a piped install never pins to the surrounding repository's HEAD"
+else
+  fail "piped install pinned to an unrelated repository's commit"
+fi
+
+if printf '%s' "$OUT4" | grep -q "$RELEASE_SHA"; then
+  pass "a piped install pins to the latest release"
+else
+  fail "piped install must resolve the latest release"
+fi
+
+if [[ $STATUS4 -eq 0 ]]; then
+  pass "a piped install from inside another repository succeeds"
+else
+  fail "piped install must not be blocked by the surrounding directory"
 fi
 
 echo ""


### PR DESCRIPTION
## What this captures

Field feedback from reviewing an actor-based front end with the skill loaded: the reviewer's expectation was **one generic editing machine rather than a machine per type of thing**, because *states for adding, editing, and deleting are the same for every kind of thing* a surface manages — and the generic lifecycle may already exist on one of the machines the feature already has.

The skill's ownership test caught the hand-rolled statechart in that review, but it only asked whether an actor already owns this **flow/edge**. It had nothing to say when the about-to-be-written machine repeats a **sibling kind's states** — so a reviewer applying the skill could still end up with N structurally identical machines, one per entity type.

## The generic principle added

**Machines model lifecycles, not entity kinds.** When flows differ only in the kind of thing they operate on, that is one machine with the kind carried as context or input — not a machine per kind. A per-kind copy is the plural form of the escaped-state bug: the finite states get duplicated instead of shared, every copy drifts and is tested separately, and the design hides that the lifecycle was the invariant all along. The ownership question gains its second half: *"why does this not belong to the machine that already owns this edge — or to the one that already models this lifecycle for a sibling kind?"* — and the answer to a sibling-kind match is to generalize that machine, not clone it.

## Where it landed

- **SKILL.md** — the shape test added to "Ask whether an existing actor already owns this flow"; rule 8 extended ("flows that differ only in the kind of thing they manage are one flow: the kind is context, not a reason for another machine"); a per-kind-proliferation bullet in the anti-pattern catalog.
- **references/when-to-model.md** — Override 2 gains the sibling-kind paragraph; "Where Machines Live" now says never-per-entity-kind alongside never-per-component.
- **references/machine-design.md** — anti-pattern table row: "Machine per entity kind | The same add/edit/delete states copied for every type of thing | One machine; the kind is context or input — states are the invariant".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SwiaBiAadr7ZwSySg9JSw