### PR TITLE
revert: remove CodexBar Homebrew install

### DIFF
--- a/.changeset/add-codexbar-cask.md
+++ b/.changeset/add-codexbar-cask.md
@@ -1,7 +1,0 @@
----
-"@citypaul/dotfiles": minor
----
-
-Install CodexBar via Homebrew during `./install.sh`
-
-Adds `brew install --cask steipete/tap/codexbar` so the Codex/Claude usage menu bar app is installed with the rest of the personal dotfiles.

--- a/.changeset/remove-codexbar-cask.md
+++ b/.changeset/remove-codexbar-cask.md
@@ -1,0 +1,7 @@
+---
+"@citypaul/dotfiles": patch
+---
+
+Remove the CodexBar Homebrew install from `install.sh`
+
+That cask was added to this repo by mistake; Homebrew packages belong elsewhere.

--- a/README.md
+++ b/README.md
@@ -2093,7 +2093,6 @@ This will install:
 - ✅ Git aliases and configuration
 - ✅ Shell configuration (bash/zsh)
 - ✅ Vim, tmux, npm configs
-- ✅ CodexBar (`brew install --cask steipete/tap/codexbar`)
 - ✅ All personal preferences
 
 ### Installing Specific Dotfiles

--- a/install.sh
+++ b/install.sh
@@ -29,6 +29,3 @@ move_with_backup "$HOME/.config/opencode/opencode.json"
 move_with_backup "$HOME/.config/herdr/config.toml"
 
 stow zsh tmux gnupg alacritty zellij .oh-my-zsh karabiner ghostty claude opencode herdr
-
-# CodexBar — menu bar usage monitor for Codex and Claude
-brew install --cask steipete/tap/codexbar


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Reverts #261. CodexBar was added to this repo by mistake.
- Removes `brew install --cask steipete/tap/codexbar` from `install.sh` and the README install list.
- Drops the unreleased add changeset so it never lands in a version changelog.

## Verification

- `install.sh` and README no longer mention CodexBar.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-454db386-8a42-4c4a-b1cd-191f8a205973?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-454db386-8a42-4c4a-b1cd-191f8a205973&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

