### PR TITLE
fix(zsh): initialize Homebrew before NVM

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -1,6 +1,10 @@
 # Path to oh-my-zsh installation
 export ZSH=$HOME/.oh-my-zsh
 
+# Cache brew prefix (avoid repeated subprocess calls)
+export HOMEBREW_PREFIX="${HOMEBREW_PREFIX:-/opt/homebrew}"
+eval "$($HOMEBREW_PREFIX/bin/brew shellenv)"
+
 # Performance optimizations
 DISABLE_AUTO_UPDATE=true
 DISABLE_MAGIC_FUNCTIONS=true
@@ -15,15 +19,11 @@ plugins=(
 
 source $ZSH/oh-my-zsh.sh
 
-# Cache brew prefix (avoid repeated subprocess calls)
-export HOMEBREW_PREFIX="${HOMEBREW_PREFIX:-/opt/homebrew}"
-
 # GPG configuration for terminal-based signing
 export GPG_TTY=$(tty)
 
 # Source configurations
 [ -f ~/.fzf.zsh ] && source ~/.fzf.zsh
-eval "$($HOMEBREW_PREFIX/bin/brew shellenv)"
 source $HOMEBREW_PREFIX/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
 source $HOME/.zsh_profile
 


### PR DESCRIPTION
## Summary

- initialize Homebrew before other zsh startup configuration
- ensure the lazy NVM setup sees the intended Homebrew paths

## Verification

- `zsh -n zsh/.zshrc`
- `zsh -n zsh/.zsh_profile`
- explicit ordering check confirms `brew shellenv` precedes `.zsh_profile`